### PR TITLE
Option for forcing English ship type

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -146,6 +146,12 @@
 				"name" : "SettingsAutoExpedTab",
 				"type" : "check",
 				"options" : {}
+			},
+			{
+				"id" : "info_eng_stype",
+				"name" : "SettingsEnglishShipType",
+				"type" : "check",
+				"options" : {}
 			}
 		]
 	},

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -40,6 +40,7 @@ Retreives when needed to apply on components
 				info_delta 			: false,
 				info_fleetstat 		: true,
 				info_auto_exped_tab : true,
+				info_eng_stype		: false,
 
 				// AIR PROFICIENCY BONUSES (Configurable by user)
 				air_formula			: 3, // 1=no veteran 2=veteran average 3=veteran bounds

--- a/src/library/modules/Translation.js
+++ b/src/library/modules/Translation.js
@@ -60,7 +60,9 @@
 				extendEnglish=false;
 			}
 			
-			// console.log(filename, "extendEnglish", extendEnglish);
+			var language = ConfigManager.language;
+			if (filename === "stype" && ConfigManager.info_eng_stype)
+				language = "en";
 			
 			var translationBase = {}, enJSON;
 			if(extendEnglish){
@@ -75,7 +77,7 @@
 			}
 			
 			return $.extend(true, translationBase, JSON.parse($.ajax({
-				url : repo+'lang/data/' +ConfigManager.language+ '/' + filename + '.json',
+				url : repo+'lang/data/' +language+ '/' + filename + '.json',
 				async: false
 			}).responseText));
 		}

--- a/src/library/modules/Translation.js
+++ b/src/library/modules/Translation.js
@@ -75,11 +75,23 @@
 				// Make is as the translation base
 				translationBase = enJSON;
 			}
-			
-			return $.extend(true, translationBase, JSON.parse($.ajax({
-				url : repo+'lang/data/' +language+ '/' + filename + '.json',
-				async: false
-			}).responseText));
+
+			// make "stype.json" an option:
+			// if we can't fetch this file, the English
+			// version will be used instead
+			var translation;
+			try {
+				translation = JSON.parse($.ajax({
+					url : repo+'lang/data/' +language+ '/' + filename + '.json',
+					async: false
+				}).responseText);
+			} catch (e) {
+				if (e instanceof SyntaxError && filename === "stype")
+					translation = null;
+				else
+					throw e;
+			}
+			return $.extend(true, translationBase, translation);
 		}
 		
 	};


### PR DESCRIPTION
implements #1036 

- when this option is enabled, ship type is always in English. (disabled by default)
- when `stype.json` is missing, the English version will be used (making `stype.json` in other languages optional)

