### PR TITLE
Tracking quests with shared counter

### DIFF
--- a/src/library/managers/QuestManager.js
+++ b/src/library/managers/QuestManager.js
@@ -17,6 +17,8 @@ Uses KC3Quest objects to play around with
 		timeToResetWeeklyQuests: -1,
 		timeToResetMonthlyQuests: -1,
 		
+		sharedCounterQuests: [ [218, 212] ],
+		
 		// Internal constants for time period quests
 		_dailyIds: [201, 216, 210, 211, 218, 212, 226, 230, 303, 304, 402, 403, 503, 504, 605, 606, 607, 608, 609, 619, 702],
 		_weeklyIds: [214, 220, 213, 221, 228, 229, 241, 242, 243, 261, 302, 404, 410, 411, 613, 703],

--- a/src/library/objects/Quest.js
+++ b/src/library/objects/Quest.js
@@ -100,17 +100,28 @@ Quest Type:
 	/* INCREMENT
 	Add one to tracking progress
 	------------------------------------------*/
-	KC3Quest.prototype.increment = function(reqNum, amount){
-		if(this.tracking && this.status==2){    //2 = On progress
+	KC3Quest.prototype.increment = function(reqNum, amount, noLoop){
+		var self = this;
+		if(this.tracking && (this.status==2 || !!noLoop)){    //2 = On progress
 			if(typeof reqNum == "undefined"){ reqNum=0; }
 			if(typeof amount == "undefined"){ amount=1; }
-			if (this.tracking[reqNum][0] + amount <= this.tracking[reqNum][1]) {
+			var maxValue = (!!noLoop && this.status!=2) ? this.tracking[reqNum][1] - 1 : this.tracking[reqNum][1];
+			if (this.tracking[reqNum][0] + amount <= maxValue) {
 				this.tracking[reqNum][0] += amount;
 			}
 			KC3QuestManager.save();
 		}
+		if(!noLoop && Array.isArray(KC3QuestManager.sharedCounterQuests)){
+			KC3QuestManager.sharedCounterQuests.forEach(function(idList){
+				for(var idx in idList){
+					if(self.id !== idList[idx]){
+						KC3QuestManager.get(idList[idx]).increment(undefined, undefined, true);
+					}
+				}
+			});
+		}
 	};
-
+	
 	/* ISCOMPLETE
 	Return true iff all of the counters are complete
 	------------------------------------------*/


### PR DESCRIPTION
Try to handle quests which sharing single counter, esp those quests are able to be activated at same time. (which cause on 1 condition full-filled, progress +2 for all shared quests)

Currently just added Bd6 and Bd5 (`[218, 212]`) pair, more configs are expected.
iirc some 'submarine sunk' quests also sharing counter.
