### PR TITLE
Fix #49 Detect devicePixelRatio for screenshot

### DIFF
--- a/src/library/objects/Screenshot.js
+++ b/src/library/objects/Screenshot.js
@@ -1,7 +1,7 @@
 var imgurLimit = 0;
 
 function KCScreenshot(){
-	this.scale = ((ConfigManager.api_gameScale || 100) / 100);
+	this.scale = ((ConfigManager.api_gameScale || 100) / 100) * (window.devicePixelRatio || 1);
 	this.gamebox = {};
 	this.canvas = {};
 	this.context = {};


### PR DESCRIPTION
* Detects `window.devicePixelRatio` and applies it to screenshot scales
* Would detect both retina (2dppx) and other high-density (1.3dppx etc)