### PR TITLE
invert selection for ship list

### DIFF
--- a/src/pages/strategy/tabs/ships/ships.html
+++ b/src/pages/strategy/tabs/ships/ships.html
@@ -16,6 +16,7 @@
 			<dt class="massLabel">Select:</dt>
 			<dd class="hover all">All</dd>
 			<dd class="hover none">None</dd>
+			<dd class="hover invert">Invert</dd>
 		</dl>
 		<dl>
 			<dt class="massLabel">Equip Stats:</dt>

--- a/src/pages/strategy/tabs/ships/ships.js
+++ b/src/pages/strategy/tabs/ships/ships.js
@@ -117,6 +117,15 @@
 				}
 				self.refreshTable();
 			});
+
+			// Select: Invert
+			self.options.none = $(".tab_ships .filters .massSelect .invert").on("click", function(){
+				$(".tab_ships .ship_filter_type .filter_check").toggle();
+				for(sCtr in KC3Meta._stype){
+					self.filters[sCtr] = !self.filters[sCtr];
+				}
+				self.refreshTable();
+			});
 			
 			// Equip Stats: Yes
 			self.options.equip_yes = $(".tab_ships .filters .massSelect .equip_yes").on("click", function(){


### PR DESCRIPTION
Adding invert selection for ship list

![2015-10-05_155947_3360x1080_scrot](https://cloud.githubusercontent.com/assets/1096354/10291879/1ee8203e-6b7a-11e5-86fe-487466ace27c.png)

for example:
1. all ship types are selected by default
2. click "CA", "CAV"
3. every ship except "CA" and "CAV"
4. click "Invert"
5. "CA" and "CAV" only