### PR TITLE
Fix overlodger start time issue

### DIFF
--- a/src/pages/strategy/tabs/overlodger/overlodger.js
+++ b/src/pages/strategy/tabs/overlodger/overlodger.js
@@ -1018,7 +1018,7 @@
 										givenAry.push(newItem);
 										newTotalBuffer.push(newItem);
 									}
-									self.totalBuffer = newTotalBuffer.concat(self.totalBuffer);
+									[].unshift.apply(self.totalBuffer,newTotalBuffer);
 								} catch (e) {
 									console.error(e.stack);
 								} finally {

--- a/src/pages/strategy/tabs/overlodger/overlodger.js
+++ b/src/pages/strategy/tabs/overlodger/overlodger.js
@@ -986,12 +986,14 @@
 					
 					// ASYNC == Fetch Available Data
 					(function AsyncFetch(thr){
-						var oldwholebuff = Object.keys(this.totalBuffer);
+						// totalBuffer is ordered by id desc
+						var latestItem = this.totalBuffer[0] || {};
 						// Fetch new buffer
 						KC3Database.get_lodger_data(
-							Range(oldwholebuff.slice(-1).shift() || 0,Infinity,0,1),
+							Range(latestItem.id || 0,Infinity,0,1),
 							function(newBuffer){
 								// Process here
+								var newTotalBuffer = [];
 								try {
 									for(var index in newBuffer) { // tested and faster than those forEach :joy:
 										var
@@ -1014,8 +1016,9 @@
 										//		bufferArray.push(newItem);
 										//});
 										givenAry.push(newItem);
-										(self.totalBuffer).push(newItem);
+										newTotalBuffer.push(newItem);
 									}
+									self.totalBuffer = newTotalBuffer.concat(self.totalBuffer);
 								} catch (e) {
 									console.error(e.stack);
 								} finally {


### PR DESCRIPTION
Two things are misunderstood leading the issue:
 * `totalBuffer` is supposed to order by its elements.id desc.
   but push new elements (which are also order by id desc) to `totalBuffer` will break the order.
   so just concat new elements (in front of all) with old totalBuffer (after the new ones).
 * the first argument of `Range` sent to function `get_lodger_data` is supposed to be the latest ledger id in `totalBuffer`.
   but `Object.keys(this.totalBuffer)` will return index array instead of elements.id array.
   so just get the first element's id as long as previous order not broken.

@ReiFan49 could review it, I think this will solve it without breaking hour range check.