### PR TITLE
Show Taiha HP left tooltip on panel

### DIFF
--- a/src/pages/devtools/themes/natsuiro/js/Shipbox.js
+++ b/src/pages/devtools/themes/natsuiro/js/Shipbox.js
@@ -146,6 +146,12 @@ KC3改 Ship Box for Natsuiro theme
 		var hpPercent = this.shipData.hp[0] / this.shipData.hp[1];
 		$(".ship_hp_bar", this.element).css("width", (this.hpBarLength*hpPercent)+"px");
 		
+		// Left HP to be Taiha
+		var taihaHp = Math.floor(0.25 * this.shipData.hp[1]);
+		if(this.shipData.hp[0] > taihaHp && this.shipData.hp[0] < this.shipData.hp[1]){
+			$(".ship_hp_cur", this.element).attr("title", KC3Meta.term("PanelTaihaHpLeft").format(taihaHp, this.shipData.hp[0] - taihaHp) );
+		}
+		
 		// Clear box colors
 		this.element.css("background-color", "transparent");
 		

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -1371,20 +1371,7 @@
 				// If anti-air CI fire is triggered
 				if(!!thisNode.antiAirFire){
 					$(".module.activity .battle_aaci img").attr("src", "../../../../assets/img/ui/dark_aaci.png");
-					var aaciTips = "";
-					var fireShipPos = thisNode.antiAirFire.api_idx; // starts from 0
-					if(fireShipPos>=0 && fireShipPos<6){
-						var sentFleet = PlayerManager.fleets[KC3SortieManager.fleetSent-1];
-						var shipName = KC3ShipManager.get(sentFleet.ships[fireShipPos]).name();
-						aaciTips += shipName;
-					}
-					var itemList = thisNode.antiAirFire.api_use_items;
-					if(!!itemList && itemList.length > 0){
-						for(var itemIdx=0; itemIdx<Math.min(itemList.length,4); itemIdx++) {
-							if(itemList[itemIdx] > -1) aaciTips += String.fromCharCode(13) + KC3Meta.gearName(KC3Master.slotitem(itemList[itemIdx]).api_name);
-						}
-					}
-					$(".module.activity .battle_aaci").attr("title", aaciTips);
+					$(".module.activity .battle_aaci").attr("title", buildAntiAirCutinTooltip(thisNode));
 				} else {
 					$(".module.activity .battle_aaci img").attr("src", "../../../../assets/img/ui/dark_aaci-x.png");
 					$(".module.activity .battle_aaci").attr("title", KC3Meta.term("BattleAntiAirCutIn"));
@@ -1752,20 +1739,7 @@
 			// If anti-air CI fire is triggered
 			if(!!thisPvP.antiAirFire){
 				$(".module.activity .battle_aaci img").attr("src", "../../../../assets/img/ui/dark_aaci.png");
-				var aaciTips = "";
-				var fireShipPos = thisPvP.antiAirFire.api_idx;
-				if(fireShipPos>=0 && fireShipPos<6){
-					var sentFleet = PlayerManager.fleets[KC3SortieManager.fleetSent-1];
-					var shipName = KC3ShipManager.get(sentFleet.ships[fireShipPos]).name();
-					aaciTips += shipName;
-				}
-				var itemList = thisPvP.antiAirFire.api_use_items;
-				if(!!itemList && itemList.length > 0){
-					for(var itemIdx=0; itemIdx<Math.min(itemList.length,4); itemIdx++) {
-						if(itemList[itemIdx] > -1) aaciTips += String.fromCharCode(13) + KC3Meta.gearName(KC3Master.slotitem(itemList[itemIdx]).api_name);
-					}
-				}
-				$(".module.activity .battle_aaci").attr("title", aaciTips);
+				$(".module.activity .battle_aaci").attr("title", buildAntiAirCutinTooltip(thisPvP));
 			} else {
 				$(".module.activity .battle_aaci img").attr("src", "../../../../assets/img/ui/dark_aaci-x.png");
 				$(".module.activity .battle_aaci").attr("title", KC3Meta.term("BattleAntiAirCutIn"));
@@ -2274,6 +2248,23 @@
 			.append(KC3Meta.term("BattleContactVs"))
 			.append(!!eContactIcon ? eContactIcon : econtact);
 		return contactSpan;
+	}
+
+	function buildAntiAirCutinTooltip(thisNode) {
+		var aaciTips = "";
+		var fireShipPos = thisNode.antiAirFire.api_idx; // starts from 0
+		if(fireShipPos>=0 && fireShipPos<6){
+			var sentFleet = PlayerManager.fleets[KC3SortieManager.fleetSent-1];
+			var shipName = KC3ShipManager.get(sentFleet.ships[fireShipPos]).name();
+			aaciTips += shipName;
+		}
+		var itemList = thisNode.antiAirFire.api_use_items;
+		if(!!itemList && itemList.length > 0){
+			for(var itemIdx=0; itemIdx<Math.min(itemList.length,4); itemIdx++) {
+				if(itemList[itemIdx] > -1) aaciTips += String.fromCharCode(13) + KC3Meta.gearName(KC3Master.slotitem(itemList[itemIdx]).api_name);
+			}
+		}
+		return aaciTips;
 	}
 
 	function updateMapGauge(gaugeDmg,fsKill,noBoss) {

--- a/src/pages/devtools/themes/plain/js/Shipbox.js
+++ b/src/pages/devtools/themes/plain/js/Shipbox.js
@@ -105,6 +105,12 @@ KC3改 Ship Box for Natsuiro theme
 		var hpPercent = this.shipData.hp[0] / this.shipData.hp[1];
 		$(".ship_hp_bar", this.element).css("width", (this.hpBarLength*hpPercent)+"px");
 		
+		// Left HP to be Taiha
+		var taihaHp = Math.floor(0.25 * this.shipData.hp[1]);
+		if(this.shipData.hp[0] > taihaHp && this.shipData.hp[0] < this.shipData.hp[1]){
+			$(".ship_hp_cur", this.element).attr("title", KC3Meta.term("PanelTaihaHpLeft").format(taihaHp, this.shipData.hp[0] - taihaHp) );
+		}
+		
 		// Clear box colors
 		this.element.css("background-color", "transparent");
 		


### PR DESCRIPTION
Close #1289
Dislike to calculate 25% hp manually for each ship either, so add a tool tip to current HP of ship list panel :sweat_smile: 
Hint by #1289 , add a left value too and only appear when Taiha HP < Current HP < Max HP.

BTW remove the duplicated AACI tool tip builder codes, commit it here...