### PR TITLE
[dev-sroom-update] Improve update mechanism of Strategy Room tab

### DIFF
--- a/src/library/objects/StrategyTab.js
+++ b/src/library/objects/StrategyTab.js
@@ -56,7 +56,8 @@
 	 * Terms of callback function definitions:
 	 *   "init": Invoked for the first time tab initialzing, only once (for once browser refresh).
 	 *   "reload": Invoked when data loading required, optional once, may many times on demand.
-	 *   "execute": Invoked for rendering HTML content for each time tab is shown.
+	 *   "execute": Invoked for rendering HTML content from scratch when each time tab shown (or switched from other tabs).
+	 *   "update": Invoked when arguments or states inside tab changed and partial elements possibly updated.
 	 */
 	KC3StrategyTab.prototype.apply = function(forceReload){
 		this.error = false;

--- a/src/pages/strategy/strategy.css
+++ b/src/pages/strategy/strategy.css
@@ -201,3 +201,32 @@ body {
 .page_body {
 	margin:0px 0px 20px 0px;
 }
+
+.float_toolbar {
+	position:fixed;
+	bottom:2em;
+	right:0px;
+	text-decoration:none;
+	color:#000;
+	font-size:12px;
+	font-weight:bold;
+	display:none;
+}
+.float_toolbar .back_to_top {
+	background-color:#def;
+	padding:8px 10px 8px 10px;
+	margin:0px 0px 4px 0px;
+	border-radius:10px 0px 0px 10px;
+}
+.float_toolbar .back_to_top:hover {
+	background-color:#ffc;
+}
+.float_toolbar .reload {
+	background-color:#def;
+	padding:8px 10px 8px 10px;
+	margin:0px 0px 4px 0px;
+	border-radius:10px 0px 0px 10px;
+}
+.float_toolbar .reload:hover {
+	background-color:#ffc;
+}

--- a/src/pages/strategy/strategy.html
+++ b/src/pages/strategy/strategy.html
@@ -104,6 +104,10 @@
 				</div>
 				<div class="clear"></div>
 			</div>
+			<div class="float_toolbar">
+				<div class="back_to_top hover">Back to Top</div>
+				<div class="reload hover">Reload Tab</div>
+			</div>
 		</div>
 
 		<script type="text/javascript" src="../../assets/js/global.js"></script>

--- a/src/pages/strategy/strategy.js
+++ b/src/pages/strategy/strategy.js
@@ -2,6 +2,7 @@
 	"use strict";
 	_gaq.push(['_trackPageview']);
 	
+	var HASH_PARAM_DELIM = "-";
 	var activeTab;
 	
 	Object.defineProperties(window,{
@@ -71,7 +72,7 @@
 		window.addEventListener('popstate', KC3StrategyTabs.onpopstate);
 		
 		// If there is a hash tag on URL, set it as initial selected
-		KC3StrategyTabs.pageParams = window.location.hash.substring(1).split("-");
+		KC3StrategyTabs.pageParams = window.location.hash.substring(1).split(HASH_PARAM_DELIM);
 		if(KC3StrategyTabs.pageParams[0] !== ""){
 			$("#menu .submenu ul.menulist li").removeClass("active");
 			$("#menu .submenu ul.menulist li[data-id="+KC3StrategyTabs.pageParams[0]+"]").addClass("active");
@@ -93,14 +94,14 @@
 				params = [ params ];
 			}
 			// encodeURIComponent may be needed
-			newHash += "-"+params.join("-");
+			newHash += HASH_PARAM_DELIM + params.join(HASH_PARAM_DELIM);
 		}
 		window.location.hash = newHash;
 	};
 
 	KC3StrategyTabs.reloadTab = function(tab, reloadData) {
 		var tabElement = typeof tab;
-		KC3StrategyTabs.pageParams = (tabElement=="string" ? tab : window.location.hash).substring(1).split("-");
+		KC3StrategyTabs.pageParams = (tabElement=="string" ? tab : window.location.hash).substring(1).split(HASH_PARAM_DELIM);
 		if(tabElement != "object") {
 			var tabId = KC3StrategyTabs.pageParams[0] || "profile";
 			tab = $("#menu .submenu ul.menulist li[data-id="+tabId+"]");
@@ -135,8 +136,17 @@
 
 	KC3StrategyTabs.onpopstate = function(event){
 		var newHash = window.location.hash.substring(1);
-		var oldHash = KC3StrategyTabs.pageParams.join("-");
+		var oldHash = KC3StrategyTabs.pageParams.join(HASH_PARAM_DELIM);
 		if(!!newHash && !KC3StrategyTabs.loading && newHash !== oldHash){
+			var newParams = newHash.split(HASH_PARAM_DELIM);
+			if(newParams[0] === KC3StrategyTabs.pageParams[0] && !!window.activeSelf.update){
+				// Pass new hash parameters to callback, keep old params in KC3StrategyTabs
+				if(!!window.activeSelf.update(newParams)){
+					// Update `KC3StrategyTabs.pageParams` if `reloadTab` skipped
+					KC3StrategyTabs.pageParams = window.location.hash.substring(1).split(HASH_PARAM_DELIM);
+					return;
+				}
+			}
 			console.debug("Auto reloading from [", oldHash, "] to [", newHash, "]");
 			KC3StrategyTabs.reloadTab();
 		}

--- a/src/pages/strategy/strategy.js
+++ b/src/pages/strategy/strategy.js
@@ -64,6 +64,21 @@
 			}
 		});
 		
+		// Add back to top and reload float button
+		$(window).scroll(function(){
+			if($(this).scrollTop() > 90){
+				$('.float_toolbar').fadeIn();
+			} else {
+				$('.float_toolbar').fadeOut();
+			}
+		});
+		$(".float_toolbar .back_to_top").on("click", function(){
+			$("html, body").animate({scrollTop: 0}, 300);
+		});
+		$(".float_toolbar .reload").on("click", function(){
+			$(".logo").click();
+		});
+		
 		$("#error").on("click", function(){
 			$(this).empty().hide();
 		});

--- a/src/pages/strategy/tabs/mstgear/mstgear.js
+++ b/src/pages/strategy/tabs/mstgear/mstgear.js
@@ -10,14 +10,21 @@
 		server_ip: "",
 		
 		/* INIT
-		Prepares all data needed
+		Prepares static data needed
 		---------------------------------*/
 		init :function(){
 			var MyServer = (new KC3Server()).setNum( PlayerManager.hq.server );
 			this.server_ip = MyServer.ip;
 		},
 		
-		/* EXECUTE
+		/* RELOAD
+		Prepares latest in game data
+		---------------------------------*/
+		reload :function(){
+			// None for gear library
+		},
+		
+			/* EXECUTE
 		Places data onto the interface
 		---------------------------------*/
 		execute :function(){
@@ -57,6 +64,18 @@
 			}, 200);
 		},
 		
+		/* UPDATE
+		Partially update elements of the interface without clearing all contents first
+		Be careful! Do NOT only update new data, but also handle the old states (do cleanup)
+		---------------------------------*/
+		update :function(pageParams){
+			if(!!pageParams[1]){
+				this.showGear(pageParams[1]);
+			}else{
+				this.showGear();
+			}
+			return true;
+		},
 		
 		showGear :function(gear_id){
 			gear_id = Number(gear_id||"124");

--- a/src/pages/strategy/tabs/mstship/mstship.js
+++ b/src/pages/strategy/tabs/mstship/mstship.js
@@ -330,7 +330,7 @@
 
 					// in case when the data isn't available,
 					// slots should still be getting cleaned up
-					$(".slotitem", this).empty()
+					$(".slotitem", this).empty();
 					$(".sloticon img", this).attr("src", "");
 					$(".sloticon img", this).hide();
 

--- a/src/pages/strategy/tabs/mstship/mstship.js
+++ b/src/pages/strategy/tabs/mstship/mstship.js
@@ -98,6 +98,7 @@
 				var vnum = Number($(this).data("vnum"));
 				var voiceFile = KC3Meta.getFilenameByVoiceLine(self.currentShipId, vnum);
 				//console.debug("VOICE META: voiceFile", voiceFile);
+				$(".tab_mstship .shipInfo .subtitles").show();
 				if(!voiceFile || voiceFile==100000){
 					$(".tab_mstship .shipInfo .subtitles").html("This voice is currently disabled to be replayable in KC3Kai");
 					return true;
@@ -256,14 +257,14 @@
 				.attr("menu", "false")
 				.appendTo(".tab_mstship .shipInfo .cgswf");
 			$(".tab_mstship .shipInfo .salty-zone").text(KC3Meta.term(denyTerm()));
-			$(".tab_mstship .shipInfo .hourlies").html("");
+			$(".tab_mstship .shipInfo .hourlies").empty();
 			
 			saltClassUpdate();
 			
 			var statBox;
 			if(ship_id<=500){
 				// Ship-only, non abyssal
-				$(".tab_mstship .shipInfo .stats").html("");
+				$(".tab_mstship .shipInfo .stats").empty();
 				$(".tab_mstship .shipInfo .intro").html( shipData.api_getmes );
 				$(".tab_mstship .shipInfo .cgswf").css("width", "218px")
 					.css("height", "300px");
@@ -329,8 +330,8 @@
 
 					// in case when the data isn't available,
 					// slots should still be getting cleaned up
-					$(".slotitem", this).text( "" );
-					$(".sloticon img", this).attr("src","");
+					$(".slotitem", this).empty()
+					$(".sloticon img", this).attr("src", "");
 					$(".sloticon img", this).hide();
 
 					if (stockEquipments) {
@@ -398,11 +399,11 @@
 				$(".tab_mstship .shipInfo .consume_fuel .rsc_value").text( shipData.api_fuel_max );
 				$(".tab_mstship .shipInfo .consume_ammo .rsc_value").text( shipData.api_bull_max );
 				
-				$(".tab_mstship .shipInfo .subtitles").html("");
+				$(".tab_mstship .shipInfo .subtitles").empty();
 				
 				// VOICE LINES
 				$(".tab_mstship .shipInfo .voices").show();
-				$(".tab_mstship .shipInfo .voices").html("");
+				$(".tab_mstship .shipInfo .voices").empty();
 
 				var allVoiceNums = KC3Translation.getShipVoiceNums(shipData.api_id,false,false);
 				$.each(allVoiceNums, function(ignored, vnum){
@@ -417,7 +418,7 @@
 				
 				// HOURLIES
 				$(".tab_mstship .shipInfo .hourlies").show();
-				$(".tab_mstship .shipInfo .hourlies").html("");
+				$(".tab_mstship .shipInfo .hourlies").empty();
 				
 				if (KC3Translation.shipHasHourlyVoices(shipData.api_id)){
 					$.each(this.hourlies, function(vnum, vname){
@@ -453,7 +454,7 @@
 				$(".tab_mstship .shipInfo .equipments").hide();
 				$(".tab_mstship .shipInfo .json").text(JSON.stringify(shipData))
 					.css("width", "100%").show();
-				$(".tab_mstship .shipInfo .subtitles").html("").hide();
+				$(".tab_mstship .shipInfo .subtitles").empty().hide();
 				$(".tab_mstship .shipInfo .cgswf").css("width", "100%")
 					.css("height", "400px");
 				$(".tab_mstship .shipInfo .cgswf embed").css("width", "468px")
@@ -464,7 +465,7 @@
 					console.debug("enemyInfo", enemyInfo);
 					if(enemyInfo){
 						// ENEMY STATS
-						$(".tab_mstship .shipInfo .stats").html("");
+						$(".tab_mstship .shipInfo .stats").empty();
 						$.each([
 							["hp", "taik"],
 							["fp", "houg"],
@@ -503,9 +504,10 @@
 								$(".sloticon img", this).off("click").click(function(){
 									KC3StrategyTabs.gotoTab("mstgear", $(this).attr("alt"));
 								});
+								$(".sloticon img", this).show();
 								$(".sloticon", this).addClass("hover");
 							} else {
-								$(".slotitem", this).text( "" );
+								$(".slotitem", this).empty();
 								$(".sloticon img", this).hide();
 								$(".sloticon img", this).off("click");
 								$(".sloticon", this).removeClass("hover");

--- a/src/pages/strategy/tabs/mstship/mstship.js
+++ b/src/pages/strategy/tabs/mstship/mstship.js
@@ -38,7 +38,7 @@
 		server_ip: "",
 		
 		/* INIT
-		Prepares all data needed
+		Prepares static data needed
 		---------------------------------*/
 		init :function(){
 			KC3Meta.loadQuotes();
@@ -46,26 +46,19 @@
 			this.server_ip = MyServer.ip;
 		},
 		
+		/* RELOAD
+		Prepares latest in game data
+		---------------------------------*/
+		reload :function(){
+			// None for ship library
+		},
+		
 		/* EXECUTE
 		Places data onto the interface
 		---------------------------------*/
 		execute :function(){
 			$(".tab_mstship .runtime_id").text(chrome.runtime.id);
-			
 			var self = this;
-			
-			/*
-			// Add ship type filters
-			$.each(KC3Meta._stype, function(index, stype_code){
-				if(index === 0) return true;
-				
-				$("<div />")
-					.addClass("stype")
-					.text(stype_code)
-					.data("id", index)
-					.appendTo(".tab_mstship .filters");
-			});
-			$("<div />").addClass("clear").appendTo(".tab_mstship .filters");*/
 			
 			// List all ships
 			var shipBox;
@@ -96,7 +89,6 @@
 				var sid = $(this).data("id");
 				if( sid != self.currentShipId ){
 					KC3StrategyTabs.gotoTab(null, sid);
-					//self.showShip( sid );
 				}
 			});
 			
@@ -203,6 +195,21 @@
 			}, 200);
 		},
 		
+		/* UPDATE
+		Partially update elements of the interface without clearing all contents first
+		Be careful! Do NOT only update new data, but also handle the old states (do cleanup)
+		---------------------------------*/
+		update :function(pageParams){
+			// KC3StrategyTabs.pageParams has been keeping the old values for states tracking
+			if(!!pageParams && !!pageParams[1]){
+				this.showShip(pageParams[1]);
+			}else{
+				this.showShip();
+			}
+			// Tell tab manager: Have handled the updating, donot re-execute the rendering
+			return true;
+		},
+		
 		showShip :function(ship_id){
 			ship_id = Number(ship_id||"405");
 			var
@@ -258,6 +265,10 @@
 				// Ship-only, non abyssal
 				$(".tab_mstship .shipInfo .stats").html("");
 				$(".tab_mstship .shipInfo .intro").html( shipData.api_getmes );
+				$(".tab_mstship .shipInfo .cgswf").css("width", "218px")
+					.css("height", "300px");
+				$(".tab_mstship .shipInfo .cgswf embed").css("width", "218px")
+					.css("height", "300px");
 				
 				// STATS
 				var statFromDb = WhoCallsTheFleetDb.getShipStat(ship_id);
@@ -330,13 +341,14 @@
 							$(".sloticon img", this)
 								.attr("src","../../../../assets/img/items/"+equipment.api_type[3]+".png");
 							$(".sloticon img", this).attr("alt", equipId);
-							$(".sloticon img", this).click(function(){
+							$(".sloticon img", this).off("click").click(function(){
 								KC3StrategyTabs.gotoTab("mstgear", $(this).attr("alt"));
 							});
 							$(".sloticon img", this).show();
 							$(".sloticon", this).addClass("hover");
 						} else {
 							$(".sloticon img", this).hide();
+							$(".sloticon img", this).off("click");
 							$(".sloticon", this).removeClass("hover");
 						}
 					}
@@ -488,13 +500,14 @@
 								$(".sloticon img", this)
 									.attr("src","../../../../assets/img/items/"+equipment.api_type[3]+".png");
 								$(".sloticon img", this).attr("alt", equipId);
-								$(".sloticon img", this).click(function(){
+								$(".sloticon img", this).off("click").click(function(){
 									KC3StrategyTabs.gotoTab("mstgear", $(this).attr("alt"));
 								});
 								$(".sloticon", this).addClass("hover");
 							} else {
 								$(".slotitem", this).text( "" );
 								$(".sloticon img", this).hide();
+								$(".sloticon img", this).off("click");
 								$(".sloticon", this).removeClass("hover");
 							}
 						});


### PR DESCRIPTION
Close #1381 

The re-executed rendering and hash parameters handling problems has been realized when I tried to improve ship list page. It's not only the thingy about 'Ship Library', but an important mechanism all tab pages should rely on.

This time add a new term `update` to tab definition first, allowing each tab itself to decide if partially updating content required and how updating performed.

Currently `mstship`, `mstgear`, `quotes` supported,
More possible tabs: `ships`, `gears`, `fleet`, `aircraft`, `maps/event`

ps. performance of quotes tab is better by moving en/jp quotes loading into `reload` term.