### PR TITLE
Show resupply costs

### DIFF
--- a/src/library/objects/Fleet.js
+++ b/src/library/objects/Fleet.js
@@ -368,6 +368,23 @@ Contains summary information about a fleet and its 6 ships
 		return {fuel: totalFuel, ammo: totalAmmo};
 	};
 
+	KC3Fleet.prototype.calcResupplyCost = function() {
+		var self = this;
+		var totalFuel = 0;
+		var totalAmmo = 0;
+		var totalBauxite = 0;
+		$.each( this.ships, function(i, shipId) {
+			if (shipId > -1) {
+				var shipObj = self.ship(i);
+				var cost = shipObj.calcResupplyCost(-1, -1, true);
+				totalFuel += cost.fuel;
+				totalAmmo += cost.ammo;
+				totalBauxite += cost.bauxite;
+			}
+		});
+		return {fuel: totalFuel, ammo: totalAmmo, bauxite:totalBauxite};
+	};
+
 	/*--------------------------------------------------------*/
 	/*-----------------[ STATUS INDICATORS ]------------------*/
 	/*--------------------------------------------------------*/

--- a/src/library/objects/Gear.js
+++ b/src/library/objects/Gear.js
@@ -127,4 +127,12 @@ KC3改 Equipment Object
 			+(2.0 * Number(this.master().api_baku) );
 	};
 	
+	KC3Gear.prototype.bauxiteCost = function(slotCurrent, slotMaxeq){
+		if(this.itemId===0){ return 0; }
+		if( [6,7,8,11,45].indexOf( this.master().api_type[2] ) > -1){
+			return 5 * (slotMaxeq - slotCurrent);
+		}
+		return 0;
+	};
+
 })();

--- a/src/library/objects/Ship.js
+++ b/src/library/objects/Ship.js
@@ -444,19 +444,19 @@ KC3改 Ship Object
 		var fullFuel = master.api_fuel_max;
 		var fullAmmo = master.api_bull_max;
 
-		// http://puu.sh/mtMFg.png
-		if (this.level >= 100) {
-			fullFuel = Math.floor(fullFuel * 0.85);
-			fullAmmo = Math.floor(fullAmmo * 0.85);
-		}
-
 		var mulRounded = function (a, percent) {
 			return Math.floor( a * percent );
 		};
-		var result = {
-			fuel: fuelPercent < 0 ? fullFuel - this.fuel : mulRounded( fullFuel, fuelPercent ),
-			ammo: ammoPercent < 0 ? fullAmmo - this.ammo : mulRounded( fullAmmo, ammoPercent )
+		var marriageConserve = function (v) {
+			return self.level >= 100 ? Math.floor(0.85 * v) : v;
 		};
+		var result = {
+			fuel: fuelPercent < 0 ? fullFuel - this.fuel : mulRounded(fullFuel, fuelPercent),
+			ammo: ammoPercent < 0 ? fullAmmo - this.ammo : mulRounded(fullAmmo, ammoPercent)
+		};
+		// After testing, 85% is applied to supply cost, not max value
+		result.fuel = marriageConserve(result.fuel);
+		result.ammo = marriageConserve(result.ammo);
 		if(!!bauxiteNeeded){
 			var equipBauxiteCost = function() {
 				return self.equipment(0).bauxiteCost(self.slots[0], master.api_maxeq[0])
@@ -465,9 +465,9 @@ KC3改 Ship Object
 					+ self.equipment(3).bauxiteCost(self.slots[3], master.api_maxeq[3]);
 			};
 			result.bauxite = equipBauxiteCost();
-			// Bauxite cost to replace planes shot down does not change.
+			// Bauxite cost to replace planes shot down does not change by marriage.
 			// via http://kancolle.wikia.com/wiki/Marriage
-			//if (this.level >= 100) { result.bauxite = Math.floor(0.85 * result.bauxite); }
+			//result.bauxite = marriageConserve(result.bauxite);
 		}
 		return result;
 	};

--- a/src/library/objects/Ship.js
+++ b/src/library/objects/Ship.js
@@ -463,12 +463,11 @@ KC3改 Ship Object
 					+ self.equipment(1).bauxiteCost(self.slots[1], master.api_maxeq[1])
 					+ self.equipment(2).bauxiteCost(self.slots[2], master.api_maxeq[2])
 					+ self.equipment(3).bauxiteCost(self.slots[3], master.api_maxeq[3]);
-			}
+			};
 			result.bauxite = equipBauxiteCost();
-			// TODO 85% bauxite for married ship needs to be verified
-			if (this.level >= 100) {
-				result.bauxite = Math.floor(0.85 * result.bauxite);
-			}
+			// Bauxite cost to replace planes shot down does not change.
+			// via http://kancolle.wikia.com/wiki/Marriage
+			//if (this.level >= 100) { result.bauxite = Math.floor(0.85 * result.bauxite); }
 		}
 		return result;
 	};

--- a/src/pages/devtools/themes/natsuiro/js/Shipbox.js
+++ b/src/pages/devtools/themes/natsuiro/js/Shipbox.js
@@ -96,7 +96,12 @@ KC3改 Ship Box for Natsuiro theme
 		$(".ship_exp", this.element).css("width", (120 * this.expPercent)+"px");		
 		$(".ship_fuel", this.element).css("width", (120 * Math.min(this.fuelPercent, 1))+"px");
 		$(".ship_ammo", this.element).css("width", (120 * Math.min(this.ammoPercent, 1))+"px");
-		$(".ship_bars", this.element).attr("title", KC3Meta.term("PanelCombinedShipBarsHint").format(this.shipData.exp[1], Math.ceil(this.fuelPercent*100), Math.ceil(this.ammoPercent*100)) );
+		var resupplyCost = this.shipData.calcResupplyCost(-1, -1, true);
+		$(".ship_bars", this.element).attr("title",
+			KC3Meta.term("PanelCombinedShipBarsHint")
+			.format(this.shipData.exp[1], Math.ceil(this.fuelPercent*100), Math.ceil(this.ammoPercent*100))
+			+ "\n" + KC3Meta.term("PanelResupplyCosts").format(resupplyCost.fuel, resupplyCost.ammo, resupplyCost.bauxite)
+		);
 		
 		if(!this.showCombinedFleetBars){
 			$(".ship_bars", this.element).css("opacity", "0");
@@ -131,6 +136,16 @@ KC3改 Ship Box for Natsuiro theme
 		$(".ship_fuel .ship_supply_bar", this.element).css("width", (38 * Math.min(this.fuelPercent, 1))+"px");
 		$(".ship_ammo .ship_supply_bar", this.element).css("width", (38 * Math.min(this.ammoPercent, 1))+"px");
 		
+		if(this.fuelPercent<1 || this.ammoPercent<1){
+			var resupplyCost = this.shipData.calcResupplyCost(-1, -1, true);
+			$(".ship_supply", this.element).attr("title",
+				KC3Meta.term("PanelResupplyCosts")
+				.format(resupplyCost.fuel, resupplyCost.ammo, resupplyCost.bauxite)
+			);
+		} else {
+			$(".ship_supply", this.element).attr("title", "");
+		}
+
 		this.showEquipment(0);
 		this.showEquipment(1);
 		this.showEquipment(2);

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -1072,7 +1072,6 @@
 					$(".module.status .status_supply .status_text").text( KC3Meta.term("PanelSupplied") );
 					$(".module.status .status_supply img").attr("src", "../../../../assets/img/ui/check.png");
 					$(".module.status .status_supply .status_text").addClass("good");
-					$(".module.status .status_supply").attr("title", "");
 				}else{
 					$(".module.status .status_supply .status_text").text(KC3Meta.term(
 						FleetSummary.badState[1] ? "PanelEmptySupply" :
@@ -1080,13 +1079,13 @@
 						));
 					$(".module.status .status_supply img").attr("src", "../../../../assets/img/ui/sunk.png");
 					$(".module.status .status_supply .status_text").addClass("bad");
-					$(".module.status .status_supply").attr("title",
-						KC3Meta.term("PanelResupplyCosts").format(
-							FleetSummary.supplyCost.fuel, FleetSummary.supplyCost.ammo, FleetSummary.supplyCost.bauxite
-						)
-					);
 				}
-				
+				$(".module.status .status_supply").attr("title",
+					FleetSummary.supplied ? "": KC3Meta.term("PanelResupplyCosts").format(
+						FleetSummary.supplyCost.fuel, FleetSummary.supplyCost.ammo, FleetSummary.supplyCost.bauxite
+					)
+				);
+
 				// STATUS: MORALE
 				if( FleetSummary.lowestMorale > 54 ){
 					$(".module.status .status_morale .status_text").text( KC3Meta.term("PanelGreatMorale") );

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -965,6 +965,7 @@
 					hasTaiha: MainFleet.hasTaiha() || EscortFleet.hasTaiha(),
 					taihaIndexes: MainFleet.getTaihas().concat( EscortFleet.getTaihas() ),
 					supplied: MainFleet.isSupplied() && EscortFleet.isSupplied(),
+					supplyCost: MainFleet.calcResupplyCost(),
 					badState: [
 						MainFleet.needsSupply(false)|| EscortFleet.needsSupply(false),
 						MainFleet.needsSupply(true) || EscortFleet.needsSupply(true) ,
@@ -976,7 +977,10 @@
 						? MainFleet.lowestMorale() : EscortFleet.lowestMorale(),
 					supportPower: 0
 				};
-			
+				var escortSupplyCost = EscortFleet.calcResupplyCost();
+				FleetSummary.supplyCost.fuel += escortSupplyCost.fuel;
+				FleetSummary.supplyCost.ammo += escortSupplyCost.ammo;
+				FleetSummary.supplyCost.bauxite += escortSupplyCost.bauxite;
 			
 			// SINGLE
 			}else{
@@ -1015,6 +1019,7 @@
 					hasTaiha: CurrentFleet.hasTaiha(),
 					taihaIndexes: CurrentFleet.getTaihas(),
 					supplied: CurrentFleet.isSupplied(),
+					supplyCost: CurrentFleet.calcResupplyCost(),
 					badState: [
 						CurrentFleet.needsSupply(false) ||
 						(
@@ -1067,6 +1072,7 @@
 					$(".module.status .status_supply .status_text").text( KC3Meta.term("PanelSupplied") );
 					$(".module.status .status_supply img").attr("src", "../../../../assets/img/ui/check.png");
 					$(".module.status .status_supply .status_text").addClass("good");
+					$(".module.status .status_supply").attr("title", "");
 				}else{
 					$(".module.status .status_supply .status_text").text(KC3Meta.term(
 						FleetSummary.badState[1] ? "PanelEmptySupply" :
@@ -1074,6 +1080,11 @@
 						));
 					$(".module.status .status_supply img").attr("src", "../../../../assets/img/ui/sunk.png");
 					$(".module.status .status_supply .status_text").addClass("bad");
+					$(".module.status .status_supply").attr("title",
+						KC3Meta.term("PanelResupplyCosts").format(
+							FleetSummary.supplyCost.fuel, FleetSummary.supplyCost.ammo, FleetSummary.supplyCost.bauxite
+						)
+					);
 				}
 				
 				// STATUS: MORALE

--- a/src/pages/devtools/themes/plain/js/Shipbox.js
+++ b/src/pages/devtools/themes/plain/js/Shipbox.js
@@ -59,7 +59,12 @@ KC3改 Ship Box for Natsuiro theme
 		$(".ship_exp", this.element).css("width", (120 * this.expPercent)+"px");		
 		$(".ship_fuel", this.element).css("width", (120 * Math.min(this.fuelPercent, 1))+"px");
 		$(".ship_ammo", this.element).css("width", (120 * Math.min(this.ammoPercent, 1))+"px");
-		$(".ship_bars", this.element).attr("title", KC3Meta.term("PanelCombinedShipBarsHint").format(this.shipData.exp[1], Math.ceil(this.fuelPercent*100), Math.ceil(this.ammoPercent*100)) );
+		var resupplyCost = this.shipData.calcResupplyCost(-1, -1, true);
+		$(".ship_bars", this.element).attr("title",
+			KC3Meta.term("PanelCombinedShipBarsHint")
+			.format(this.shipData.exp[1], Math.ceil(this.fuelPercent*100), Math.ceil(this.ammoPercent*100))
+			+ "\n" + KC3Meta.term("PanelResupplyCosts").format(resupplyCost.fuel, resupplyCost.ammo, resupplyCost.bauxite)
+		);
 		
 		return this.element;
 	};

--- a/src/pages/devtools/themes/plain/plain.js
+++ b/src/pages/devtools/themes/plain/plain.js
@@ -824,6 +824,7 @@
 					hasTaiha: MainFleet.hasTaiha() || EscortFleet.hasTaiha(),
 					taihaIndexes: MainFleet.getTaihas().concat( EscortFleet.getTaihas() ),
 					supplied: MainFleet.isSupplied() && EscortFleet.isSupplied(),
+					supplyCost: MainFleet.calcResupplyCost(),
 					badState: [
 						MainFleet.needsSupply(false)|| EscortFleet.needsSupply(false),
 						MainFleet.needsSupply(true) || EscortFleet.needsSupply(true) ,
@@ -835,7 +836,10 @@
 						? MainFleet.lowestMorale() : EscortFleet.lowestMorale(),
 					supportPower: 0
 				};
-				
+				var escortSupplyCost = EscortFleet.calcResupplyCost();
+				FleetSummary.supplyCost.fuel += escortSupplyCost.fuel;
+				FleetSummary.supplyCost.ammo += escortSupplyCost.ammo;
+				FleetSummary.supplyCost.bauxite += escortSupplyCost.bauxite;
 				
 			// SINGLE
 			}else{
@@ -868,6 +872,7 @@
 					hasTaiha: CurrentFleet.hasTaiha(),
 					taihaIndexes: CurrentFleet.getTaihas(),
 					supplied: CurrentFleet.isSupplied(),
+					supplyCost: CurrentFleet.calcResupplyCost(),
 					badState: [
 						CurrentFleet.needsSupply(false) ||
 						(!(KC3SortieManager.onSortie && KC3SortieManager.fleetSent == selectedFleet)
@@ -924,6 +929,11 @@
 					$(".module.status .status_supply img").attr("src", "../../../../assets/img/ui/sunk.png");
 					$(".module.status .status_supply .status_text").addClass("bad");
 				}
+				$(".module.status .status_supply").attr("title",
+					FleetSummary.supplied ? "": KC3Meta.term("PanelResupplyCosts").format(
+						FleetSummary.supplyCost.fuel, FleetSummary.supplyCost.ammo, FleetSummary.supplyCost.bauxite
+					)
+				);
 				
 				// STATUS: MORALE
 				if( FleetSummary.lowestMorale > 54 ){


### PR DESCRIPTION
Partially satisfy #1392

Just add tooltips to panel for selected fleet and every ships to show resupply cost (including bauxite).

Indeed supply consuming result shown at Activity panel not impl yet.
