### PR TITLE
fix air power calculation

### DIFF
--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -38,20 +38,36 @@ Retreives when needed to apply on components
 				
 				// AIR PROFICIENCY BONUSES (Configurable by user)
 				air_formula			: 3, // 1=no veteran 2=veteran average 3=veteran bounds
-				air_average			: [0, 1.35, 3.5, 7.1, 11.4, 16.8, 17, 25],
-				air_bounds			: [
-					[0.026, 0.845],
-					[1, 1.715],
-					[3.212, 3.984],
-					[6.845, 7.504],
-					[11.205, 11.786],
-					[16.639, 17],
-					[16.999, 17.205],
-					[24.679, 25.411]
-				],
-				
-				ss_mode 			: 0,
-				ss_type 			: 'JPG',
+				air_average			: {
+					"6":  [0, 1.35, 3.5, 7.1, 11.4, 16.8, 17, 25],
+					"7":  [0,    1,	  1,   1,    2,	   2,  2,  3],
+					"8":  [0,    1,	  1,   1,    2,	   2,  2,  3],
+					"11": [0,    1,	  1,   3,    3,	   7,  7,  9]
+				},
+				air_bounds			: {
+					"6": [
+						[0.026, 0.845], // 0
+						[1, 1.715], [3.212, 3.984], [6.845, 7.504], // 3
+						[11.205, 11.786], [16.639, 17], [16.999, 17.205], [24.679, 25.411] // 7
+					],
+					"7": [
+						[0,0], // 0
+						[0,1], [0,1], [0,1], // 3
+						[1,2], [1,2], [1,2], [1,3]	// 7
+					],
+					"8": [
+						[0,0], // 0
+						[0,1], [0,1], [0,1], // 3
+						[1,2], [1,2], [1,2], [1,3]	// 7
+					],
+					"11": [
+						[0,0], // 0
+						[0,1], [0,1], [1,3], // 3
+						[1,3], [3,7], [3,7], [7,9]	// 7
+					]},
+
+				ss_mode				: 0,
+				ss_type				: 'JPG',
 				ss_directory 		: 'KanColle',
 				
 				alert_diff 			: 59,
@@ -99,13 +115,21 @@ Retreives when needed to apply on components
 				pan_opacity 		: 100
 			};
 		},
+        
+		// Reset value of a specific key to the current default value
+		resetValueOf: function(key) {
+			this[key] = this.defaults()[key];
+			console.log( "key is " + key);
+			console.log( "new value is " + JSON.stringify( this[key] ));
+			this.save();
+		},
 		
 		// Reset to default values
 		clear : function(){
 			$.extend(this, this.defaults());
 			this.save();
 		},
-		
+
 		// Load previously saved config
 		load : function(){
 			// Get old config or create dummy if none

--- a/src/library/objects/Gear.js
+++ b/src/library/objects/Gear.js
@@ -62,11 +62,18 @@ KC3改 Equipment Object
 		
 		// Check if this object is a fighter plane
 		if( [6,7,8,11].indexOf( this.master().api_type[2] ) > -1){
+			var typInd = String( this.master().api_type[2] );
+
+			if (typeof ConfigManager.air_average[typInd] == 'undefined') {
+				ConfigManager.resetValueOf('air_average');
+			}
+			var airAverageTable = ConfigManager.air_average[typInd];
+
 			var veteranBonus;
 			if(this.ace==-1){
-			 	veteranBonus = ConfigManager.air_average[ 0 ];
+				veteranBonus = airAverageTable[ 0 ];
 			}else{
-				veteranBonus = ConfigManager.air_average[ this.ace ];
+				veteranBonus = airAverageTable[ this.ace ];
 			}
 			return Math.floor( Math.sqrt(capacity) * this.master().api_tyku + veteranBonus );
 		}
@@ -87,11 +94,16 @@ KC3改 Equipment Object
 		if( [6,7,8,11].indexOf( this.master().api_type[2] ) > -1){
 			console.log("this.ace", this.ace);
 			
+			var typInd = String( this.master().api_type[2] );
+			if (typeof ConfigManager.air_bounds[typInd] == 'undefined') {
+				ConfigManager.resetValueOf('air_bounds');
+			}
+			var airBoundTable = ConfigManager.air_bounds[typInd];
 			var veteranBounds;
 			if(this.ace==-1){
-				veteranBounds = ConfigManager.air_bounds[ 0 ];
+				veteranBounds = airBoundTable[ 0 ];
 			}else{
-				veteranBounds = ConfigManager.air_bounds[ this.ace ];
+				veteranBounds = airBoundTable[ this.ace ];
 			}
 			
 			console.log("ConfigManager.air_bounds",ConfigManager.air_bounds);


### PR DESCRIPTION
More accurate air power calculation: aircraft bombers and seaplane bombers don't share the bonus that fighers have, in `ConfigManager` I've splitted AP bonus table by gear types.

Data format changed:
* `ConfigManager.air_bounds`
* `ConfigManager.air_average`

Most seaplane bomber APs values are just guessing - all I know is the +9 bonus for double chevron ones. Until more accurate formula gets figured out, I think this is the best we can do.
References:

* http://wikiwiki.jp/kancolle/?%B4%CF%BA%DC%B5%A1%BD%CF%CE%FD%C5%D9
* http://zh.moegirl.org/%E8%88%B0%E9%98%9FCollection/%E8%88%B0%E8%BD%BD%E6%9C%BA%E7%86%9F%E7%BB%83%E5%BA%A6
* http://kancolle.wikia.com/wiki/Aircraft_Proficiency
