### PR TITLE
Adding stat sorters on equipment page

### DIFF
--- a/src/pages/strategy/tabs/gears/gears.css
+++ b/src/pages/strategy/tabs/gears/gears.css
@@ -3,7 +3,7 @@
 }
 .tab_gears .item_types {
 	width:700px;
-	margin:0px 0px 10px 0px;
+/*	margin:0px 0px 10px 0px; */
 	background:#f0f5ff;
 	padding:10px 5px;
 	border-bottom:1px solid #369;
@@ -34,10 +34,10 @@
 	background:#def;
 	border-radius:10px;
 	/*padding:10px;*/
-	
-	position: 	relative;
-	border: 	10px solid transparent;
-	overflow: 	hidden;
+
+	position:	relative;
+	border:		10px solid transparent;
+	overflow:	hidden;
 }
 
 .tab_gears .slotitem .info {
@@ -178,74 +178,106 @@
 
 /* .slotitem .holders (new since 2015/07/13) */
 .tab_gears .slotitem .holders{
-	width: 		calc(100% - 260px);
+	width:		calc(100% - 260px);
 	min-height: 85px;
-	position: 	relative;
+	position:	relative;
 	padding-bottom: 40px;
-	float: 		left;
+	float:		left;
 }
 .tab_gears .slotitem .holders dl{
-	overflow: 	hidden;
-	margin: 	0;
-	display: 	block;
-	width: 		100%;
+	overflow:	hidden;
+	margin:		0;
+	display:	block;
+	width:		100%;
 }
 .tab_gears .slotitem .holders dl ~ dl{
-	margin-top: 	10px;
-	padding-top: 	10px;
-	border-top: 	2px solid hsl(210, 50%, 85%);
+	margin-top:		10px;
+	padding-top:	10px;
+	border-top:		2px solid hsl(210, 50%, 85%);
 }
 .tab_gears .slotitem .holders dl:last-child{
-	position: 	absolute;
-	bottom: 	0;
-	font-size: 	14px;
+	position:	absolute;
+	bottom:		0;
+	font-size:	14px;
 	font-weight:	bold;
 }
 .tab_gears .slotitem .holders dl dt span{
-	color: 		#45A9A5;
+	color:		#45A9A5;
 }
 .tab_gears .slotitem .holders dl dt small{
 	font-weight:bold;
 	padding-left: 1em
 }
 .tab_gears .slotitem .holders dl dd{
-	overflow: 	hidden;
+	overflow:	hidden;
 	margin-right: -10px
 }
 .tab_gears .slotitem .holders dl dd .holder{
-	width: 		calc(50% - 10px);
-	float: 		left;
-	height: 	24px;
+	width:		calc(50% - 10px);
+	float:		left;
+	height:		24px;
 	line-height:20px;
-	margin: 	5px 10px 0 0;
+	margin:		5px 10px 0 0;
 	background: #fff;
 	border-radius: 12px 8px 8px 12px;
-	padding: 	2px 5px 2px 0;
-	overflow: 	hidden;
-	font-size: 	12px;
-	position: 	relative;
+	padding:	2px 5px 2px 0;
+	overflow:	hidden;
+	font-size:	12px;
+	position:	relative;
 }
 .tab_gears .slotitem .holders dl dd .holder img{
-	float: 		left;
-	display: 	block;
-	width: 		24px;
-	height: 	24px;
+	float:		left;
+	display:	block;
+	width:		24px;
+	height:		24px;
 	margin-top: -2px;
 }
 .tab_gears .slotitem .holders dl dd .holder font{
-	width: 		calc(100% - 24px - 40px - 16px);
-	position: 	relative;
-	display: 	block;
-	float: 		left;
-	padding: 	0 0 0 6px;
+	width:		calc(100% - 24px - 40px - 16px);
+	position:	relative;
+	display:	block;
+	float:		left;
+	padding:	0 0 0 6px;
 }
 .tab_gears .slotitem .holders dl dd .holder span{
-	width: 		40px;
-	position: 	relative;
-	display: 	block;
-	float: 		left;
-	padding: 	0 0 0 2px;
+	width:		40px;
+	position:	relative;
+	display:	block;
+	float:		left;
+	padding:	0 0 0 2px;
 }
 .tab_gears .slotitem .holders dl dd .holder span + span{
-	width: 		16px;
+	width:		16px;
+}
+
+.tab_gears .itemSorters {
+	width:700px;
+	margin:0px 0px 10px 0px;
+	padding:5px 10px;
+	border-bottom:1px solid #369;
+}
+.tab_gears .itemSorters .sorterLabel {
+	width: 60px;
+	height:20px;
+	line-height:20px;
+	font-size:12px;
+	float:left;
+	font-weight:bold;
+}
+.tab_gears .itemSorters .sortControl {
+	width: 40px;
+	height:20px;
+	line-height:20px;
+	padding:0px 4px 0px 4px;
+		margin: 0px 1px 0px 1px;
+	background:#AAA;
+	color:#fff;
+	font-weight:bold;
+	font-size:12px;
+	text-align:center;
+	float:left;
+	border-radius:7px;
+}
+.tab_gears .itemSorters .sortControl:hover {
+	background:#ace;
 }

--- a/src/pages/strategy/tabs/gears/gears.html
+++ b/src/pages/strategy/tabs/gears/gears.html
@@ -49,6 +49,44 @@
 	<div class="clear"></div>
 </div>
 
+<div class="itemSorters">
+	<div class="sorterLabel">Sort by:</div>
+        <div class="sortControl hover fp">
+          <img src="../../assets/img/stats/fp.png"><span></span>
+        </div>
+        <div class="sortControl hover tp">
+          <img src="../../assets/img/stats/tp.png"><span></span>
+        </div>
+        <div class="sortControl hover aa">
+          <img src="../../assets/img/stats/aa.png"><span></span>
+        </div>
+        <div class="sortControl hover ar">
+          <img src="../../assets/img/stats/ar.png"><span></span>
+        </div>
+        <div class="sortControl hover as">
+          <img src="../../assets/img/stats/as.png"><span></span>
+        </div>
+        <div class="sortControl hover ev">
+          <img src="../../assets/img/stats/ev.png"><span></span>
+        </div>
+        <div class="sortControl hover ls">
+          <img src="../../assets/img/stats/ls.png"><span></span>
+        </div>
+        <div class="sortControl hover dv">
+          <img src="../../assets/img/stats/dv.png"><span></span>
+        </div>
+        <div class="sortControl hover ht">
+          <img src="../../assets/img/stats/ht.png"><span></span>
+        </div>
+        <div class="sortControl hover rn">
+          <img src="../../assets/img/stats/rn.png"><span></span>
+        </div>
+        <div class="sortControl hover overall">
+          Sum
+        </div>
+	<div class="clear"></div>
+</div>
+
 <!-- CONTENT -->
 <div class="page_padding">
 	<!-- LIST CONTAINER -->

--- a/src/pages/strategy/tabs/gears/gears.js
+++ b/src/pages/strategy/tabs/gears/gears.js
@@ -1,18 +1,126 @@
 (function(){
 	"use strict";
-	
+
 	KC3StrategyTabs.gears = new KC3StrategyTab("gears");
-	
+
 	KC3StrategyTabs.gears.definition = {
 		tabSelf: KC3StrategyTabs.gears,
-		
+
 		_items: {},
 		_holders: {},
-		
+		_comparator: {},
+		_currentTypeId: 1, // keep track of current type_id
+		_allProperties: ["fp","tp","aa","ar","as","ev","ls","dv","ht","rn"],
+		_defaultCompareMethod: {
+			// main guns
+			"t1": "fp",
+			"t2": "fp",
+			"t3": "fp",
+			// secondary
+			"t4": "fp",
+			// torpedo
+			"t5": "tp",
+			// fighter
+			"t6": "aa",
+			// dive bomber
+			"t7": "dv",
+			// torpedo bomber
+			"t8": "tp",
+			// scout
+			"t9": "ls",
+			// seaplane, default to overall stat
+			"t10": "overall",
+			// radar
+			"t11": "overall",
+			// type 3 shell
+			"t12": "aa",
+			// AP
+			"t13": "fp",
+			// dam con
+			"t14": "overall",
+			// AA gun
+			"t15": "aa",
+			"t16": "aa",
+			// ASW
+			"t17": "as",
+			"t18": "as",
+			// engine
+			"t19": "ev",
+			// landing craft
+			"t20": "overall",
+			// KA obs
+			"t21": "as",
+			// type 3 CLA
+			"t22": "as",
+			// bulge
+			"t23": "ar",
+			// searchlight
+			"t24": "ls",
+			// drum
+			"t25": "overall",
+			// repair facility
+			"t26": "overall",
+			// star shell
+			"t27": "overall",
+			// fleet command facility
+			"t28": "overall",
+			// skilled aircraft maintenance
+			"t29": "fp",
+			// AAFD
+			"t30": "aa",
+			// WG42
+			"t31": "overall",
+			// skilled lookout
+			"t32": "overall",
+			// flying boat
+			"t33": "overall",
+			// combat ration
+			"t34": "overall",
+			// underway replenishment
+			"t35": "overall"
+		},
+
+		/* Initialize comparators
+		---------------------------------*/
+		initComparator: function() {
+			var mkComparator = function(propertyGetter) {
+				return function(a,b) {
+					// for equipments, greater usually means better xD
+					// so the comparison is flipped
+					var result = propertyGetter(b) - propertyGetter(a);
+					// additionally, if they look the same on the given stat
+					// we compare all properties by taking their sum.
+					if (result === 0) {
+						return sumAllGetter(b) - sumAllGetter(a);
+					} else {
+						return result;
+					}
+				};
+			};
+			var self = this;
+			var allProperties = this._allProperties;
+			var sumAllGetter = function(obj) {
+				return allProperties
+					.map( function(p) { return obj.stats[p]; } )
+					.reduce( function(a,b) { return a+b; }, 0);
+			};
+
+			allProperties.forEach( function(property,i) {
+				var getter = function(obj) {
+					return obj.stats[property];
+				};
+				self._comparator[property] = mkComparator(getter);
+			});
+			self._comparator.overall = function(a,b) {
+				return sumAllGetter(b) - sumAllGetter(a);
+			};
+		},
+
 		/* INIT
 		Prepares all data needed
 		---------------------------------*/
 		init :function(){
+			this.initComparator();
 			// Compile equipment holders
 			var ctr, ThisItem, MasterItem, ThisShip, MasterShip;
 			for(ctr in KC3ShipManager.list){
@@ -21,18 +129,18 @@
 				this.checkShipSlotForItemHolder(2, KC3ShipManager.list[ctr]);
 				this.checkShipSlotForItemHolder(3, KC3ShipManager.list[ctr]);
 			}
-			
+
 			// Compile ships on Index
 			for(ctr in KC3GearManager.list){
 				ThisItem = KC3GearManager.list[ctr];
 				MasterItem = ThisItem.master();
 				if(!MasterItem) continue;
-				
+
 				// Check if slotitem_type is filled
 				if(typeof this._items["t"+MasterItem.api_type[3]] == "undefined"){
 					this._items["t"+MasterItem.api_type[3]] = [];
 				}
-				
+
 				// Check if slotitem_id is filled
 				if(typeof this._items["t"+MasterItem.api_type[3]]["s"+MasterItem.api_id] == "undefined"){
 					this._items["t"+MasterItem.api_type[3]]["s"+MasterItem.api_id] = {
@@ -56,9 +164,9 @@
 						arranged: {}
 					};
 				}
-				
+
 				var holder = this._holders["s"+ThisItem.itemId];
-				
+
 				// Add this item to the instances
 				if(typeof this._holders["s"+ThisItem.itemId] != "undefined"){
 					// Someone is holding it
@@ -68,20 +176,20 @@
 						locked: ThisItem.lock,
 						holder: holder,
 					});
-					
+
 					if( !this._items["t"+MasterItem.api_type[3]]["s"+MasterItem.api_id].arranged[ThisItem.stars] )
 						this._items["t"+MasterItem.api_type[3]]["s"+MasterItem.api_id].arranged[ThisItem.stars] = {
 							holder: {},
 							extraCount: 0,
 							heldCount: 0
 						};
-					
+
 					if( !this._items["t"+MasterItem.api_type[3]]["s"+MasterItem.api_id].arranged[ThisItem.stars].holder[holder.rosterId] )
 						this._items["t"+MasterItem.api_type[3]]["s"+MasterItem.api_id].arranged[ThisItem.stars].holder[holder.rosterId] = {
 							holder: holder,
 							count: 0
 						};
-					
+
 					this._items["t"+MasterItem.api_type[3]]["s"+MasterItem.api_id].arranged[ThisItem.stars].holder[holder.rosterId].count++;
 					this._items["t"+MasterItem.api_type[3]]["s"+MasterItem.api_id].arranged[ThisItem.stars].heldCount++;
 				}else{
@@ -91,19 +199,19 @@
 						level: ThisItem.stars,
 						locked: ThisItem.lock
 					});
-					
+
 					if( !this._items["t"+MasterItem.api_type[3]]["s"+MasterItem.api_id].arranged[ThisItem.stars] )
 						this._items["t"+MasterItem.api_type[3]]["s"+MasterItem.api_id].arranged[ThisItem.stars] = {
 							holder: {},
 							extraCount: 0,
 							heldCount: 0
 						};
-					
+
 					this._items["t"+MasterItem.api_type[3]]["s"+MasterItem.api_id].arranged[ThisItem.stars].extraCount++;
 				}
 			}
 		},
-		
+
 		/* Check a ship's equipment slot of an item is equipped
 		--------------------------------------------*/
 		checkShipSlotForItemHolder :function(slot, ThisShip){
@@ -111,28 +219,106 @@
 				this._holders["s"+ThisShip.items[slot]] = ThisShip;
 			}
 		},
-		
+
 		/* EXECUTE
 		Places data onto the interface
 		---------------------------------*/
 		execute :function(){
 			var self = this;
-			
+
 			$(".tab_gears .item_type").on("click", function(){
 				$(".tab_gears .item_type").removeClass("active");
 				$(this).addClass("active");
-				self.showType($(this).data("type"));
+				var type_id = $(this).data("type");
+				self._currentTypeId = type_id;
+				var compareMethod = self._defaultCompareMethod["t"+type_id];
+				if (typeof compareMethod == "undefined")
+					compareMethod = "overall";
+				self.updateSorters(type_id);
+				self.showType(type_id, compareMethod);
 			});
-			
+
+			// setup sort methods
+			var sortControls = this._allProperties.slice(0);
+			sortControls.push( "overall" );
+			sortControls.forEach( function(property,i) {
+				$(".tab_gears .itemSorters .sortControl." + property).on("click", function() {
+					var type_id = self._currentTypeId;
+					var compareMethod = property;
+					self.showType(type_id, compareMethod);
+				});
+				
+			});
+
 			$(".tab_gears .item_type").first().trigger("click");
 		},
-		
-		/* Show slotitem type
+
+		/* check available items and show or hide sorters accordingly
+		  ------------------------------------------*/
+		updateSorters: function(type_id) {
+			var self = this;
+			var statSets = {};
+			var allProperties = self._allProperties;
+			allProperties.forEach(function(p,i) {
+				statSets[p] = [];
+			});
+
+			// grab stat from all available slotitems
+            function accumulateStats(statSets,ThisSlotitem) {
+                return function(p,i) {
+					statSets[p].push( ThisSlotitem.stats[p] );                    
+                };
+            }
+			for (var item in self._items["t"+type_id]) {
+				var ThisSlotitem = self._items["t"+type_id][item];
+                allProperties.forEach(accumulateStats(statSets, ThisSlotitem));
+
+                // well, if jshlint is trying to be smart and makes code harder
+                // to read, then that's not my fault
+                // the equivalent code:
+                /*
+				allProperties.forEach(function(p,i) {
+					statSets[p].push( ThisSlotitem.stats[p] );
+				});
+                */
+			}
+
+			var removeDuplicates = function(xs) {
+				var result = [];
+				xs.forEach(function(v,i) {
+					if (result.indexOf(v) === -1)
+						result.push(v);
+				});
+				return result;
+			};
+
+			// making sets for each stat values
+			allProperties.forEach(function(p,i) {
+				statSets[p] = removeDuplicates( statSets[p] );
+			});
+
+			allProperties.forEach(function(p,i) {
+				var q = ".tab_gears .itemSorters .sortControl." + p;
+				if (statSets[p].length <= 1 &&
+					self._defaultCompareMethod[type_id] !== p) {
+					  $(q).addClass("hide");
+				} else {
+					  $(q).removeClass("hide");
+				}
+			});
+		},
+
+		/* Show slotitem type, with a compare method
 		--------------------------------------------*/
-		showType :function(type_id){
+		showType :function(type_id, compareMethod){
 			$(".tab_gears .item_list").html("");
-			
-			function showEqList(arranged){
+
+			var comparator = this._comparator[compareMethod];
+			if (typeof comparator == "undefined") {
+				console.warn("comparator missing for: " + compareMethod);
+			}
+
+			function showEqList(i,arranged){
 				if( !arranged[i].heldCount )
 					return null;
 
@@ -153,33 +339,32 @@
 				}
 				return els;
 			}
-			
+
 			var ctr, ThisType, ItemElem, ThisSlotitem;
-			for(ctr in this._items["t"+type_id]){
-				ThisSlotitem = this._items["t"+type_id][ctr];
-				
+			var SlotItems = [];
+			for (var slotItem in this._items["t"+type_id]) {
+				SlotItems.push( this._items["t"+type_id][slotItem] );
+			}
+
+			SlotItems.sort( comparator );
+
+			var self = this;
+			var allProperties = this._allProperties;
+			$.each(SlotItems, function(index,ThisSlotitem) {
 				ItemElem = $(".tab_gears .factory .slotitem").clone().appendTo(".tab_gears .item_list");
 				$(".icon img", ItemElem).attr("src", "../../assets/img/items/"+type_id+".png");
 				$(".english", ItemElem).text(ThisSlotitem.english);
 				$(".japanese", ItemElem).text(ThisSlotitem.japanese);
 				//$(".counts", ItemElem).html("You have <strong>"+(ThisSlotitem.held.length+ThisSlotitem.extras.length)+"</strong> (<strong>"+ThisSlotitem.held.length+"</strong> worn, <strong>"+ThisSlotitem.extras.length+"</strong> extras)");
-				
-				this.slotitem_stat(ItemElem, ThisSlotitem.stats, "fp");
-				this.slotitem_stat(ItemElem, ThisSlotitem.stats, "tp");
-				this.slotitem_stat(ItemElem, ThisSlotitem.stats, "aa");
-				this.slotitem_stat(ItemElem, ThisSlotitem.stats, "ar");
-				this.slotitem_stat(ItemElem, ThisSlotitem.stats, "as");
-				this.slotitem_stat(ItemElem, ThisSlotitem.stats, "ev");
-				this.slotitem_stat(ItemElem, ThisSlotitem.stats, "ls");
-				this.slotitem_stat(ItemElem, ThisSlotitem.stats, "dv");
-				this.slotitem_stat(ItemElem, ThisSlotitem.stats, "ht");
-				this.slotitem_stat(ItemElem, ThisSlotitem.stats, "rn");
-				
+
+
+				allProperties.forEach( function(v,i) {
+					self.slotitem_stat(ItemElem, ThisSlotitem.stats, v);
+				});
+
 				var holderCtr, ThisHolder, HolderElem;
 				console.log(ThisSlotitem);
-				
-				
-				
+
 				for( var i in ThisSlotitem.arranged ){
 					$('<dl/>')
 						.append( $('<dt/>',{
@@ -193,10 +378,10 @@
 								)
 							) )
 						)
-						.append( $('<dd/>').append(showEqList(ThisSlotitem.arranged)) )
+						.append( $('<dd/>').append(showEqList(i,ThisSlotitem.arranged)) )
 						.appendTo( ItemElem.children('.holders') );
 				}
-				
+
 				$('<dl/>')
 					.append( $('<dd/>').html(
 						'Total ' + (ThisSlotitem.held.length+ThisSlotitem.extras.length)
@@ -211,7 +396,7 @@
 					ThisHolder = ThisSlotitem.held[holderCtr];
 					HolderElem = $(".tab_gears .factory .holder").clone();
 					$(".holder_list", ItemElem).append(HolderElem);
-					
+
 					$(".holder_pic img", HolderElem).attr("src",
 						KC3Meta.shipIcon(
 							ThisHolder.holder.masterId,
@@ -220,26 +405,26 @@
 					);
 					$(".holder_name", HolderElem).text(ThisHolder.holder.name());
 					$(".holder_level", HolderElem).text("Lv"+ThisHolder.holder.level);
-					
+
 					if(ThisHolder.level==0){ $(".holder_star", HolderElem).hide(); }
 					else{ $(".holder_star span", HolderElem).text(ThisHolder.level); }
 				}
-				
+
 				for(holderCtr in ThisSlotitem.extras){
 					ThisHolder = ThisSlotitem.extras[holderCtr];
 					HolderElem = $(".tab_gears .factory .xholder").clone();
 					$(".holder_list", ItemElem).append(HolderElem);
-					
+
 					$(".holder_icon img", HolderElem).attr("src", "../../assets/img/items/"+type_id+".png");
-					
+
 					if(ThisHolder.level==0){ $(".holder_star", HolderElem).hide(); }
 					else{ $(".holder_star span", HolderElem).text(ThisHolder.level); }
 				}
 				*/
-			}
-			
+			});
+
 		},
-		
+
 		/* Determine if an item has a specific stat
 		--------------------------------------------*/
 		slotitem_stat :function(ItemElem, stats, stat_name){
@@ -249,7 +434,7 @@
 				$(".stats .item_"+stat_name, ItemElem).hide();
 			}
 		}
-		
+
 	};
-	
+
 })();


### PR DESCRIPTION
Added few buttons on equipment list, the list now can be sorted by stats

![2015-10-12_101333_3840x1080_scrot](https://cloud.githubusercontent.com/assets/1096354/10429918/1832c186-70ca-11e5-8edb-e25afaae4eea.png)

and these buttons are changed dynamically depending on equipment types and equipments available.

![2015-10-12_101428_3840x1080_scrot](https://cloud.githubusercontent.com/assets/1096354/10429921/1cd16422-70ca-11e5-8673-25069049a1b8.png)
