### PR TITLE
"Other forms" in Ship Library

### DIFF
--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -20,6 +20,7 @@ Previously known as "Reactor"
 		-------------------------------------------------------*/
 		"api_start2":function(params, response, headers){
 			var newCounts = KC3Master.init( response.api_data );
+			RemodelDb.init( response.api_data );
 			
 			if(ConfigManager.KC3DBSubmission_enabled) {
 				KC3DBSubmission.sendMaster( JSON.stringify(response) );

--- a/src/library/modules/RemodelDb.js
+++ b/src/library/modules/RemodelDb.js
@@ -1,0 +1,177 @@
+/* RemodelDb.js
+
+   Everything related to ship remodels
+
+*/
+(function() {
+    "use strict";
+
+    window.RemodelDb = {
+        _db: null,
+        // NOTE: masterData on init is optional
+        // as long as pre-processed data has been saved in localStorage
+        init: function(masterData) {
+            // load stored db if any
+            if (typeof localStorage.remodelDb !== 'undefined')
+                this._db = JSON.parse( localStorage.remodelDb );
+
+            if (masterData && this.requireUpdate(masterData)) {
+                try {
+                    var db = this.mkDb(masterData);
+                    localStorage.remodelDb = JSON.stringify(db);
+                    this._db = db;
+                    console.log("RemodelDb: database updated");
+                } catch (e) {
+                    console.error("RemodelDb:",e);
+                }
+            } else {
+                console.log("RemodelDb: no update required");
+            }
+
+            if (! this._db) {
+                console.warn("RemodelDb: database unavailable, need to re-initialize with master data");
+            }
+        },
+        // compare master data against _db (could be null)
+        // if this function returns true, then we need to perform a db update
+        requireUpdate: function(masterData) {
+            if (!this._db)
+                return true;
+            if (this._db.shipCount !== masterData.api_mst_ship.length ||
+                this._db.upgradeCount !== masterData.api_mst_shipupgrade.length)
+                return true;
+            return false;
+        },
+        mkDb: function(masterData) {
+            // step 1: collect remodel info
+            /*
+               remodelInfo[ shipId  ] =
+                 { ship_id_from: Int
+                 , ship_id_to: Int
+                 , level: Int
+                 , steel: Int
+                 , ammo: Int
+                 , catapult: Int
+                 , blueprint: Int
+                 , devmat: Int
+                 }
+             */
+            var remodelInfo = {};
+            // all ship Ids (except abyssals)
+            var shipIds = [];
+            // all ship Ids that appears in x.aftershipid
+            // stored as a set.
+            var shipDstIds = {};
+
+            $.each(masterData.api_mst_ship, function(i,x){
+                if (x.api_id >= 500)
+                    return;
+                shipIds.push( x.api_id );
+                var shipId_to = parseInt(x.api_aftershipid,10) || 0;
+                if (shipId_to === 0)
+                    return;
+
+                shipDstIds[shipId_to] = true;
+                var remodel =
+                    { ship_id_from: x.api_id,
+                      ship_id_to: shipId_to,
+                      level: x.api_afterlv,
+                      // yes, this is steel
+                      steel: x.api_afterfuel,
+                      ammo: x.api_afterbull,
+                      // these fields are unknown for now
+                      catapult: 0,
+                      blueprint: 0,
+                      devmat: 0
+                    }
+                remodelInfo[x.api_id] = remodel;
+
+            });
+
+            function id2name(id) {
+                return KC3Meta.shipName( KC3Master.ship(id).api_name );
+            }
+
+            $.each(masterData.api_mst_shipupgrade, function(i,x) {
+                if (x.api_current_ship_id === 0)
+                    return;
+                var remodel = remodelInfo[x.api_current_ship_id];
+                console.assert(
+                    remodel.ship_id_to === x.api_id,
+                    "data inconsistent:"+x.api_id);
+                remodel.catapult = x.api_catapult_count;
+                remodel.blueprint = x.api_drawing_count;
+                remodelInfo[x.api_current_ship_id] = remodel;
+            });
+
+            // patch devmat info, can't find it in api_start2
+            console.assert( remodelInfo[461].ship_id_to === 466 );
+            remodelInfo[461].devmat = 15;
+            console.assert( remodelInfo[462].ship_id_to === 467 );
+            remodelInfo[462].devmat = 15;
+            console.assert( remodelInfo[466].ship_id_to === 461 );
+            remodelInfo[461].devmat = 10;
+            console.assert( remodelInfo[461].ship_id_to === 466 );
+            remodelInfo[462].devmat = 10;
+
+            // step 2: get all original ship ids
+            // an original ship can only remodel into other ships
+            // but is never a remodel target
+            var originalShipIds = [];
+            $.each( shipIds, function(i,x) {
+                if (!shipDstIds[x])
+                    originalShipIds.push(x);
+            });
+
+            /*
+               remodelGroups[ originalShipId  ] =
+                 { origin: shipId
+                 // circular-remodels are all considered final forms
+                 , final_forms: [shipId]
+                 // all forms of one kanmusu
+                 , group: [shipId]
+                 }
+             */
+            var remodelGroups = {};
+            // reverse from shipId to orginal
+            var originOf = {};
+
+            $.each( originalShipIds, function(i, x) {
+                var group = [x];
+                var cur = x;
+                while (typeof remodelInfo[cur] !== 'undefined' &&
+                       group.indexOf(remodelInfo[cur].ship_id_to) === -1) {
+                    cur = remodelInfo[cur].ship_id_to;
+                    group.push( cur );
+                }
+
+                cur = group[group.length-1];
+                var final_forms = [ cur ];
+                while (typeof remodelInfo[cur] !== 'undefined' &&
+                       final_forms.indexOf(remodelInfo[cur].ship_id_to) === -1) {
+                    cur = remodelInfo[cur].ship_id_to;
+                    final_forms.push( cur );
+                }
+
+                remodelGroups[x] =
+                    { origin: x,
+                      group: group,
+                      final_forms: final_forms,
+                    }
+
+                $.each(group, function(j,y) {
+                    originOf[y] = x;
+                });
+            });
+
+            return { remodelInfo: remodelInfo,
+                     remodelGroups: remodelGroups,
+                     originOf: originOf,
+                     // this 2 numbers are "checksum"s, if master data does not change
+                     // on this 2 numbers, we don't recompute
+                     shipCount: masterData.api_mst_ship.length,
+                     upgradeCount: masterData.api_mst_shipupgrade.length
+                   };
+        }
+    }
+})();

--- a/src/library/modules/RemodelDb.js
+++ b/src/library/modules/RemodelDb.js
@@ -42,7 +42,16 @@
                 return true;
             return false;
         },
+        // according to the following doc:
+        // https://github.com/andanteyk/ElectronicObserver/blob/d28e1d904521ea60b25c15010d06f130ae36dc62/ElectronicObserver/Other/Information/kcmemo.md#%E6%94%B9%E8%A3%85%E6%99%82%E3%81%AB%E5%BF%85%E8%A6%81%E3%81%AA%E9%96%8B%E7%99%BA%E8%B3%87%E6%9D%90
+        calcDevMat: function(steel) {
+            return (steel < 4500) ? 0
+                : ( steel < 5500) ? 10
+                : ( steel < 6500) ? 15
+                : 20;
+        },
         mkDb: function(masterData) {
+            var self = this;
             // step 1: collect remodel info
             /*
                remodelInfo[ shipId  ] =
@@ -84,6 +93,8 @@
                       blueprint: 0,
                       devmat: 0
                     };
+
+                remodel.devmat = self.calcDevMat(remodel.steel);
                 remodelInfo[x.api_id] = remodel;
 
             });
@@ -103,16 +114,6 @@
                 remodel.blueprint = x.api_drawing_count;
                 remodelInfo[x.api_current_ship_id] = remodel;
             });
-
-            // patch devmat info, can't find it in api_start2
-            console.assert( remodelInfo[461].ship_id_to === 466 );
-            remodelInfo[461].devmat = 15;
-            console.assert( remodelInfo[462].ship_id_to === 467 );
-            remodelInfo[462].devmat = 15;
-            console.assert( remodelInfo[466].ship_id_to === 461 );
-            remodelInfo[461].devmat = 10;
-            console.assert( remodelInfo[461].ship_id_to === 466 );
-            remodelInfo[462].devmat = 10;
 
             // step 2: get all original ship ids
             // an original ship can only remodel into other ships

--- a/src/library/modules/RemodelDb.js
+++ b/src/library/modules/RemodelDb.js
@@ -172,6 +172,31 @@
                      shipCount: masterData.api_mst_ship.length,
                      upgradeCount: masterData.api_mst_shipupgrade.length
                    };
+        },
+        // return root ship in this ships's remodel chain
+        originOf: function(shipId) {
+            return this._db.originOf[shipId];
+        },
+        // return remodel info, including cost and required level
+        remodelInfo: function(shipId) {
+            return this._db.remodelInfo[shipId];
+        },
+        // return all ships in ship's remodel chain
+        // in other words, all ships that considered "same" kanmusu
+        remodelGroup: function(shipId) {
+            var oid = this.originOf(shipId);
+            return oid?this._db.remodelGroups[oid].group:false;
+        },
+        // get final forms / remodels of one ship,
+        // cyclic remodels are all considered final
+        finalForms: function(shipId) {
+            var oid = this.originOf(shipId);
+            return oid?this._db.remodelGroups[oid].final_forms:false;
+        },
+        // check if one ship is in her final form
+        isFinalForm: function(shipId) {
+            var ff = this.finalForms(shipId);
+            return ff ? ff.indexOf(shipId) !== -1 : false;
         }
     }
 })();

--- a/src/library/modules/RemodelDb.js
+++ b/src/library/modules/RemodelDb.js
@@ -83,7 +83,7 @@
                       catapult: 0,
                       blueprint: 0,
                       devmat: 0
-                    }
+                    };
                 remodelInfo[x.api_id] = remodel;
 
             });
@@ -157,7 +157,7 @@
                     { origin: x,
                       group: group,
                       final_forms: final_forms,
-                    }
+                    };
 
                 $.each(group, function(j,y) {
                     originOf[y] = x;
@@ -198,5 +198,5 @@
             var ff = this.finalForms(shipId);
             return ff ? ff.indexOf(shipId) !== -1 : false;
         }
-    }
+    };
 })();

--- a/src/pages/devtools/themes/natsuiro/natsuiro.html
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.html
@@ -858,6 +858,7 @@
 		<script type="text/javascript" src="../../../../library/modules/PoiDBSubmission.js"></script>
 		<script type="text/javascript" src="../../../../library/modules/KC3DBSubmission.js"></script>
 		
+		<script type="text/javascript" src="../../../../library/modules/RemodelDb.js"></script>
 		<script type="text/javascript" src="../../../../library/modules/Database.js"></script>
 		<script type="text/javascript" src="../../../../library/modules/Kcsapi.js"></script>
 		<script type="text/javascript" src="../../../../library/modules/Network.js"></script>

--- a/src/pages/strategy/strategy.js
+++ b/src/pages/strategy/strategy.js
@@ -28,6 +28,7 @@
 		KC3Database.init( PlayerManager.hq.id );
 		KC3Translation.execute();
 		WhoCallsTheFleetDb.init("../../");
+		RemodelDb.init();
 		
 		// Click a menu item
 		$("#menu .submenu ul.menulist li").on("click", function(){

--- a/src/pages/strategy/tabs/mstship/mstship.html
+++ b/src/pages/strategy/tabs/mstship/mstship.html
@@ -104,6 +104,14 @@
 				</div>
 				<div class="clear"></div>
 			</div>
+
+            <div class="other_forms"> 
+				<div class="ship_label">Other forms</div>
+                <a class="hover">a</a>
+                <a class="hover">b</a>
+                <a class="hover">c</a>
+                <a class="hover">d</a>
+            </div>
 			
 			<!-- Scrap Value -->
 			<div class="scrap moreinfo_box">

--- a/src/pages/strategy/tabs/mstship/mstship.js
+++ b/src/pages/strategy/tabs/mstship/mstship.js
@@ -279,7 +279,7 @@
 					.remodelGroup(shipData.api_id)
 					.filter( function(x) {
 						return x !== shipData.api_id &&
-							x !== shipData.api_aftershipid
+							x !== shipData.api_aftershipid;
 					});
 				
 				if (otherFormIds.length > 0) {

--- a/src/pages/strategy/tabs/mstship/mstship.js
+++ b/src/pages/strategy/tabs/mstship/mstship.js
@@ -140,6 +140,12 @@
 				e.preventDefault();
 				return false;
 			});
+
+			$(".tab_mstship .shipInfo").on("click", ".more .other_forms a", function(e){
+				self.showShip( $(this).data("sid") );
+				e.preventDefault();
+				return false;
+			});
 			
 			// Salt-toggle
 			$(".tab_mstship .shipInfo").on("click", ".salty-zone", function(e){
@@ -267,6 +273,30 @@
 				}else{
 					$(".tab_mstship .shipInfo .remodel").hide();
 				}
+
+				// other forms
+				var otherFormIds = RemodelDb
+					.remodelGroup(shipData.api_id)
+					.filter( function(x) {
+						return x !== shipData.api_id &&
+							x !== shipData.api_aftershipid
+					});
+				
+				if (otherFormIds.length > 0) {
+					$(".tab_mstship .shipInfo .more .other_forms a").remove();
+
+					$.each(otherFormIds, function(i,x) {
+						$("<a/>")
+							.text( KC3Meta.shipName(KC3Master.ship(x).api_name) )
+							.data("sid",x)
+							.appendTo( ".tab_mstship .shipInfo .more .other_forms" );
+					});
+					
+					$(".tab_mstship .shipInfo .more .other_forms").show();
+				} else {
+					$(".tab_mstship .shipInfo .more .other_forms").hide();
+				}
+
 				$(".tab_mstship .scrap .rsc").each(function(index){
 					$(".rsc_value", this).text( shipData.api_broken[index] );
 				});


### PR DESCRIPTION
I have implemented a module called "RemodelDb", that computes everything related to remodeling (cost, required level, etc.) from `api_start2` data. devs can take a look.

As a byproduct of this. I added "other forms" in ship library. when a ship has forms other than herself and her next remodel, "Other forms" will appear. may need some tweak on UI afterwards xD.

![2016-02-06_223726_3840x1080_scrot](https://cloud.githubusercontent.com/assets/1096354/12870779/4e3c4e8c-cd22-11e5-9621-64b6805af90a.png)

Note that for this patch to work you need to start the game so RemodelDb can receive `api_start2`. (you only need to do this once)