### PR TITLE
Release 28.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "KC3Kai",
-  "version": "28.0.0",
+  "version": "28.1.0",
   "description": "Kantai Collection Game Viewer and Tools",
   "repository": {
     "type": "git",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
 	"name": "KC3改 Development",
 	"short_name": "KC3改",
 	"description": "Kantai Collection Game Viewer and Helper",
-	"version": "28.0",
+	"version": "28.1",
 	"devtools_page": "pages/devtools/init.html",
 	"options_page": "pages/settings/settings.html",
 	"icons": {

--- a/src/pages/game/api.js
+++ b/src/pages/game/api.js
@@ -318,9 +318,13 @@ var interactions = {
 				break;
 		}
 		subtitleText = KC3Meta.quote( quoteIdentifier, quoteVoiceNum );
-
+		
+		// hide first to fading will stop
+		$(".overlay_subtitles").stop(true, true);
+		$(".overlay_subtitles").hide();
+		
 		// If subtitle removal timer is ongoing, reset
-		if(subtitleVanishTimer && subtitleText){
+		if(subtitleVanishTimer){
 			clearTimeout(subtitleVanishTimer);
 		}
 		
@@ -328,29 +332,9 @@ var interactions = {
 		if(subtitleText){
 			$(".overlay_subtitles").html(subtitleText);
 			$(".overlay_subtitles").show();
-			
-			/*subtitleMp3 = new Audio();
-			subtitleMp3.canplaythrough = function() { 
-				console.log("DURATION: "+subtitleMp3.duration);
-			};
-			subtitleMp3.src = request.url;*/
-			
-			/*subtitleMp3 = document.createElement("audio");
-			subtitleMp3.addEventListener('canplaythrough', function() { 
-				console.log("DURATION: "+subtitleMp3.duration);
-			}, false);
-			subtitleMp3.src = request.url;*/
-			
 			subtitleVanishTimer = setTimeout(function(){
 				subtitleVanishTimer = false;
-				$(".overlay_subtitles").fadeOut(500);
-			}, (2000+ ($(".overlay_subtitles").text().length*50)) );
-		} else {
-			//$(".overlay_subtitles").html("Missing quote #" + quoteIdentifier + "-" + quoteVoiceNum);
-			$(".overlay_subtitles").hide();
-			subtitleVanishTimer = setTimeout(function(){
-				subtitleVanishTimer = false;
-				$(".overlay_subtitles").fadeOut(500);
+				$(".overlay_subtitles").fadeOut(2000);
 			}, (2000+ ($(".overlay_subtitles").text().length*50)) );
 		}
 	}

--- a/src/pages/game/dmm.js
+++ b/src/pages/game/dmm.js
@@ -373,7 +373,7 @@ var interactions = {
 		subtitleText = KC3Meta.quote( quoteIdentifier, quoteVoiceNum );
 		
 		// hide first to fading will stop
-		$(".overlay_subtitles").stop(true);
+		$(".overlay_subtitles").stop(true, true);
 		$(".overlay_subtitles").hide();
 		
 		// If subtitle removal timer is ongoing, reset
@@ -387,7 +387,7 @@ var interactions = {
 			$(".overlay_subtitles").show();
 			subtitleVanishTimer = setTimeout(function(){
 				subtitleVanishTimer = false;
-				$(".overlay_subtitles").fadeOut(500);
+				$(".overlay_subtitles").fadeOut(2000);
 			}, (2000+ ($(".overlay_subtitles").text().length*50)) );
 		}
 	},

--- a/update
+++ b/update
@@ -1,6 +1,6 @@
 {
-	"version" : "28",
-	"time" : "Sun, 27 March 2016 13:00:00 +0900",
+	"version" : "28.1",
+	"time" : "Sun, 27 March 2016 15:00:00 +0900",
 	"maintenance_start": "Fri, 1 April 2016 11:00:00 +0900",
 	"maintenance_end": "Fri, 1 April 2016 17:00:00 +0900"
 }


### PR DESCRIPTION
* Fix subtitle fade transparency applies to next quote
* Sync DMM page and API page subtitle fade scripts
* More subtitle quote fixes [from the sheet](https://docs.google.com/spreadsheets/d/1wg7pCv3l6g8BfOye3-DbrCuYDhTvSX4h1UuiRCp0_K8)
* Fix errors on languages without `quotes.json`
