### PR TITLE
[dev-panel-toggle-quest] Toggle completion status of quest from panel

### DIFF
--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -779,20 +779,40 @@
 		Quests: function(data){
 			KC3QuestManager.load();
 			var questType, questBox;
+			var toggleQuestFunc = function(){
+				var quest = KC3QuestManager.get($(this).data("id"));
+				if(quest.status == 2){
+					console.info("Going to complete quest:", quest);
+					quest.status = 3;
+					KC3QuestManager.save();
+					$(this).parent().addClass("complete");
+				} else if(quest.status == 3){
+					console.info("Going to open quest agin:", quest);
+					quest.status = 2;
+					KC3QuestManager.save();
+					$(this).parent().removeClass("complete");
+				} else {
+					console.warn("Quest status invalid:", quest);
+				}
+			};
 			$(".module.quests").html("");
 			$.each(KC3QuestManager.getActives(), function(index, quest){
 				questBox = $("#factory .quest").clone().appendTo(".module.quests");
 				if(!quest.tracking){ questBox.addClass("untracked"); }
-				$(".quest_color", questBox).css("background", quest.getColor() );
+				$(".quest_color", questBox).css("background", quest.getColor() )
+					.addClass("hover")
+					.attr("title", KC3Meta.term("PanelToggleQuestComplete") )
+					.data("id", quest.id)
+					.click(toggleQuestFunc);
 				if(quest.isComplete()){
 					questBox.addClass("complete");
 					// $(".quest_color", questBox).html("&#x2714;");
 				}
 				if(quest.meta){
 					$(".quest_text", questBox).text( quest.meta().name );
-					$(".quest_text", questBox).attr("title", quest.meta().code + " " + quest.meta().name + "\n" + quest.meta().desc );
+					$(".quest_text", questBox).attr("title", "{0} {1}\n{2}".format(quest.meta().code, quest.meta().name, quest.meta().desc) );
 					if(!!quest.meta().memo) {
-						$(".quest_text", questBox).attr("title", $(".quest_text", questBox).attr("title") + "\n" + quest.meta().memo );
+						$(".quest_text", questBox).attr("title", "{0}\n{1}".format($(".quest_text", questBox).attr("title"), quest.meta().memo) );
 					}
 				}else{
 					$(".quest_text", questBox).text( KC3Meta.term("UntranslatedQuest") );

--- a/src/pages/devtools/themes/plain/plain.js
+++ b/src/pages/devtools/themes/plain/plain.js
@@ -718,18 +718,40 @@
 		Quests: function(data){
 			KC3QuestManager.load();
 			var questType, questBox;
+			var toggleQuestFunc = function(){
+				var quest = KC3QuestManager.get($(this).data("id"));
+				if(quest.status == 2){
+					console.info("Going to complete quest:", quest);
+					quest.status = 3;
+					KC3QuestManager.save();
+					$(this).parent().addClass("complete");
+				} else if(quest.status == 3){
+					console.info("Going to open quest agin:", quest);
+					quest.status = 2;
+					KC3QuestManager.save();
+					$(this).parent().removeClass("complete");
+				} else {
+					console.warn("Quest status invalid:", quest);
+				}
+			};
 			$(".module.quests").html("");
 			$.each(KC3QuestManager.getActives(), function(index, quest){
 				questBox = $("#factory .quest").clone().appendTo(".module.quests");
 				if(!quest.tracking){ questBox.addClass("untracked"); }
-				$(".quest_color", questBox).css("background", quest.getColor() );
+				$(".quest_color", questBox).css("background", quest.getColor() )
+					.addClass("hover")
+					.attr("title", KC3Meta.term("PanelToggleQuestComplete") )
+					.data("id", quest.id)
+					.click(toggleQuestFunc);
 				if(quest.isComplete()){
 					questBox.addClass("complete");
-					// $(".quest_color", questBox).html("&#x2714;");
 				}
 				if(quest.meta){
 					$(".quest_text", questBox).text( quest.meta().name );
-					$(".quest_text", questBox).attr("title", quest.meta().desc );
+					$(".quest_text", questBox).attr("title", "{0} {1}\n{2}".format(quest.meta().code, quest.meta().name, quest.meta().desc) );
+					if(!!quest.meta().memo) {
+						$(".quest_text", questBox).attr("title", "{0}\n{1}".format($(".quest_text", questBox).attr("title"), quest.meta().memo) );
+					}
 				}else{
 					$(".quest_text", questBox).text( KC3Meta.term("UntranslatedQuest") );
 					$(".quest_text", questBox).attr("title", KC3Meta.term("UntranslatedQuest") );


### PR DESCRIPTION
#### Issues Addressed
Merging this PR will automatically close the following issues
* Close #1283

#### Updates
For #1283, I feel this workaround really easy to impl :joy: 
Of course better plan should be syncing profile data (including quest tracking status) via Chrome between devices.

This one just for convenience to avoid open Strategy Room when some opened quests completed at other place.
Usage: Click on the color box of quest at quest list of panel. Status will be toggled between 'open' and 'complete'. And when u go back to main port in-game, the completed ones will disappear.
As usual, if a quest not completed in fact, go to quest page in-game, it will be reopened again.