### PR TITLE
[dev-show-aaci] Show AACI battle flag on panel #2

### DIFF
--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -250,6 +250,7 @@ Used by SortieManager
 		this.eships = enemyships;
 		this.eformation = battleData.api_formation[1];
 		this.eParam = battleData.api_eParam;
+		this.eKyouka = battleData.api_eKyouka;
 		this.eSlot = battleData.api_eSlot;
 
 		this.supportFlag = (battleData.api_support_flag>0);
@@ -282,8 +283,8 @@ Used by SortieManager
 		
 		this.airbattle = KC3Meta.airbattle( planePhase.api_disp_seiku );
 		
-		if(!!attackPhase){
-			this.antiAirFire = attackPhase.api_air_fire;
+		if(!!attackPhase && !!attackPhase.api_air_fire){
+			this.antiAirFire = [ attackPhase.api_air_fire ];
 		}
 		
 		// Fighter phase 1
@@ -324,6 +325,12 @@ Used by SortieManager
 			if(battleData.api_kouku2.api_stage2 !== null){
 				this.planeBombers.player[1] += battleData.api_kouku2.api_stage2.api_f_lostcount;
 				this.planeBombers.abyssal[1] += battleData.api_kouku2.api_stage2.api_e_lostcount;
+				if(!!battleData.api_kouku2.api_stage2.api_air_fire){
+					if(!this.antiAirFire || this.antiAirFire.length<1){
+						this.antiAirFire = [null];
+					}
+					this.antiAirFire[1] = battleData.api_kouku2.api_stage2.api_air_fire;
+				}
 			}
 		}
 
@@ -484,6 +491,7 @@ Used by SortieManager
 		this.eships = enemyships;
 		this.eformation = this.eformation || nightData.api_formation[1];
 		this.eParam = nightData.api_eParam;
+		this.eKyouka = nightData.api_eKyouka;
 		this.eSlot = nightData.api_eSlot;
 		
 		// if we did not started at night, at this point dayBeginHPs should be available

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -2252,19 +2252,26 @@
 
 	function buildAntiAirCutinTooltip(thisNode) {
 		var aaciTips = "";
-		var fireShipPos = thisNode.antiAirFire.api_idx; // starts from 0
-		if(fireShipPos>=0 && fireShipPos<6){
-			var sentFleet = PlayerManager.fleets[KC3SortieManager.fleetSent-1];
-			var shipName = KC3ShipManager.get(sentFleet.ships[fireShipPos]).name();
-			aaciTips += shipName;
+		if(!!thisNode.antiAirFire && thisNode.antiAirFire.length>0){
+			thisNode.antiAirFire.forEach(function(fire){
+				if(!!fire){
+					var fireShipPos = fire.api_idx; // starts from 0
+					if(fireShipPos>=0 && fireShipPos<6){
+						var sentFleet = PlayerManager.fleets[KC3SortieManager.fleetSent-1];
+						var shipName = KC3ShipManager.get(sentFleet.ships[fireShipPos]).name();
+						aaciTips += (!!aaciTips ? String.fromCharCode(13) : "") + shipName;
+					}
+					var itemList = fire.api_use_items;
+					if(!!itemList && itemList.length > 0){
+						for(var itemIdx=0; itemIdx<Math.min(itemList.length,4); itemIdx++) {
+							if(itemList[itemIdx] > -1) aaciTips += String.fromCharCode(13) + 
+								KC3Meta.gearName(KC3Master.slotitem(itemList[itemIdx]).api_name);
+						}
+					}
+				}
+			});
 		}
-		var itemList = thisNode.antiAirFire.api_use_items;
-		if(!!itemList && itemList.length > 0){
-			for(var itemIdx=0; itemIdx<Math.min(itemList.length,4); itemIdx++) {
-				if(itemList[itemIdx] > -1) aaciTips += String.fromCharCode(13) + KC3Meta.gearName(KC3Master.slotitem(itemList[itemIdx]).api_name);
-			}
-		}
-		return aaciTips;
+		return aaciTips || KC3Meta.term("BattleAntiAirCutIn");
 	}
 
 	function updateMapGauge(gaugeDmg,fsKill,noBoss) {


### PR DESCRIPTION
Continued for #1294 

Fix twice triggered AACI node issue.

And for @Javran and @dragonjet :
I've considered the way that show AACI indicator in ship box at first. But there are some design problems:
 * Battle activity attach the data for current battle node only
 * Shipbox list attach the data from player's fleets (showing current selected)
 * Extra data for indicators have to be passed to Shipbox object (or every ship objects in Fleet array) and kept during the battle node completed. Otherwise the indicators would disappear if user click on other fleet and switch back (or other events re-render the shipbox)
 * I add a extra attribute to ship object for the MVP icon, and do cleaning for each time battle node changed.
 * DJ gonna to pass extra data to Shipbox define function to show Damecon consuming. I'm not sure they will 'disappear' or not if user change current fleet during battle.
 * Finally I feel it's rather easier to show AACI (the battle node data) at battle activity panel, than pass it to Shipbox panel.

Maybe we have to get the proper way to pass the arguments to Shipbox for representing the 1-node only indicators on ship list panel.