### PR TITLE
Local Storage Sortie Data Overquota

### DIFF
--- a/src/library/managers/ShipManager.js
+++ b/src/library/managers/ShipManager.js
@@ -71,6 +71,22 @@ Saves and loads list to and from localStorage
 						cShip[key] = tempData[key];
 				});
 				
+				// enforce freshify sortie0 placeholder
+				(function(){
+					var szs = 'sortie0';
+					var ls  = cShip.lastSortie;
+					var cnt = 0;
+					var szi;
+					for(szi=0;szi<ls.length;szi++)
+						cnt += ls[szi]==szs;
+					while(cnt) {
+						for(szi=0;ls[szi]!=szs;szi++){}
+						ls.splice(szi,1);
+						cnt--;
+					}
+					ls.push(szs);
+				}).call(this);
+			} else {
 				// check ship master in lock_prep before lock request it
 				if(ConfigManager.lock_prep[0] == cShip.rosterId) {
 					ConfigManager.lock_prep.shift();


### PR DESCRIPTION
this is only workaround to force every `sortie0` data to not appear anywhere around the sortie0 itself,
**you need to supply/repair the respective ship to remove the ghost entries**

- Attempt #1356

to test the data there are some steps that need to check:

1. find any ship with long entry of `lastSortie` data<br>(it's not a must for a global maximum length one, it can be more than one)
2. output the current state of `lastSortie` of the respective ship
3. perform supply and/or repair
4. output the last state of `lastSortie` of the respective ship
