### PR TITLE
Highlight ships that are close to remodel or can be remodelled

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -664,5 +664,24 @@
 				"options" : { "label" : "%" }
 			}
 		]
+	},
+	{
+		"section":"Strategy Room",
+		"help":"",
+		"contents":[
+			{
+				"id" : "sr_lvl_difference",
+				"name" : "SettingsLevellingDifference",
+				"type" : "small_text",
+				"bound" : {
+					"min" :  0,
+					"max" : 15,
+					"type": "Number"
+				},
+				"options" : {
+					"label" : "lvl"
+				}
+			}
+		]
 	}
 ]

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -147,7 +147,9 @@ Retreives when needed to apply on components
 				pan_bg_image		: "",
 				pan_bg_size			: "cover",
 				pan_bg_position		: "top center",
-				pan_opacity 		: 100
+				pan_opacity 		: 100,
+
+				sr_lvl_difference	: 3
 			};
 		},
         

--- a/src/pages/strategy/tabs/expcalc/expcalc.css
+++ b/src/pages/strategy/tabs/expcalc/expcalc.css
@@ -176,6 +176,48 @@
 	margin-right:3px;
 }
 
+.tab_expcalc .ship_goal.ship_closeToRemodel{
+	background-color:#2be;
+	/* Chrome */
+	-webkit-animation-name: ship_closeToRemodel;
+	-webkit-animation-duration: 4s;
+	-webkit-animation-iteration-count: infinite;
+	animation-name: ship_closeToRemodel;
+	animation-duration: 4s;
+	animation-iteration-count: infinite;
+}
+@-webkit-keyframes ship_closeToRemodel{
+	0%  {background-color:#def;}
+	50%  {background-color:#2be;}
+	100%  {background-color:#def;}
+}
+@keyframes ship_closeToRemodel {
+	0%  {background-color:#def;}
+	50%  {background-color:#2be;}
+	100%  {background-color:#def;}
+}
+
+.tab_expcalc .ship_goal.ship_canBeRemodelled{
+	background-color:#2be;
+	/* Chrome */
+	-webkit-animation-name: ship_canBeRemodelled;
+	-webkit-animation-duration: 4s;
+	-webkit-animation-iteration-count: infinite;
+	animation-name: ship_canBeRemodelled;
+	animation-duration: 4s;
+	animation-iteration-count: infinite;
+}
+
+@-webkit-keyframes ship_canBeRemodelled{
+	0%  {background-color:#def;}
+	50%  {background-color:#1e7;}
+	100%  {background-color:#def;}
+}
+@keyframes ship_canBeRemodelled {
+	0%  {background-color:#def;}
+	50%  {background-color: #1e7;}
+	100%  {background-color:#def;}
+}
 /* INACTIVE OVERRIDES
 --------------------------------*/
 .tab_expcalc .ship_goal.inactive {

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -415,10 +415,21 @@
 
 				goalBox.addClass("inactive");
 
-				// If still has next remodel, add to recommendations
-				if(ThisShip.master().api_aftershipid > 0 && ThisShip.level<ThisShip.master().api_afterlv){
+				// If can be remodelled
+				if(ThisShip.master().api_aftershipid > 0 && ThisShip.level >= ThisShip.master().api_afterlv) {
+					goalBox.addClass("ship_canBeRemodelled");
+				}
+
+				// If next remodel lvl is greater then current, add to recommendations
+				if(ThisShip.master().api_aftershipid > 0 && ThisShip.level < ThisShip.master().api_afterlv){
 					$(".ship_target .ship_value", goalBox).text( ThisShip.master().api_afterlv );
 					goalBox.appendTo(".section_expcalc .box_recommend");
+
+					//If is close to remodel
+					if(ThisShip.master().api_afterlv - ThisShip.level > 0 &&
+						ThisShip.master().api_afterlv - ThisShip.level <= ConfigManager.sr_lvl_difference){
+						goalBox.addClass("ship_closeToRemodel");
+					}
 					return true;
 				}
 


### PR DESCRIPTION
**Problem** young teitoku got too many ships inside recommendations section. Can easily miss ship that can be remodelled or close to remodel.

**Solution**
- highlight with green colour ships that can be upgraded
- highlight with blue colour ships that are close to upgrade (lvl difference could be changed in settings)

[How it looks like in the end]( http://imgur.com/00gVjUI)

P.S. `"min" : 0` actually isn't working.