### PR TITLE
[dev-contact-plane] Show contact plane

### DIFF
--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -275,8 +275,10 @@ Used by SortieManager
 				api_e_lostcount:0,
 			},
 			attackPhase = battleData.api_kouku.api_stage2;
-		this.fcontact = (planePhase.api_touch_plane[0] > -1)? KC3Meta.term("BattleContactYes") : KC3Meta.term("BattleContactNo");
-		this.econtact = (planePhase.api_touch_plane[1] > -1)? KC3Meta.term("BattleContactYes") : KC3Meta.term("BattleContactNo");
+		this.fcontactId = planePhase.api_touch_plane[0];
+		this.fcontact = this.fcontactId > 0 ? KC3Meta.term("BattleContactYes") : KC3Meta.term("BattleContactNo");
+		this.econtactId = planePhase.api_touch_plane[1];
+		this.econtact = this.econtactId > 0 ? KC3Meta.term("BattleContactYes") : KC3Meta.term("BattleContactNo");
 		
 		this.airbattle = KC3Meta.airbattle( planePhase.api_disp_seiku );
 		
@@ -488,10 +490,12 @@ Used by SortieManager
 		}
 		
 		this.engagement = this.engagement || KC3Meta.engagement( nightData.api_formation[2] );
-		this.fcontact = (nightData.api_touch_plane[0] > -1)? KC3Meta.term("BattleContactYes") : KC3Meta.term("BattleContactNo");
-		this.econtact = (nightData.api_touch_plane[1] > -1)? KC3Meta.term("BattleContactYes") : KC3Meta.term("BattleContactNo");
-		this.flare = nightData.api_flare_pos[0]; //??
-		this.searchlight = nightData.api_flare_pos[1]; //??
+		this.fcontactId = nightData.api_touch_plane[0]; // masterId of slotitem, starts from 1
+		this.fcontact = this.fcontactId > 0 ? KC3Meta.term("BattleContactYes") : KC3Meta.term("BattleContactNo");
+		this.econtactId = nightData.api_touch_plane[1];
+		this.econtact = this.econtactId > 0 ? KC3Meta.term("BattleContactYes") : KC3Meta.term("BattleContactNo");
+		this.flare = nightData.api_flare_pos[0]; // Star shell user pos
+		this.searchlight = nightData.api_flare_pos[1]; // Search light user pos
 		
 		var PS = window.PS;
 		var DA = PS["KanColle.DamageAnalysis"];

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -688,6 +688,11 @@ html,body {
 	float:left;
 	color:#fff;
 }
+.module.activity .battle_contact img {
+	width:15px;
+	height:15px;
+	vertical-align:top;
+}
 /* Battle Planes */
 .module.activity .battle_planes {
 	width:180px;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -1333,7 +1333,8 @@
 			// Battle conditions
 			$(".module.activity .battle_engagement").text( thisNode.engagement[2] || thisNode.engagement[0] );
 			$(".module.activity .battle_engagement").attr("title", thisNode.engagement[0] );
-			$(".module.activity .battle_contact").text(thisNode.fcontact + KC3Meta.term("BattleContactVs") + thisNode.econtact);
+			var contactSpan = buildContactPlaneSpan(thisNode.fcontactId, thisNode.fcontact, thisNode.econtactId, thisNode.econtact);
+			$(".module.activity .battle_contact").html($(contactSpan).html());
 			
 			// Swap fish and support icons
 			$(".module.activity .battle_fish").hide();
@@ -1430,7 +1431,8 @@
 				});
 			}
 			
-			$(".module.activity .battle_contact").text(thisNode.fcontact + KC3Meta.term("BattleContactVs") + thisNode.econtact);
+			var contactSpan = buildContactPlaneSpan(thisNode.fcontactId, thisNode.fcontact, thisNode.econtactId, thisNode.econtact);
+			$(".module.activity .battle_contact").html($(contactSpan).html());
 			
 			if(thisNode.predictedRankNight){
 				$(".module.activity .battle_rating img").attr("src",
@@ -1722,7 +1724,8 @@
 			$(".module.activity .battle_airbattle").text( thisPvP.airbattle[0] );
 			$(".module.activity .battle_airbattle").attr("title", thisPvP.airbattle[2] || "" );
 			$(".module.activity .battle_engagement").text( thisPvP.engagement[2] || thisNode.engagement[0] );
-			$(".module.activity .battle_contact").text(thisPvP.fcontact + KC3Meta.term("BattleContactVs") + thisPvP.econtact);
+			var contactSpan = buildContactPlaneSpan(thisPvP.fcontactId, thisPvP.fcontact, thisPvP.econtactId, thisPvP.econtact);
+			$(".module.activity .battle_contact").html($(contactSpan).html());
 			
 			// Fighter phase
 			$(".fighter_ally .plane_before").text(thisPvP.planeFighters.player[0]);
@@ -2182,6 +2185,29 @@
 		}
 	}
 	
+	function buildContactPlaneSpan(fcontactId, fcontact, econtactId, econtact) {
+		var fContactIcon = null,
+			eContactIcon = null,
+			contactSpan = $("<span/>");
+		if(fcontactId > 0){
+			var fcpMaster = KC3Master.slotitem(fcontactId);
+			fContactIcon = $("<img />")
+				.attr("src", "../../../../assets/img/items/"+fcpMaster.api_type[3]+".png")
+				.attr("title", KC3Meta.gearName(fcpMaster.api_name));
+		}
+		if(econtactId > 0){
+			var ecpMaster = KC3Master.slotitem(econtactId);
+			eContactIcon = $("<img />")
+				.attr("src", "../../../../assets/img/items/"+ecpMaster.api_type[3]+".png")
+				.attr("title", KC3Meta.gearName(ecpMaster.api_name));
+		}
+		$(contactSpan)
+			.append(!!fContactIcon ? fContactIcon : fcontact)
+			.append(KC3Meta.term("BattleContactVs"))
+			.append(!!eContactIcon ? eContactIcon : econtact);
+		return contactSpan;
+	}
+
 	function updateMapGauge(gaugeDmg,fsKill,noBoss) {
 		// Map Gauge and status
 		var

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -1774,6 +1774,7 @@
 				.attr("src", "../../../../assets/img/client/ratings/"+thisPvP.rating+".png")
 				.css("opacity", 1);
 			updateHQEXPGained($(".admiral_lvnext"), KC3SortieManager.hqExpGained);
+			this.Fleet();
 		},
 		
 		ExpeditionSelection: function (data) {

--- a/src/pages/devtools/themes/plain/plain.js
+++ b/src/pages/devtools/themes/plain/plain.js
@@ -1274,7 +1274,8 @@
 			
 			// Battle conditions
 			$(".module.activity .battle_engagement").text( thisNode.engagement[2] );
-			$(".module.activity .battle_contact").text(thisNode.fcontact+KC3Meta.term("BattleContactVs")+thisNode.econtact);
+			var contactSpan = buildContactPlaneSpan(thisNode.fcontactId, thisNode.fcontact, thisNode.econtactId, thisNode.econtact);
+			$(".module.activity .battle_contact").html($(contactSpan).html());
 			
 			// Swap fish and support icons
 			$(".module.activity .battle_fish").hide();
@@ -1365,7 +1366,8 @@
 				});
 			}
 			
-			$(".module.activity .battle_contact").text(thisNode.fcontact+KC3Meta.term("BattleContactVs")+thisNode.econtact);
+			var contactSpan = buildContactPlaneSpan(thisNode.fcontactId, thisNode.fcontact, thisNode.econtactId, thisNode.econtact);
+			$(".module.activity .battle_contact").html($(contactSpan).html());
 			
 			if(thisNode.predictedRankNight){
 				$(".module.activity .battle_rating img").attr("src",
@@ -1644,7 +1646,8 @@
 			$(".module.activity .battle_detection").text( thisPvP.detection[0] );
 			$(".module.activity .battle_airbattle").text( thisPvP.airbattle[0] );
 			$(".module.activity .battle_engagement").text( thisPvP.engagement[2] );
-			$(".module.activity .battle_contact").text(thisPvP.fcontact+KC3Meta.term("BattleContactVs")+thisPvP.econtact);
+			var contactSpan = buildContactPlaneSpan(thisPvP.fcontactId, thisPvP.fcontact, thisPvP.econtactId, thisPvP.econtact);
+			$(".module.activity .battle_contact").html($(contactSpan).html());
 			
 			// Fighter phase
 			$(".fighter_ally .plane_before").text(thisPvP.planeFighters.player[0]);
@@ -2094,6 +2097,29 @@
 			.text( PlayerManager.hq.exp[hqDt] );
 	}
 	
+	function buildContactPlaneSpan(fcontactId, fcontact, econtactId, econtact) {
+		var fContactIcon = null,
+			eContactIcon = null,
+			contactSpan = $("<span/>");
+		if(fcontactId > 0){
+			var fcpMaster = KC3Master.slotitem(fcontactId);
+			fContactIcon = $("<img />")
+				.attr("src", "../../../../assets/img/items/"+fcpMaster.api_type[3]+".png")
+				.attr("title", KC3Meta.gearName(fcpMaster.api_name));
+		}
+		if(econtactId > 0){
+			var ecpMaster = KC3Master.slotitem(econtactId);
+			eContactIcon = $("<img />")
+				.attr("src", "../../../../assets/img/items/"+ecpMaster.api_type[3]+".png")
+				.attr("title", KC3Meta.gearName(ecpMaster.api_name));
+		}
+		$(contactSpan)
+			.append(!!fContactIcon ? fContactIcon : fcontact)
+			.append(KC3Meta.term("BattleContactVs"))
+			.append(!!eContactIcon ? eContactIcon : econtact);
+		return contactSpan;
+	}
+
 	function CraftGearStats(MasterItem, StatProperty, Code){
 		if(parseInt(MasterItem["api_"+StatProperty], 10) !== 0){
 			var thisStatBox = $("#factory .equipStat").clone().appendTo(".module.activity .activity_crafting .equipStats");


### PR DESCRIPTION
#### Issues Addressed
Merging this PR will automatically close the following issues
* Close #960

#### Update
A simple impl. for #960, on both sortie and PvP, show line on battle activity:
`Contact: <img>(or "None") vs <img>(or "None")` (image icon with title of plane name)
instead of former plain text.
Plane icon only half-size as line-height limited.

* Only available for natsuiro theme
* Not synced for plain theme and Strategy Room sortie history yet, history may left to 'Strategy Room enhancement'.
