### PR TITLE
modification to leveling tab

### DIFF
--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -148,7 +148,7 @@
 				
 				// Icon and level, common for all categories
 				$(".ship_icon img", goalBox).attr("src", KC3Meta.shipIcon(ThisShip.masterId) );
-				$(".ship_icon img", goalBox).attr("title", ThisShip.rosterId );
+				$(".ship_icon img", goalBox).attr("title", ThisShip.name() + ' (' + ThisShip.rosterId + ')' );
 				$(".ship_name", goalBox).text( ThisShip.name() );
 				$(".ship_type", goalBox).text( ThisShip.stype() );
 				$(".ship_lv .ship_value", goalBox).text( ThisShip.level );
@@ -176,7 +176,7 @@
 				if(ThisShip.level<99){
 					$(".ship_target .ship_value", goalBox).text( 99 );
 				}else{
-					$(".ship_target .ship_value", goalBox).text( 150 );
+					$(".ship_target .ship_value", goalBox).text( 155 );
 				}
 				goalBox.appendTo(".tab_expcalc .box_other");
 			});


### PR DESCRIPTION
set image title to ship name + rosterid this can make it easier for newer players or ships that some of us don't recognize easily to be selected. Also increase max level to 155 per 12/8 kancolle release.