### PR TITLE
fix deckbuilder export: use ace stat if available

### DIFF
--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -348,9 +348,11 @@
 			var result = {};
 			for(var i = 0; i < 4; i++) {
 				if(shipObj.items[i]> -1){
+					var item = KC3GearManager.get(shipObj.items[i]);
+					var rank = (item.ace === -1) ? item.stars : item.ace ;
 					result["i".concat(i+1)] ={
-							"id":KC3GearManager.get(shipObj.items[i]).masterId,
-							"rf":KC3GearManager.get(shipObj.items[i]).stars
+							"id":item.masterId,
+							"rf":rank
 					};
 				} else {break;}
 			}


### PR DESCRIPTION
Before:

![2015-11-19_123215_3360x1080_scrot](https://cloud.githubusercontent.com/assets/1096354/11278614/dfbcde00-8eb9-11e5-8293-0558dd7f4f0b.png)


After:

![2015-11-19_122816_3360x1080_scrot](https://cloud.githubusercontent.com/assets/1096354/11278615/e2c75418-8eb9-11e5-8ddc-e21438c44e7d.png)
