### PR TITLE
[dev-upgrade-encounters] Encounters record difficulty of event maps

### DIFF
--- a/src/library/modules/Database.js
+++ b/src/library/modules/Database.js
@@ -194,6 +194,15 @@ Uses Dexie.js third-party plugin on the assets directory
 							console.log("V7",t);
 						},
 						vr: 7,
+					},
+					{
+						ch: {
+							encounters: "&uniqid,world,map,diff,node,form,ke,count"
+						},
+						up: function(t){
+							console.log("V7.1",t);
+						},
+						vr: 7.1,
 					}
 				];
 				
@@ -324,20 +333,17 @@ Uses Dexie.js third-party plugin on the assets directory
 		},
 		
 		Enemy :function(data, callback){
-			try {
-				this.con.enemy.add(data);
-			} catch (e) {
-				console.log("Enemy data already exists:", data);
-			}
+			this.con.enemy.put(data).then(callback);
 		},
 		
 		Encounter :function(data, callback){
-			try {
-				this.con.encounters.add(data);
-			} catch (e) {
-				console.log("Enemy composition already exists:", data);
-			}
-			
+			var self = this;
+			this.con.encounters.get(data.uniqid, function(oldData){
+				if(!!oldData){
+					data.count = (oldData.count || 1) + 1;
+				}
+				self.con.encounters.put(data).then(callback);
+			});
 		},
 		
 		/* [GET] Retrive logs from Local DB

--- a/src/library/modules/Database.js
+++ b/src/library/modules/Database.js
@@ -197,12 +197,12 @@ Uses Dexie.js third-party plugin on the assets directory
 					},
 					{
 						ch: {
-							encounters: "&uniqid,world,map,diff,node,form,ke,count"
+							encounters: "&uniqid,world,map,diff,node,form,ke,count,name"
 						},
 						up: function(t){
-							console.log("V7.1",t);
+							console.log("V7.2",t);
 						},
-						vr: 7.1,
+						vr: 7.2,
 					}
 				];
 				
@@ -336,11 +336,16 @@ Uses Dexie.js third-party plugin on the assets directory
 			this.con.enemy.put(data).then(callback);
 		},
 		
-		Encounter :function(data, callback){
+		Encounter :function(data, isIncCount, callback){
 			var self = this;
 			this.con.encounters.get(data.uniqid, function(oldData){
 				if(!!oldData){
-					data.count = (oldData.count || 1) + 1;
+					if(!!isIncCount){
+						data.count = (oldData.count || 1) + 1;
+					}
+					if(!data.name && !!oldData.name){
+						data.name = oldData.name;
+					}
 				}
 				self.con.encounters.put(data).then(callback);
 			});

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -490,7 +490,8 @@ Used by SortieManager
 			};
 			ed.uniqid = [ed.world,ed.map,ed.diff,ed.node,ed.form,ed.ke]
 				.filter(function(v){return !!v;}).join("/");
-			KC3Database.Encounter(ed);
+			KC3Database.Encounter(ed, true);
+			this.enemyEncounter = ed;
 			
 			// Save enemy info
 			for(i = 0; i < 6; i++) {
@@ -836,6 +837,13 @@ Used by SortieManager
 					}
 					
 				}
+			}
+			
+			// Save enemy deck name for encounter
+			var name = resultData.api_enemy_info.api_deck_name;
+			if(KC3SortieManager.onSortie > 0 && !!this.enemyEncounter && !!name){
+				this.enemyEncounter.name = name;
+				KC3Database.Encounter(this.enemyEncounter, false);
 			}
 		} catch (e) {
 			console.error("Captured an exception ==>", e,"\n==> proceeds safely");

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -483,11 +483,13 @@ Used by SortieManager
 			var ed = {
 				world: KC3SortieManager.map_world,
 				map: KC3SortieManager.map_num,
+				diff: KC3SortieManager.map_difficulty,
 				node: this.id,
 				form: this.eformation,
 				ke: JSON.stringify(this.eships)
 			};
-			ed.uniqid = ed.world+"/"+ed.map+"/"+ed.node+"/"+ed.form+"/"+ed.ke;
+			ed.uniqid = [ed.world,ed.map,ed.diff,ed.node,ed.form,ed.ke]
+				.filter(function(v){return !!v;}).join("/");
 			KC3Database.Encounter(ed);
 			
 			// Save enemy info

--- a/src/pages/strategy/tabs/encounters/encounters.js
+++ b/src/pages/strategy/tabs/encounters/encounters.js
@@ -7,6 +7,7 @@
 		tabSelf: KC3StrategyTabs.encounters,
 		
 		list: [],
+		diffStrs: ["", "E", "N", "H"],
 		
 		/* INIT
 		Prepares all data needed
@@ -33,36 +34,48 @@
 				$.each(self.list, function(index, encounter){
 					if(encounter.world < 1) return true;
 					
+					var diffStr = self.diffStrs[encounter.diff || 0] || "";
 					// Check map box
-					if( $("#encounter-"+encounter.world+"-"+encounter.map).length === 0){
+					if( $("#encounter-"+encounter.world+"-"+encounter.map+diffStr).length === 0){
 						curBox = $(".tab_encounters .factory .encounter_map").clone();
-						curBox.attr("id", "encounter-"+encounter.world+"-"+encounter.map);
-						$(".encounter_world_head", curBox).text("World "+encounter.world+"-"+encounter.map);
+						curBox.attr("id", "encounter-"+encounter.world+"-"+encounter.map+diffStr);
+						$(".encounter_world_head", curBox).text("World "+encounter.world+"-"+encounter.map+diffStr);
 						curBox.appendTo(".encounter_list");
 					}
 					// Check node box
-					if( $("#encounter-"+encounter.world+"-"+encounter.map+" .node-"+encounter.node).length === 0){
+					var nodeLetter = KC3Meta.nodeLetter(encounter.world, encounter.map, encounter.node);
+					if( $("#encounter-"+encounter.world+"-"+encounter.map+diffStr+" .node-"+nodeLetter).length === 0){
 						curBox = $(".tab_encounters .factory .encounter_node").clone();
-						curBox.addClass("node-"+encounter.node);
-						$(".encounter_node_head", curBox).text("Node "+KC3Meta.nodeLetter(encounter.world, encounter.map, encounter.node));
-						curBox.appendTo("#encounter-"+encounter.world+"-"+encounter.map+" .encounter_world_body");
+						curBox.addClass("node-"+nodeLetter);
+						$(".encounter_node_head", curBox).text("Node "+nodeLetter);
+						curBox.appendTo("#encounter-"+encounter.world+"-"+encounter.map+diffStr+" .encounter_world_body");
 					}
 					// Clone record box
-					curBox = $(".tab_encounters .factory .encounter_record").clone();
-					curBox.appendTo("#encounter-"+encounter.world+"-"+encounter.map+" .node-"+encounter.node+" .encounter_node_body");
-					$(".encounter_formation img", curBox).attr("src", KC3Meta.formationIcon(encounter.form));
-					
-					shipList = JSON.parse(encounter.ke);
-					$.each(shipList, function(shipIndex, shipId){
-						if(shipId > -1){
-							shipBox = $(".tab_encounters .factory .encounter_ship").clone();
-							$(".encounter_icon img", shipBox).attr("src", KC3Meta.abyssIcon(shipId));
-							$(".encounter_icon img", shipBox).attr("alt", shipId);
-							$(".encounter_icon img", shipBox).click(shipClickFunc);
-							$(".encounter_id", shipBox).text(shipId);
-							shipBox.appendTo($(".encounter_ships", curBox));
-						}
-					});
+					var curNodeBody = $("#encounter-"+encounter.world+"-"+encounter.map+diffStr+" .node-"+nodeLetter+" .encounter_node_body");
+					var keSafe = encounter.ke.replace(/[\[\]\"\'\{\}]/g,"").replace(/[,:]/g,"_");
+					curBox = $(".formke-"+encounter.form+keSafe, curNodeBody);
+					if( curBox.length === 0 ){
+						curBox = $(".tab_encounters .factory .encounter_record").clone();
+						curBox.addClass("formke-"+encounter.form+keSafe);
+						curBox.data("count", encounter.count || 1);
+						curBox.appendTo(curNodeBody);
+						$(".encounter_formation img", curBox).attr("src", KC3Meta.formationIcon(encounter.form));
+						$(".encounter_formation", curBox).attr("title", curBox.data("count"));
+						shipList = JSON.parse(encounter.ke);
+						$.each(shipList, function(shipIndex, shipId){
+							if(shipId > 0){
+								shipBox = $(".tab_encounters .factory .encounter_ship").clone();
+								$(".encounter_icon img", shipBox).attr("src", KC3Meta.abyssIcon(shipId));
+								$(".encounter_icon img", shipBox).attr("alt", shipId);
+								$(".encounter_icon img", shipBox).click(shipClickFunc);
+								$(".encounter_id", shipBox).text(shipId);
+								shipBox.appendTo($(".encounter_ships", curBox));
+							}
+						});
+					} else {
+						curBox.data("count", (encounter.count || 1) + curBox.data("count") );
+						$(".encounter_formation", curBox).attr("title", curBox.data("count"));
+					}
 					
 				});
 				

--- a/src/pages/strategy/tabs/encounters/encounters.js
+++ b/src/pages/strategy/tabs/encounters/encounters.js
@@ -44,23 +44,28 @@
 					}
 					// Check node box
 					var nodeLetter = KC3Meta.nodeLetter(encounter.world, encounter.map, encounter.node);
-					if( $("#encounter-"+encounter.world+"-"+encounter.map+diffStr+" .node-"+nodeLetter).length === 0){
+					var nodeName = encounter.name || "";
+					curBox = $("#encounter-"+encounter.world+"-"+encounter.map+diffStr+" .node-"+nodeLetter);
+					if( curBox.length === 0){
 						curBox = $(".tab_encounters .factory .encounter_node").clone();
 						curBox.addClass("node-"+nodeLetter);
-						$(".encounter_node_head", curBox).text("Node "+nodeLetter);
+						$(".encounter_node_head", curBox).text("Node {0} {1}".format(nodeLetter, nodeName));
 						curBox.appendTo("#encounter-"+encounter.world+"-"+encounter.map+diffStr+" .encounter_world_body");
+					} else if(!!nodeName){
+						$(".encounter_node_head", curBox).text("Node {0} {1}".format(nodeLetter, nodeName));
 					}
-					// Clone record box
+					// Check formation and ships box
 					var curNodeBody = $("#encounter-"+encounter.world+"-"+encounter.map+diffStr+" .node-"+nodeLetter+" .encounter_node_body");
 					var keSafe = encounter.ke.replace(/[\[\]\"\'\{\}]/g,"").replace(/[,:]/g,"_");
 					curBox = $(".formke-"+encounter.form+keSafe, curNodeBody);
 					if( curBox.length === 0 ){
+						// Clone record box
 						curBox = $(".tab_encounters .factory .encounter_record").clone();
 						curBox.addClass("formke-"+encounter.form+keSafe);
 						curBox.data("count", encounter.count || 1);
+						curBox.data("nodeName", nodeName);
 						curBox.appendTo(curNodeBody);
 						$(".encounter_formation img", curBox).attr("src", KC3Meta.formationIcon(encounter.form));
-						$(".encounter_formation", curBox).attr("title", curBox.data("count"));
 						shipList = JSON.parse(encounter.ke);
 						$.each(shipList, function(shipIndex, shipId){
 							if(shipId > 0){
@@ -73,9 +78,13 @@
 							}
 						});
 					} else {
+						// Update count
 						curBox.data("count", (encounter.count || 1) + curBox.data("count") );
-						$(".encounter_formation", curBox).attr("title", curBox.data("count"));
+						if(!!nodeName && curBox.data("nodeName")!==nodeName){
+							curBox.data("nodeName", "{0}/{1}".format(curBox.data("nodeName"), nodeName) );
+						}
 					}
+					$(".encounter_formation", curBox).attr("title", "{0}x{1}".format(curBox.data("nodeName"), curBox.data("count")) );
 					
 				});
 				


### PR DESCRIPTION
Close #1314
Related with #1139 

Changes:

 * Upgrade encounters table schema of IndexedDB, improve adding functions
 * Record difficulty for event nodes, name for all nodes. Build proper ID to compatible with normal maps
 * Show map box `World 3x-m[E/N/H]` at Strategy Room encounters page
 * Fix duplicated nodes of encounters page for #1314 
 * Add a simple counter to each pattern
 * Add enemy name (from `battleresult` API) to each node and formation

Known issue: existed data of encounters will still be shown without difficulty (in other map box), as there's no way to know which difficulty they are.
