### PR TITLE
Show more info at support attack flag icon tooltip

### DIFF
--- a/src/library/modules/Meta.js
+++ b/src/library/modules/Meta.js
@@ -236,6 +236,10 @@ Provides access to data on built-in JSON files
 			return this._defeq["s" + id] || 0;
 		},
 
+		support :function(index){
+			return this._battle.support[index] || "";
+		},
+
 		detection :function(index){
 			return this._battle.detection[index] || ["","",""];
 		},

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -254,6 +254,10 @@ Used by SortieManager
 		this.eSlot = battleData.api_eSlot;
 
 		this.supportFlag = (battleData.api_support_flag>0);
+		if(this.supportFlag){
+			this.supportInfo = battleData.api_support_info;
+			this.supportInfo.api_support_flag = battleData.api_support_flag;
+		}
 		this.yasenFlag = (battleData.api_midnight_flag>0);
 		
 		this.originalHPs = battleData.api_nowhps;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -708,6 +708,7 @@
 		$(".module.activity .battle_eformation").attr("title", "");
 		$(".module.activity .battle_eformation").css("-webkit-transform", "rotate(0deg)");
 		$(".module.activity .battle_support img").attr("src", "../../../../assets/img/ui/dark_support.png");
+		$(".module.activity .battle_support").attr("title", KC3Meta.term("BattleSupportExped"));
 		$(".module.activity .battle_aaci img").attr("src", "../../../../assets/img/ui/dark_aaci.png");
 		$(".module.activity .battle_aaci").attr("title", KC3Meta.term("BattleAntiAirCutIn"));
 		$(".module.activity .battle_night img").attr("src", "../../../../assets/img/ui/dark_yasen.png");
@@ -1457,6 +1458,7 @@
 			if(!thisNode.startNight){
 				// If support expedition is triggered on this battle
 				$(".module.activity .battle_support img").attr("src", "../../../../assets/img/ui/dark_support"+["-x",""][thisNode.supportFlag&1]+".png");
+				$(".module.activity .battle_support").attr("title", buildSupportAttackTooltip(thisNode));
 				
 				// If anti-air CI fire is triggered
 				if(!!thisNode.antiAirFire){
@@ -2339,6 +2341,24 @@
 			.append(KC3Meta.term("BattleContactVs"))
 			.append(!!eContactIcon ? eContactIcon : econtact);
 		return contactSpan;
+	}
+
+	function buildSupportAttackTooltip(thisNode) {
+		var supportTips = "";
+		if(thisNode.supportFlag && !!thisNode.supportInfo){
+			var fleetId = "";
+			var attackType = thisNode.supportInfo.api_support_flag;
+			if(attackType === 1){
+				var airatack = thisNode.supportInfo.api_support_airatack;
+				fleetId = airatack.api_deck_id;
+			} else if([2,3].indexOf(attackType) > -1){
+				var hourai = thisNode.supportInfo.api_support_hourai;
+				fleetId = hourai.api_deck_id;
+				// other info such as damage could be added
+			}
+			supportTips = KC3Meta.term("BattleSupportTips").format(fleetId, KC3Meta.support(attackType));
+		}
+		return supportTips || KC3Meta.term("BattleSupportExped");
 	}
 
 	function buildAntiAirCutinTooltip(thisNode) {


### PR DESCRIPTION
Currently just show the kind of attack when support expedition triggered, like this:

| ICON |
| -------- |
|Support fleet 2 has arrived! |
|Fire attack support triggered! |

There're 3 types now: `Air/Fire/Torpedo`, able to be translated in `battle.json`.
