### PR TITLE
Leveling tab improvements

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -664,24 +664,5 @@
 				"options" : { "label" : "%" }
 			}
 		]
-	},
-	{
-		"section":"SettingsStrategyRoom",
-		"help":"",
-		"contents":[
-			{
-				"id" : "sr_lvl_difference",
-				"name" : "SettingsLevellingDifference",
-				"type" : "small_text",
-				"bound" : {
-					"min" :  0,
-					"max" : 15,
-					"type": "Number"
-				},
-				"options" : {
-					"label" : "Lv"
-				}
-			}
-		]
 	}
 ]

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -670,18 +670,6 @@
 		"help":"",
 		"contents":[
 			{
-				"id" : "sr_lvl_toggle",
-				"name" : "SettingsLevellingToggle",
-				"type" : "radio",
-				"options" : {
-					"choices" : [
-						[ 0, "None" ],
-						[ 1, "SettingsLevellingToggleEnabled" ],
-						[ 2, "SettingsLevellingToggleEnabledBlink" ]
-					]
-				}
-			},
-			{
 				"id" : "sr_lvl_difference",
 				"name" : "SettingsLevellingDifference",
 				"type" : "small_text",

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -670,6 +670,18 @@
 		"help":"",
 		"contents":[
 			{
+				"id" : "sr_lvl_toggle",
+				"name" : "SettingsLevellingToggle",
+				"type" : "radio",
+				"options" : {
+					"choices" : [
+						[ 0, "None" ],
+						[ 1, "SettingsLevellingToggleEnabled" ],
+						[ 2, "SettingsLevellingToggleEnabledBlink" ]
+					]
+				}
+			},
+			{
 				"id" : "sr_lvl_difference",
 				"name" : "SettingsLevellingDifference",
 				"type" : "small_text",

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -149,7 +149,6 @@ Retreives when needed to apply on components
 				pan_bg_position		: "top center",
 				pan_opacity 		: 100,
 
-				sr_lvl_toggle       : 1,
 				sr_lvl_difference	: 3
 			};
 		},

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -149,6 +149,7 @@ Retreives when needed to apply on components
 				pan_bg_position		: "top center",
 				pan_opacity 		: 100,
 
+				sr_lvl_toggle       : 1,
 				sr_lvl_difference	: 3
 			};
 		},

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -147,9 +147,7 @@ Retreives when needed to apply on components
 				pan_bg_image		: "",
 				pan_bg_size			: "cover",
 				pan_bg_position		: "top center",
-				pan_opacity 		: 100,
-
-				sr_lvl_difference	: 3
+				pan_opacity 		: 100
 			};
 		},
         

--- a/src/library/modules/RemodelDb.js
+++ b/src/library/modules/RemodelDb.js
@@ -213,36 +213,36 @@
                 "previousForm: querying on original form?" );
             return group[curInd-1];
         },
-		// query the lowest level certain ship can have
-		lowestLevel: function(shipId) {
-			var prevId = this.previousForm(shipId);
-			if (!prevId)
-				return 1;
+        // query the lowest level certain ship can have
+        lowestLevel: function(shipId) {
+            var prevId = this.previousForm(shipId);
+            if (!prevId)
+                return 1;
 
-			var prevInfo = this.remodelInfo(prevId);
-			return prevInfo.level;
-		},
+            var prevInfo = this.remodelInfo(prevId);
+            return prevInfo.level;
+        },
         dumpRemodelGroups: function() {
             return JSON.stringify( this._db.remodelGroups );
         },
-		// returns all possible remodel levels for current ship
-		// returns false if the shipId is invalid
-		nextLevels: function(shipId) {
-			var self = this;
-			var remodelGroup = this.remodelGroup(shipId).slice();
-			if (!remodelGroup) return false;
-			// either the final form doesn't remodel or
-			// remodels into another final form, we don't care
-			// for the purpose of this function.
-			remodelGroup.pop();
+        // returns all possible remodel levels for current ship
+        // returns false if the shipId is invalid
+        nextLevels: function(shipId) {
+            var self = this;
+            var remodelGroup = this.remodelGroup(shipId).slice();
+            if (!remodelGroup) return false;
+            // either the final form doesn't remodel or
+            // remodels into another final form, we don't care
+            // for the purpose of this function.
+            remodelGroup.pop();
 
-			// for ships that has at least been remodelled once,
-			// there is no need keepin her prior form info here.
-			while (remodelGroup.length > 0 && remodelGroup[0] !== shipId)
-				remodelGroup.shift();
-			var levels = remodelGroup.map( function(sid) {
-				return self.remodelInfo(sid).level; });
-			return levels;
-		}
+            // for ships that has at least been remodelled once,
+            // there is no need keepin her prior form info here.
+            while (remodelGroup.length > 0 && remodelGroup[0] !== shipId)
+                remodelGroup.shift();
+            var levels = remodelGroup.map( function(sid) {
+                return self.remodelInfo(sid).level; });
+            return levels;
+        }
     };
 })();

--- a/src/library/modules/RemodelDb.js
+++ b/src/library/modules/RemodelDb.js
@@ -224,6 +224,25 @@
 		},
         dumpRemodelGroups: function() {
             return JSON.stringify( this._db.remodelGroups );
-        }
+        },
+		// returns all possible remodel levels for current ship
+		// returns false if the shipId is invalid
+		nextLevels: function(shipId) {
+			var self = this;
+			var remodelGroup = this.remodelGroup(shipId);
+			if (!remodelGroup) return false;
+			// either the final form doesn't remodel or
+			// remodels into another final form, we don't care
+			// for the purpose of this function.
+			remodelGroup.pop();
+
+			// for ships that has at least been remodelled once,
+			// there is no need keepin her prior form info here.
+			while (remodelGroup.length > 0 && remodelGroup[0] !== shipId)
+				remodelGroup.shift();
+			var levels = remodelGroup.map( function(sid) {
+				return self.remodelInfo(sid).level; });
+			return levels;
+		}
     };
 })();

--- a/src/library/modules/RemodelDb.js
+++ b/src/library/modules/RemodelDb.js
@@ -229,7 +229,7 @@
 		// returns false if the shipId is invalid
 		nextLevels: function(shipId) {
 			var self = this;
-			var remodelGroup = this.remodelGroup(shipId);
+			var remodelGroup = this.remodelGroup(shipId).slice();
 			if (!remodelGroup) return false;
 			// either the final form doesn't remodel or
 			// remodels into another final form, we don't care

--- a/src/pages/strategy/tabs/expcalc/expcalc.css
+++ b/src/pages/strategy/tabs/expcalc/expcalc.css
@@ -176,7 +176,7 @@
 	margin-right:3px;
 }
 
-.tab_expcalc .ship_goal.ship_closeToRemodel{
+.tab_expcalc .ship_goal.ship_closeToRemodel.should_blink {
 	background-color:#2be;
 	/* Chrome */
 	-webkit-animation-name: ship_closeToRemodel;
@@ -197,8 +197,11 @@
 	100%  {background-color:#def;}
 }
 
-.tab_expcalc .ship_goal.ship_canBeRemodelled{
+.tab_expcalc .ship_goal.ship_canBeRemodelled.hl_enabled {
 	background-color:#2be;
+}
+
+.tab_expcalc .ship_goal.ship_canBeRemodelled.should_blink {
 	/* Chrome */
 	-webkit-animation-name: ship_canBeRemodelled;
 	-webkit-animation-duration: 4s;

--- a/src/pages/strategy/tabs/expcalc/expcalc.css
+++ b/src/pages/strategy/tabs/expcalc/expcalc.css
@@ -177,11 +177,11 @@
 }
 
 .tab_expcalc .ship_goal.ship_closeToRemodel {
-	background-color:#2be;
+	background-color:#71d3f4;
 }
 
 .tab_expcalc .ship_goal.ship_canBeRemodelled {
-	background-color:#2be;
+	background-color:#60ebe2;
 }
 
 /* INACTIVE OVERRIDES

--- a/src/pages/strategy/tabs/expcalc/expcalc.css
+++ b/src/pages/strategy/tabs/expcalc/expcalc.css
@@ -5,6 +5,44 @@
 	display:none;
 }
 
+.tab_expcalc .box_control {
+	width:700px;
+	background:#def;
+	margin:0px 0px 3px 0px;
+	line-height:34px;
+	border:1px solid #ace;
+	padding-bottom: 5px;
+}
+
+.tab_expcalc .box_control_line {
+	padding: 5px 10px 0px 10px;
+}
+
+.tab_expcalc .box_control_line dl dd {
+	float: left;
+}
+.tab_expcalc .box_control_line dl dt {
+	float: left;
+}
+.tab_expcalc .box_control_line .inp_lvl_diff {
+	width: 40px;
+	height: 20px;
+}
+.tab_expcalc .box_control_line .hover {
+	padding: 0 5px;
+	margin: 0 0 0 4px;
+}
+
+.tab_expcalc .box_control_line .hover.active {
+	background: #3333ff;
+	color: #fff;
+}
+
+.tab_expcalc .box_control_line .toggle {
+	border-radius: 4px;
+	background: #fff;
+}
+
 .tab_expcalc .box_goals {
 	margin:0px 0px 20px 0px;
 }

--- a/src/pages/strategy/tabs/expcalc/expcalc.css
+++ b/src/pages/strategy/tabs/expcalc/expcalc.css
@@ -176,51 +176,14 @@
 	margin-right:3px;
 }
 
-.tab_expcalc .ship_goal.ship_closeToRemodel.should_blink {
-	background-color:#2be;
-	/* Chrome */
-	-webkit-animation-name: ship_closeToRemodel;
-	-webkit-animation-duration: 4s;
-	-webkit-animation-iteration-count: infinite;
-	animation-name: ship_closeToRemodel;
-	animation-duration: 4s;
-	animation-iteration-count: infinite;
-}
-@-webkit-keyframes ship_closeToRemodel{
-	0%  {background-color:#def;}
-	50%  {background-color:#2be;}
-	100%  {background-color:#def;}
-}
-@keyframes ship_closeToRemodel {
-	0%  {background-color:#def;}
-	50%  {background-color:#2be;}
-	100%  {background-color:#def;}
-}
-
-.tab_expcalc .ship_goal.ship_canBeRemodelled.hl_enabled {
+.tab_expcalc .ship_goal.ship_closeToRemodel {
 	background-color:#2be;
 }
 
-.tab_expcalc .ship_goal.ship_canBeRemodelled.should_blink {
-	/* Chrome */
-	-webkit-animation-name: ship_canBeRemodelled;
-	-webkit-animation-duration: 4s;
-	-webkit-animation-iteration-count: infinite;
-	animation-name: ship_canBeRemodelled;
-	animation-duration: 4s;
-	animation-iteration-count: infinite;
+.tab_expcalc .ship_goal.ship_canBeRemodelled {
+	background-color:#2be;
 }
 
-@-webkit-keyframes ship_canBeRemodelled{
-	0%  {background-color:#def;}
-	50%  {background-color:#1e7;}
-	100%  {background-color:#def;}
-}
-@keyframes ship_canBeRemodelled {
-	0%  {background-color:#def;}
-	50%  {background-color: #1e7;}
-	100%  {background-color:#def;}
-}
 /* INACTIVE OVERRIDES
 --------------------------------*/
 .tab_expcalc .ship_goal.inactive {

--- a/src/pages/strategy/tabs/expcalc/expcalc.css
+++ b/src/pages/strategy/tabs/expcalc/expcalc.css
@@ -24,7 +24,7 @@
 .tab_expcalc .box_control_line dl dt {
 	float: left;
 }
-.tab_expcalc .box_control_line .inp_lvl_diff {
+.tab_expcalc .box_control_line #inp_lvl_diff {
 	width: 40px;
 	height: 20px;
 }

--- a/src/pages/strategy/tabs/expcalc/expcalc.css
+++ b/src/pages/strategy/tabs/expcalc/expcalc.css
@@ -396,3 +396,14 @@
 .tab_expcalc .goal_template .goal_mvp {
 	width:50px;
 }
+
+.tab_expcalc .gt_content.new_template {
+	width: 680px;
+	background: #def;
+	border-radius: 8px;
+	margin: 0px 0px 3px 0px;
+	padding: 2px 4px;
+	line-height: 34px;
+	border: 1px solid #ace;
+	text-align: center;
+}

--- a/src/pages/strategy/tabs/expcalc/expcalc.css
+++ b/src/pages/strategy/tabs/expcalc/expcalc.css
@@ -65,8 +65,15 @@
 	line-height:34px;
 	border:1px solid #ace;
 }
-.tab_expcalc .ship_goal.highlight {
-	background:#fdd;
+.tab_expcalc .ship_goal.highlight_stype {
+	background-color:#fdd;
+}
+.tab_expcalc .ship_goal.highlight_closeToRemodel {
+	background-color:#71d3f4;
+}
+
+.tab_expcalc .ship_goal.highlight_canBeRemodelled {
+	background-color:#60ebe2;
 }
 .tab_expcalc .ship_goal .ship_col {
 	height:34px;
@@ -214,13 +221,6 @@
 	margin-right:3px;
 }
 
-.tab_expcalc .ship_goal.ship_closeToRemodel {
-	background-color:#71d3f4;
-}
-
-.tab_expcalc .ship_goal.ship_canBeRemodelled {
-	background-color:#60ebe2;
-}
 
 /* INACTIVE OVERRIDES
 --------------------------------*/

--- a/src/pages/strategy/tabs/expcalc/expcalc.html
+++ b/src/pages/strategy/tabs/expcalc/expcalc.html
@@ -78,7 +78,7 @@
 	  <dd class="btn_hl_can_be_remodelled hover toggle">Can Be Remodelled</dd>
 	</dl>
   </div>
-  <div class="box_control_line line_close_to_remodel hidden">
+  <div class="box_control_line line_close_to_remodel">
 	<dl>
 	  <dt class="hover">Close-to-remodel maximum level difference</dt>
 	  <dd><input type="text" class="inp_lvl_diff"></dd>

--- a/src/pages/strategy/tabs/expcalc/expcalc.html
+++ b/src/pages/strategy/tabs/expcalc/expcalc.html
@@ -89,7 +89,7 @@
 <div class="page_padding section_expcalc">
   <div class="page_section">Current Goals</div>
   <div class="section_body box_goals">
-	
+
   </div>
 
   <div class="page_section gt_content">Goal Templates</div>
@@ -98,24 +98,21 @@
   <div class="section_body gt_content">
     <a class="new_template">New template</a>
   </div>
-  <div class="section_body gt_content">
-    <a class="clear_highlight">Clear Highlight</a>
-  </div>
-  
+
   <div class="page_section recom_content">Recommended</div>
   <div class="section_body box_recommend recom_content">
-	
+
   </div>
-  
+
   <div class="page_section other_content">Other Ships</div>
   <div class="section_body box_other other_content">
-	
+
   </div>
-  
+
 </div>
 
 <div class="factory">
-  
+
   <div class="ship_goal">
 	<div class="ship_col ship_icon hover"><img/></div>
 	<div class="ship_col ship_info ship_activeOnly">

--- a/src/pages/strategy/tabs/expcalc/expcalc.html
+++ b/src/pages/strategy/tabs/expcalc/expcalc.html
@@ -1,6 +1,6 @@
 <div class="page_title">
-	Leveling Goals
-	<div class="page_help_btn hover"><span>?</span> Help Topics</div>
+  Leveling Goals
+  <div class="page_help_btn hover"><span>?</span> Help Topics</div>
 </div>
 
 <!-- HELP TOPICS -->
@@ -87,153 +87,153 @@
 </div>
 
 <div class="page_padding section_expcalc">
-	<div class="page_section">Current Goals</div>
-	<div class="section_body box_goals">
-		
-	</div>
+  <div class="page_section">Current Goals</div>
+  <div class="section_body box_goals">
+	
+  </div>
 
-	<div class="page_section">Goal Templates</div>
-	<div class="section_body box_goal_templates">
-    </div>
-	<div class="section_body">
-      <a class="new_template">New template</a>
-    </div>
-	<div class="section_body">
-      <a class="clear_highlight">Clear Highlight</a>
-    </div>
+  <div class="page_section">Goal Templates</div>
+  <div class="section_body box_goal_templates">
+  </div>
+  <div class="section_body">
+    <a class="new_template">New template</a>
+  </div>
+  <div class="section_body">
+    <a class="clear_highlight">Clear Highlight</a>
+  </div>
+  
+  <div class="page_section">Recommended</div>
+  <div class="section_body box_recommend">
 	
-	<div class="page_section">Recommended</div>
-	<div class="section_body box_recommend">
-		
-	</div>
+  </div>
+  
+  <div class="page_section">Other Ships</div>
+  <div class="section_body box_other">
 	
-	<div class="page_section">Other Ships</div>
-	<div class="section_body box_other">
-		
-	</div>
-	
+  </div>
+  
 </div>
 
 <div class="factory">
-	
-	<div class="ship_goal">
-		<div class="ship_col ship_icon hover"><img/></div>
-		<div class="ship_col ship_info ship_activeOnly">
-			<div class="ship_name"></div>
-			<div class="ship_type"></div>
-		</div>
-		<div class="ship_col ship_lv">
-			<div class="ship_label">Level</div>
-			<div class="ship_value"></div>
-		</div>
-		<div class="ship_col ship_target">
-			<div class="ship_label">Goal</div>
-			<div class="ship_value"></div>
-			<div class="ship_input"><input type="textbox"></div>
-		</div>
-		<div class="ship_col ship_exp ship_activeOnly">
-			<div class="ship_label">Exp Left</div>
-			<div class="ship_value"></div>
-		</div>
-		<div class="ship_col ship_result ship_activeOnly">
-			<div class="ship_label">Battles</div>
-			<div class="ship_value"></div>
-		</div>
-		<div class="ship_col ship_map ship_activeOnly">
-			<div class="ship_label">Map</div>
-			<div class="ship_value"></div>
-			<div class="ship_input">
-				<select></select>
-			</div>
-		</div>
-		<div class="ship_col ship_rank ship_activeOnly">
-			<div class="ship_label">Rank</div>
-			<div class="ship_value"></div>
-			<div class="ship_input">
-				<select>
-					<option value="6">S</option>
-					<option value="5">A</option>
-					<option value="4">B</option>
-					<option value="3">C</option>
-					<option value="2">D</option>
-					<option value="1">E</option>
-				</select>
-			</div>
-		</div>
-		<div class="ship_col ship_fs ship_activeOnly">
-			<div class="ship_label">FS</div>
-			<div class="ship_value yes_or_no"></div>
-			<div class="ship_input"><input type="checkbox"></div>
-		</div>
-		<div class="ship_col ship_mvp ship_activeOnly">
-			<div class="ship_label">MVP</div>
-			<div class="ship_value yes_or_no"></div>
-			<div class="ship_input"><input type="checkbox"></div>
-		</div>
-		<div class="ship_col ship_btn hover ship_add">+</div>
-		<div class="ship_col ship_btn hover ship_rem">X</div>
-		<div class="ship_col ship_btn hover ship_edit">E</div>
-		<div class="ship_col ship_btn hover ship_save">S</div>
-		<div class="clear"></div>
+  
+  <div class="ship_goal">
+	<div class="ship_col ship_icon hover"><img/></div>
+	<div class="ship_col ship_info ship_activeOnly">
+	  <div class="ship_name"></div>
+	  <div class="ship_type"></div>
 	</div>
+	<div class="ship_col ship_lv">
+	  <div class="ship_label">Level</div>
+	  <div class="ship_value"></div>
+	</div>
+	<div class="ship_col ship_target">
+	  <div class="ship_label">Goal</div>
+	  <div class="ship_value"></div>
+	  <div class="ship_input"><input type="textbox"></div>
+	</div>
+	<div class="ship_col ship_exp ship_activeOnly">
+	  <div class="ship_label">Exp Left</div>
+	  <div class="ship_value"></div>
+	</div>
+	<div class="ship_col ship_result ship_activeOnly">
+	  <div class="ship_label">Battles</div>
+	  <div class="ship_value"></div>
+	</div>
+	<div class="ship_col ship_map ship_activeOnly">
+	  <div class="ship_label">Map</div>
+	  <div class="ship_value"></div>
+	  <div class="ship_input">
+		<select></select>
+	  </div>
+	</div>
+	<div class="ship_col ship_rank ship_activeOnly">
+	  <div class="ship_label">Rank</div>
+	  <div class="ship_value"></div>
+	  <div class="ship_input">
+		<select>
+		  <option value="6">S</option>
+		  <option value="5">A</option>
+		  <option value="4">B</option>
+		  <option value="3">C</option>
+		  <option value="2">D</option>
+		  <option value="1">E</option>
+		</select>
+	  </div>
+	</div>
+	<div class="ship_col ship_fs ship_activeOnly">
+	  <div class="ship_label">FS</div>
+	  <div class="ship_value yes_or_no"></div>
+	  <div class="ship_input"><input type="checkbox"></div>
+	</div>
+	<div class="ship_col ship_mvp ship_activeOnly">
+	  <div class="ship_label">MVP</div>
+	  <div class="ship_value yes_or_no"></div>
+	  <div class="ship_input"><input type="checkbox"></div>
+	</div>
+	<div class="ship_col ship_btn hover ship_add">+</div>
+	<div class="ship_col ship_btn hover ship_rem">X</div>
+	<div class="ship_col ship_btn hover ship_edit">E</div>
+	<div class="ship_col ship_btn hover ship_save">S</div>
+	<div class="clear"></div>
+  </div>
 
-    <div class="goal_template">
-      <div class="setting_group">
-        <div class="goal_col goal_type">
-          <div class="goal_label">Ship Types</div>
-          <div class="goal_value"></div>
-          <div class="goal_input">
-            <input type="text" name="stype">
-            <br>
-          </div>
+  <div class="goal_template">
+    <div class="setting_group">
+      <div class="goal_col goal_type">
+        <div class="goal_label">Ship Types</div>
+        <div class="goal_value"></div>
+        <div class="goal_input">
+          <input type="text" name="stype">
+          <br>
         </div>
-        <div class="goal_col goal_map">
-          <div class="goal_label">Map</div>
-          <div class="goal_value"></div>
-          <div class="goal_input">
-            <select></select>
-          </div>
-        </div>
-        <div class="goal_col goal_rank">
-          <div class="goal_label">Rank</div>
-          <div class="goal_value">S</div>
-          <div class="goal_input">
-            <select>
-              <option value="6">S</option>
-              <option value="5">A</option>
-              <option value="4">B</option>
-              <option value="3">C</option>
-              <option value="2">D</option>
-              <option value="1">E</option>
-            </select>
-          </div>
-        </div>
-        <div class="goal_col goal_fs">
-          <div class="goal_label">FS</div>
-          <div class="goal_value yes_or_no"></div>
-          <div class="goal_input">
-            <input type="checkbox">
-          </div>
-        </div>
-        <div class="goal_col goal_mvp yes_or_no">
-          <div class="goal_label">MVP</div>
-          <div class="goal_value yes_or_no"></div>
-          <div class="goal_input">
-            <input type="checkbox">
-          </div>
-        </div>
-        <div class="goal_col goal_btn hover goal_edit">E</div>
-        <div class="goal_col goal_btn hover goal_save">S</div>
-        <div class="goal_col goal_btn hover goal_rem">X</div>
-        <div class="clear"></div>
       </div>
-      <div class="manage_buttons">
-        <div class="goal_col goal_btn hover goal_up">▲</div>
-        <div class="goal_col goal_btn hover goal_down">▼</div>
-        <div class="goal_col goal_btn hover goal_hl_coverage">Highlight Coverage</div>
-        <div class="goal_col goal_btn hover goal_onoff">Enable</div>
-        <div class="goal_col goal_btn hover goal_apply">Apply to Current Goals</div>
-        <div class="clear"></div>
+      <div class="goal_col goal_map">
+        <div class="goal_label">Map</div>
+        <div class="goal_value"></div>
+        <div class="goal_input">
+          <select></select>
+        </div>
       </div>
+      <div class="goal_col goal_rank">
+        <div class="goal_label">Rank</div>
+        <div class="goal_value">S</div>
+        <div class="goal_input">
+          <select>
+            <option value="6">S</option>
+            <option value="5">A</option>
+            <option value="4">B</option>
+            <option value="3">C</option>
+            <option value="2">D</option>
+            <option value="1">E</option>
+          </select>
+        </div>
+      </div>
+      <div class="goal_col goal_fs">
+        <div class="goal_label">FS</div>
+        <div class="goal_value yes_or_no"></div>
+        <div class="goal_input">
+          <input type="checkbox">
+        </div>
+      </div>
+      <div class="goal_col goal_mvp yes_or_no">
+        <div class="goal_label">MVP</div>
+        <div class="goal_value yes_or_no"></div>
+        <div class="goal_input">
+          <input type="checkbox">
+        </div>
+      </div>
+      <div class="goal_col goal_btn hover goal_edit">E</div>
+      <div class="goal_col goal_btn hover goal_save">S</div>
+      <div class="goal_col goal_btn hover goal_rem">X</div>
+      <div class="clear"></div>
     </div>
+    <div class="manage_buttons">
+      <div class="goal_col goal_btn hover goal_up">▲</div>
+      <div class="goal_col goal_btn hover goal_down">▼</div>
+      <div class="goal_col goal_btn hover goal_hl_coverage">Highlight Coverage</div>
+      <div class="goal_col goal_btn hover goal_onoff">Enable</div>
+      <div class="goal_col goal_btn hover goal_apply">Apply to Current Goals</div>
+      <div class="clear"></div>
+    </div>
+  </div>
 </div>

--- a/src/pages/strategy/tabs/expcalc/expcalc.html
+++ b/src/pages/strategy/tabs/expcalc/expcalc.html
@@ -81,7 +81,7 @@
   <div class="box_control_line line_close_to_remodel">
 	<dl>
 	  <dt class="hover">Close-to-remodel maximum level difference</dt>
-	  <dd><input type="text" class="inp_lvl_diff"></dd>
+	  <dd><input type="text" id="inp_lvl_diff"></dd>
 	</dl>
   </div>
 </div>

--- a/src/pages/strategy/tabs/expcalc/expcalc.html
+++ b/src/pages/strategy/tabs/expcalc/expcalc.html
@@ -61,6 +61,31 @@
   </div>
 </div>
 
+<div class="box_control">
+  <div class="box_control_line">
+	<dl>
+	  <dt class="hover">Sections</dt>
+	  <dd class="toggle_goal_templates hover toggle">Goal Templates</dd>
+	  <dd class="toggle_recommended hover toggle active">Recommended</dd>
+	  <dd class="toggle_other_ships hover toggle">Other Ships</dd>
+	</dl>
+  </div>
+  <div class="box_control_line">
+	<dl>
+	  <dt class="hover">Highlight</dt>
+	  <dd class="btn_hl_clear hover toggle">Clear All</dd>
+	  <dd class="btn_hl_close_to_remodel hover toggle">Close To Remodel</dd>
+	  <dd class="btn_hl_can_be_remodelled hover toggle">Can Be Remodelled</dd>
+	</dl>
+  </div>
+  <div class="box_control_line line_close_to_remodel hidden">
+	<dl>
+	  <dt class="hover">Close-to-remodel maximum level difference</dt>
+	  <dd><input type="text" class="inp_lvl_diff"></dd>
+	</dl>
+  </div>
+</div>
+
 <div class="page_padding section_expcalc">
 	<div class="page_section">Current Goals</div>
 	<div class="section_body box_goals">

--- a/src/pages/strategy/tabs/expcalc/expcalc.html
+++ b/src/pages/strategy/tabs/expcalc/expcalc.html
@@ -66,7 +66,7 @@
 	<dl>
 	  <dt class="hover">Sections</dt>
 	  <dd class="toggle_goal_templates hover toggle">Goal Templates</dd>
-	  <dd class="toggle_recommended hover toggle active">Recommended</dd>
+	  <dd class="toggle_recommended hover toggle">Recommended</dd>
 	  <dd class="toggle_other_ships hover toggle">Other Ships</dd>
 	</dl>
   </div>
@@ -92,23 +92,23 @@
 	
   </div>
 
-  <div class="page_section">Goal Templates</div>
-  <div class="section_body box_goal_templates">
+  <div class="page_section gt_content">Goal Templates</div>
+  <div class="section_body box_goal_templates gt_content">
   </div>
-  <div class="section_body">
+  <div class="section_body gt_content">
     <a class="new_template">New template</a>
   </div>
-  <div class="section_body">
+  <div class="section_body gt_content">
     <a class="clear_highlight">Clear Highlight</a>
   </div>
   
-  <div class="page_section">Recommended</div>
-  <div class="section_body box_recommend">
+  <div class="page_section recom_content">Recommended</div>
+  <div class="section_body box_recommend recom_content">
 	
   </div>
   
-  <div class="page_section">Other Ships</div>
-  <div class="section_body box_other">
+  <div class="page_section other_content">Other Ships</div>
+  <div class="section_body box_other other_content">
 	
   </div>
   

--- a/src/pages/strategy/tabs/expcalc/expcalc.html
+++ b/src/pages/strategy/tabs/expcalc/expcalc.html
@@ -95,8 +95,8 @@
   <div class="page_section gt_content">Goal Templates</div>
   <div class="section_body box_goal_templates gt_content">
   </div>
-  <div class="section_body gt_content">
-    <a class="new_template">New template</a>
+  <div class="section_body gt_content new_template">
+    <a>New template</a>
   </div>
 
   <div class="page_section recom_content">Recommended</div>

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -420,6 +420,8 @@
 					ThisShip.level >= ThisShip.master().api_afterlv &&
 					!RemodelDb.isFinalForm(ThisShip.masterId)){
 					goalBox.addClass("ship_canBeRemodelled");
+					// goalBox.addClass("should_blink");
+					// goalBox.addClass("hl_enabled");
 				}
 
 				// If next remodel lvl is greater then current, add to recommendations
@@ -432,6 +434,7 @@
 					if(ThisShip.master().api_afterlv - ThisShip.level > 0 &&
 						ThisShip.master().api_afterlv - ThisShip.level <= ConfigManager.sr_lvl_difference){
 						goalBox.addClass("ship_closeToRemodel");
+						// goalBox.addClass("should_blink");
 					}
 					return true;
 				}

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -140,12 +140,25 @@
 			});
 		},
 
+		configHighlightToggles: function() {
+			$(".btn_hl_clear").on("click", function() {
+				$(".section_body .ship_goal").each( function(i,x) {
+					var jqObj = $(x);
+					jqObj.removeClass(
+						"highlight_stype " +
+						"highlight_closeToRemodel " +
+						"highlight_canBeRemodelled ");
+				});
+			});
+		},
+
 		/* EXECUTE
 		Places data onto the interface
 		---------------------------------*/
 		execute :function(){
 			var self = this;
 			self.configSectionToggles();
+			self.configHighlightToggles();
 
 			// Add map list into the factory drop-downs
 			$.each(this.maplist, function(MapName, MapExp){
@@ -440,13 +453,6 @@
 				goalTemplateShow(goalBox);
 				goalBox.toggleClass("disabled", !dat.enable);
 				goalBox.appendTo(".section_expcalc .box_goal_templates");
-			});
-
-			$(".section_expcalc a.clear_highlight").on("click", function () {
-				$(".section_body .ship_goal").each( function(i,x) {
-					var jqObj = $(x);
-					jqObj.removeClass("highlight");
-				});
 			});
 
 			// TODO: prevent double click text selection?

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -379,9 +379,9 @@
 					var stypeId = MasterShip.api_stype;
 
 					if (stypeIds.indexOf(stypeId) != -1) {
-						jqObj.addClass("highlight");
+						jqObj.addClass("highlight_stype");
 					} else {
-						jqObj.removeClass("highlight");
+						jqObj.removeClass("highlight_stype");
 					}
 				});
 			});
@@ -544,7 +544,7 @@
 					nextLevels > 0 &&
 					!RemodelDb.isFinalForm(ThisShip.masterId) &&
 					nextLevels[0] < ThisShip.level) {
-					goalBox.addClass("ship_canBeRemodelled");
+					goalBox.addClass("highlight_canBeRemodelled");
 				}
 
 				// If next remodel lvl is greater than current, add to recommendations
@@ -557,7 +557,7 @@
 					goalBox.appendTo(".section_expcalc .box_recommend");
 					// If is close to remodel
 					if(goalLevel - ThisShip.level <= ConfigManager.sr_lvl_difference) {
-						goalBox.addClass("ship_closeToRemodel");
+						goalBox.addClass("highlight_closeToRemodel");
 					}
 					return true;
 				} else {

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -166,6 +166,7 @@
 				$(".box_control_line.line_close_to_remodel").show();
 				$(".section_body .ship_goal").each( function(i,x) {
 					var jqObj = $(x);
+					clearHighlight(jqObj);
 					var rosterId = jqObj.data("id");
 					var ThisShip = KC3ShipManager.get( rosterId );
 					if (ThisShip.masterId === 0)
@@ -177,8 +178,7 @@
 					if (goalLevel === false || goalLevel >= 99)
 						return;
 					if (goalLevel - ThisShip.level <= ConfigManager.sr_lvl_difference) {
-						clearHighlight(jqObj)
-							.addClass("highlight_closeToRemodel");
+						jqObj.addClass("highlight_closeToRemodel");
 					}
 				});
 			});
@@ -186,6 +186,7 @@
 				$(".box_control_line.line_close_to_remodel").hide();
 				$(".section_body .ship_goal").each( function(i,x) {
 					var jqObj = $(x);
+					clearHighlight(jqObj);
 					var rosterId = jqObj.data("id");
 					var ThisShip = KC3ShipManager.get( rosterId );
 					if (ThisShip.masterId === 0)
@@ -200,8 +201,7 @@
 						nextLevels.length > 0 &&
 						!RemodelDb.isFinalForm(ThisShip.masterId) &&
 						nextLevels[0] < ThisShip.level) {
-						clearHighlight(jqObj)
-							.addClass("highlight_canBeRemodelled");
+						jqObj.addClass("highlight_canBeRemodelled");
 					}
 				});
 			});
@@ -442,11 +442,14 @@
 				// traverse all ships, toggle "highlight" flag
 				$(".section_body .ship_goal").each( function(i,x) {
 					var jqObj = $(x);
+					jqObj.removeClass(
+						"highlight_stype " +
+						"highlight_closeToRemodel " +
+						"highlight_canBeRemodelled ");
 					var rosterId = jqObj.data("id");
 					var ThisShip = KC3ShipManager.get( rosterId );
 					var MasterShip = ThisShip.master();
 					var stypeId = MasterShip.api_stype;
-
 					if (stypeIds.indexOf(stypeId) != -1) {
 						jqObj.addClass("highlight_stype");
 					} else {

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -533,7 +533,7 @@
 				goalBox.appendTo(".section_expcalc .box_goal_templates");
 			});
 
-			$(".section_expcalc a.new_template").on("click", function () {
+			$(".section_expcalc .new_template a").on("click", function () {
 				var goalBox = $(".tab_expcalc .factory .goal_template").clone();
 				var dat = GoalTemplateManager.newTemplate();
 				self.goalTemplates.push(dat);

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -142,6 +142,12 @@
 
 		configHighlightToggles: function() {
 			var self = this;
+
+			// show Close To Remodel options should be shown only when
+			// this button is clicked. If user clears all highlights
+			// or want to show other kinds of highlights, we hide the option again.
+			$(".box_control_line.line_close_to_remodel").hide();
+
 			function clearHighlight( jqObj ) {
 				jqObj.removeClass(
 					"highlight_stype " +
@@ -153,9 +159,11 @@
 				$(".section_body .ship_goal").each( function(i,x) {
 					var jqObj = $(x);
 					clearHighlight(jqObj);
+					$(".box_control_line.line_close_to_remodel").hide();
 				});
 			});
 			$(".btn_hl_close_to_remodel").on("click", function() {
+				$(".box_control_line.line_close_to_remodel").show();
 				$(".section_body .ship_goal").each( function(i,x) {
 					var jqObj = $(x);
 					var rosterId = jqObj.data("id");
@@ -175,6 +183,7 @@
 				});
 			});
 			$(".btn_hl_can_be_remodelled").on("click", function() {
+				$(".box_control_line.line_close_to_remodel").hide();
 				$(".section_body .ship_goal").each( function(i,x) {
 					var jqObj = $(x);
 					var rosterId = jqObj.data("id");
@@ -417,6 +426,7 @@
 			});
 
 			$(".section_expcalc").on("click", ".goal_template .goal_hl_coverage", function() {
+				$(".box_control_line.line_close_to_remodel").hide();
 				var goalBox = $(this).parent().parent();
 				var stypes = self.goalTemplates[goalBox.index()].stype;
 				// if there's an "Any" filter, don't proceed because

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -65,12 +65,79 @@
 
 			return possibleNextLevels.length > 0 ? possibleNextLevels[0] : false;
 		},
+		
+		getSettings: function() {
+			var defSettings = {
+				showGoalTemplates: true,
+				showRecommended: true,
+				showOtherShips: true,
+				closeToRemodelLevelDiff: 5
+			};
+			var settings;
+			if (typeof localStorage.srExpcalc === "undefined") {
+				localStorage.srExpcalc = JSON.stringify( defSettings );
+				settings = defSettings;
+			} else {
+				settings = JSON.parse( localStorage.srExpcalc );
+			}
+			return settings;
+		},
 
+		configSectionToggles: function() {
+			var self = this;
+			var settings = self.getSettings();
+			var jqGoalTemplates = $(".gt_content");
+			var jqRecommended = $(".recom_content");
+			var jqOtherShips = $(".other_content");
+
+			var jqToggleGT = $(".toggle_goal_templates");
+			var jqToggleRecom = $(".toggle_recommended");
+			var jqToggleOther = $(".toggle_other_ships");
+
+			jqGoalTemplates.toggle( settings.showGoalTemplates );
+			jqRecommended.toggle( settings.showRecommended );
+			jqOtherShips.toggle( settings.showOtherShips );
+
+			jqToggleGT
+				.toggleClass("active", settings.showGoalTemplates)
+				.on("click", function() {
+					var settings = self.getSettings();
+					settings.showGoalTemplates = !settings.showGoalTemplates;
+					localStorage.srExpcalc = JSON.stringify(settings);
+					jqGoalTemplates.toggle( settings.showGoalTemplates );
+					jqToggleGT
+						.toggleClass("active", settings.showGoalTemplates);
+				});
+			jqToggleRecom
+				.toggleClass("active", settings.showRecommended)
+				.on("click", function() {
+					var settings = self.getSettings();
+					settings.showRecommended = !settings.showRecommended;
+					localStorage.srExpcalc = JSON.stringify(settings);
+					jqRecommended.toggle( settings.showRecommended );
+					jqToggleRecom
+						.toggleClass("active", settings.showRecommended);
+				});
+
+			jqToggleOther
+				.toggleClass("active", settings.showOtherShips)
+				.on("click", function() {
+					var settings = self.getSettings();
+					settings.showOtherShips = !settings.showOtherShips;
+					localStorage.srExpcalc = JSON.stringify(settings);
+					jqOtherShips.toggle( settings.showOtherShips );
+					jqToggleOther
+						.toggleClass("active", settings.showOtherShips);
+				});
+		},
+		
 		/* EXECUTE
 		Places data onto the interface
 		---------------------------------*/
 		execute :function(){
 			var self = this;
+			self.configSectionToggles();
+		
 			// Add map list into the factory drop-downs
 			$.each(this.maplist, function(MapName, MapExp){
 				$(".tab_expcalc .factory .ship_map select").append("<option>"+MapName+"</option>");

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -102,6 +102,8 @@
 			var jqToggleRecom = $(".toggle_recommended");
 			var jqToggleOther = $(".toggle_other_ships");
 
+			var jqCloseToRemLvlDiff = $("input#inp_lvl_diff");
+
 			function updateUI() {
 				var settings = self.getSettings();
 				jqGoalTemplates.toggle( settings.showGoalTemplates );
@@ -114,6 +116,8 @@
 					.toggleClass("active", settings.showRecommended);
 				jqToggleOther
 					.toggleClass("active", settings.showOtherShips);
+
+				jqCloseToRemLvlDiff.val( settings.closeToRemodelLevelDiff );
 			}
 
 			updateUI();
@@ -138,11 +142,40 @@
 				self.modifySettings( negateField("showOtherShips") );
 				updateUI();
 			});
+			jqCloseToRemLvlDiff
+				.on("blur", function() {
+					var jqObj = $(this);
+					var settings = self.getSettings();
+					var newInp = parseInt(jqObj.val(), 10);
+					if (!newInp) {
+						// restore option when the input isn't valid
+						jqObj.val( settings.closeToRemodelLevelDiff );
+						return;
+					} else {
+						self.modifySettings( function(settings) {
+							settings.closeToRemodelLevelDiff = newInp;
+							return settings;
+						});
+						updateUI();
+						$(".btn_hl_close_to_remodel").click();
+					}
+				})
+				.on("keydown", function(e) {
+					// disable tab otherwise UI might be ruined
+					if (e.which === 9)
+						e.preventDefault();
+
+					// give up focus when hitting enter
+					// so that "blur" event can be triggered.
+					if (e.which === 13) {
+						this.blur();
+						e.preventDefault();
+					}
+				});
 		},
 
 		configHighlightToggles: function() {
 			var self = this;
-
 			// show Close To Remodel options should be shown only when
 			// this button is clicked. If user clears all highlights
 			// or want to show other kinds of highlights, we hide the option again.
@@ -164,6 +197,7 @@
 			});
 			$(".btn_hl_close_to_remodel").on("click", function() {
 				$(".box_control_line.line_close_to_remodel").show();
+				var settings = self.getSettings();
 				$(".section_body .ship_goal").each( function(i,x) {
 					var jqObj = $(x);
 					clearHighlight(jqObj);
@@ -177,7 +211,7 @@
 
 					if (goalLevel === false || goalLevel >= 99)
 						return;
-					if (goalLevel - ThisShip.level <= ConfigManager.sr_lvl_difference) {
+					if (goalLevel - ThisShip.level <= settings.closeToRemodelLevelDiff ) {
 						jqObj.addClass("highlight_closeToRemodel");
 					}
 				});
@@ -192,10 +226,6 @@
 					if (ThisShip.masterId === 0)
 						return;
 					var nextLevels = RemodelDb.nextLevels( ThisShip.masterId );
-					if (ThisShip.masterId == 184 && ThisShip.level === 100) {
-						
-						console.log("here", nextLevels,!RemodelDb.isFinalForm(ThisShip.masterId) );
-					}
 					// If can be remodelled (without convert remodels)
 					if (nextLevels !== false &&
 						nextLevels.length > 0 &&

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -117,27 +117,25 @@
 			}
 
 			updateUI();
+			function negateField(field) {
+				return function(obj) {
+					// well, make sure not to use old obj afterwards.
+					obj[field] = !obj[field];
+					return obj;
+				};
+			}
 
 			jqToggleGT.on("click", function() {
-				self.modifySettings( function(settings) {
-					settings.showGoalTemplates = !settings.showGoalTemplates;
-					return settings;
-				});
+				self.modifySettings( negateField("showGoalTemplates") );
 				updateUI();
 			});
 			jqToggleRecom.on("click", function() {
-				self.modifySettings( function(settings) {
-					settings.showRecommended = !settings.showRecommended;
-					return settings;
-				});
+				self.modifySettings( negateField("showRecommended") );
 				updateUI();
 			});
 
 			jqToggleOther.on("click", function() {
-				self.modifySettings( function(settings) {
-					settings.showOtherShips = !settings.showOtherShips;
-					return settings;
-				});
+				self.modifySettings( negateField("showOtherShips") );
 				updateUI();
 			});
 		},

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -484,9 +484,14 @@
 
 			// This has just been added, no grinding data yet, initialize defaults
 			if(grindData.length === 0){
+				var goalLevel = self.computeNextLevel( ThisShip.masterId, ThisShip.level );
+				// if we ever want to run "recompute" on any ship, that particular ship
+				// should have already been added in this tab (those locked but have not yet reached Lv 155) 
+				// in the first place.
+				console.assert( goalLevel !== false, "targeting ship that has no goal?" );
 				// As much as possible use arrays nowadays to shrink JSON size, we might run out of the 5MB localStorage allocated for our app
 				grindData = [
-					/*0*/ (MasterShip.api_aftershipid > 0 && ThisShip.level<MasterShip.api_afterlv)?MasterShip.api_afterlv:(ThisShip.level<99)?99:155, // target level
+					/*0*/ goalLevel, // target level
 					/*1*/ 1, // world
 					/*2*/ 1, // map
 					/*3*/ 1, // node

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -420,8 +420,6 @@
 					ThisShip.level >= ThisShip.master().api_afterlv &&
 					!RemodelDb.isFinalForm(ThisShip.masterId)){
 					goalBox.addClass("ship_canBeRemodelled");
-					// goalBox.addClass("should_blink");
-					// goalBox.addClass("hl_enabled");
 				}
 
 				// If next remodel lvl is greater then current, add to recommendations
@@ -434,7 +432,6 @@
 					if(ThisShip.master().api_afterlv - ThisShip.level > 0 &&
 						ThisShip.master().api_afterlv - ThisShip.level <= ConfigManager.sr_lvl_difference){
 						goalBox.addClass("ship_closeToRemodel");
-						// goalBox.addClass("should_blink");
 					}
 					return true;
 				}

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -60,12 +60,8 @@
 			setAdd(possibleNextLevels, 99);
 			setAdd(possibleNextLevels, 155);
 
-			if (masterId == 171)
-				console.log( possibleNextLevels );
 			while (possibleNextLevels.length > 0 && possibleNextLevels[0] <= currentLevel)
 				possibleNextLevels.shift();
-			if (masterId == 171)
-				console.log( possibleNextLevels );
 
 			return possibleNextLevels.length > 0 ? possibleNextLevels[0] : false;
 		},
@@ -382,6 +378,32 @@
 			// Remove from Goals Button
 			$(".section_expcalc").on("click", ".ship_rem", function(){
 				editingBox = $(this).parent();
+
+				var ShipRosterId = editingBox.data("id");
+				var ThisShip = KC3ShipManager.get(ShipRosterId);
+				var nextLevel = self.computeNextLevel( ThisShip.masterId, ThisShip.level );
+
+				var curGoal = self.goals["s"+ ShipRosterId];
+				// when the ship can still be remodelled further
+				// and the current goal set is fewer than that,
+				// we can ask user whether he wants to update the goal level
+				// instead of removing this goal.
+				if (nextLevel < 99
+					&& typeof curGoal !== "undefined"
+					&& curGoal[0] < nextLevel) {
+
+					var resp = confirm(
+						"Would you like to change your leveling goal for " +
+						ThisShip.name() + " (" + ShipRosterId + ") to level " +
+					    nextLevel + "?");
+					if (resp) {
+						self.goals["s"+ ShipRosterId][0] = nextLevel;
+						self.save();
+						self.recompute( ThisShip.rosterId );
+						return true;
+					}
+				}
+				
 				delete self.goals["s"+ editingBox.data("id") ];
 				self.save();
 				//window.location.reload();
@@ -390,8 +412,6 @@
 				$(".ship_edit", editingBox).hide();
 				$(".ship_rem", editingBox).hide();
 				editingBox.addClass("inactive");
-				var ThisShip = KC3ShipManager.get(editingBox.data("id"));
-				var nextLevel = self.computeNextLevel( ThisShip.masterId, ThisShip.level );
 
 				// the only can when nextLevel === false is when your ship have reached Lv.155
 				if (nextLevel === false)
@@ -455,8 +475,6 @@
 				var goalLevel = self.computeNextLevel( ThisShip.masterId, ThisShip.level );
 				if (goalLevel === false)
 					return true;
-
-				console.log( ThisShip.name(), goalLevel );
 
 				$(".ship_target .ship_value", goalBox).text( goalLevel );
 				if (goalLevel < 99) {

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -391,11 +391,17 @@
 				$(".ship_rem", editingBox).hide();
 				editingBox.addClass("inactive");
 				var ThisShip = KC3ShipManager.get(editingBox.data("id"));
-				if(ThisShip.master().api_aftershipid > 0 && ThisShip.level<ThisShip.master().api_afterlv){
+				var nextLevel = self.computeNextLevel( ThisShip.masterId, ThisShip.level );
+
+				// the only can when nextLevel === false is when your ship have reached Lv.155
+				if (nextLevel === false)
+					return;
+
+				if (nextLevel < 99) {
 					$(".section_expcalc .box_recommend .clear").remove();
 					editingBox.appendTo(".section_expcalc .box_recommend");
 					$("<div />").addClass("clear").appendTo(".section_expcalc .box_recommend");
-				}else{
+				} else {
 					$(".section_expcalc .box_other .clear").remove();
 					editingBox.appendTo(".section_expcalc .box_other");
 					$("<div />").addClass("clear").appendTo(".section_expcalc .box_other");
@@ -424,7 +430,7 @@
 				$(".ship_type", goalBox).text( ThisShip.stype() );
 				$(".ship_lv .ship_value", goalBox).text( ThisShip.level );
 
-				// If ship already on the current goals
+				// If ship is already one of the current goals
 				if(typeof self.goals["s"+ThisShip.rosterId] != "undefined"){
 					$(".ship_edit", goalBox).show();
 					$(".ship_rem", goalBox).show();
@@ -437,9 +443,11 @@
 				goalBox.addClass("inactive");
 
 				// If can be remodelled (without convert remodels)
-				if(ThisShip.master().api_aftershipid > 0 &&
-					ThisShip.level >= ThisShip.master().api_afterlv &&
-					!RemodelDb.isFinalForm(ThisShip.masterId)){
+				var nextLevels = RemodelDb.nextLevels( ThisShip.masterId );
+				if (nextLevels !== false &&
+					nextLevels > 0 &&
+					!RemodelDb.isFinalForm(ThisShip.masterId) &&
+					nextLevels[0] < ThisShip.level) {
 					goalBox.addClass("ship_canBeRemodelled");
 				}
 
@@ -486,10 +494,11 @@
 			if(grindData.length === 0){
 				var goalLevel = self.computeNextLevel( ThisShip.masterId, ThisShip.level );
 				// if we ever want to run "recompute" on any ship, that particular ship
-				// should have already been added in this tab (those locked but have not yet reached Lv 155) 
-				// in the first place.
+				// should have already been added in this tab 
+				// (those locked but have not yet reached Lv 155) in the first place.
 				console.assert( goalLevel !== false, "targeting ship that has no goal?" );
-				// As much as possible use arrays nowadays to shrink JSON size, we might run out of the 5MB localStorage allocated for our app
+				// As much as possible use arrays nowadays to shrink JSON size,
+				// we might run out of the 5MB localStorage allocated for our app
 				grindData = [
 					/*0*/ goalLevel, // target level
 					/*1*/ 1, // world

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -49,6 +49,27 @@
 			KC3ShipManager.load();
 		},
 
+		computeNextLevel: function(masterId, currentLevel) {
+			function setAdd(arr,x) {
+				if (arr.indexOf(x) === -1)
+					arr.push(x);
+			}
+			// figure out a list of possible goal levels in ascending order.
+			// a goal level might be remodel level or 99 (can be married) / 155 (full exp)
+			var possibleNextLevels = RemodelDb.nextLevels( masterId );
+			setAdd(possibleNextLevels, 99);
+			setAdd(possibleNextLevels, 155);
+
+			if (masterId == 171)
+				console.log( possibleNextLevels );
+			while (possibleNextLevels.length > 0 && possibleNextLevels[0] <= currentLevel)
+				possibleNextLevels.shift();
+			if (masterId == 171)
+				console.log( possibleNextLevels );
+
+			return possibleNextLevels.length > 0 ? possibleNextLevels[0] : false;
+		},
+
 		/* EXECUTE
 		Places data onto the interface
 		---------------------------------*/
@@ -422,27 +443,26 @@
 					goalBox.addClass("ship_canBeRemodelled");
 				}
 
-				// If next remodel lvl is greater then current, add to recommendations
-				if(ThisShip.master().api_aftershipid > 0 &&
-					ThisShip.level < ThisShip.master().api_afterlv){
-					$(".ship_target .ship_value", goalBox).text( ThisShip.master().api_afterlv );
-					goalBox.appendTo(".section_expcalc .box_recommend");
+				// If next remodel lvl is greater than current, add to recommendations
+				var goalLevel = self.computeNextLevel( ThisShip.masterId, ThisShip.level );
+				if (goalLevel === false)
+					return true;
 
-					//If is close to remodel
-					if(ThisShip.master().api_afterlv - ThisShip.level > 0 &&
-						ThisShip.master().api_afterlv - ThisShip.level <= ConfigManager.sr_lvl_difference){
+				console.log( ThisShip.name(), goalLevel );
+
+				$(".ship_target .ship_value", goalBox).text( goalLevel );
+				if (goalLevel < 99) {
+					goalBox.appendTo(".section_expcalc .box_recommend");
+					// If is close to remodel
+					if(goalLevel - ThisShip.level <= ConfigManager.sr_lvl_difference) { 
 						goalBox.addClass("ship_closeToRemodel");
 					}
 					return true;
+				} else {
+					goalBox.appendTo(".section_expcalc .box_other");
+					return true;
 				}
 
-				// If this is the last remodel stage, add to others
-				if(ThisShip.level<99){
-					$(".ship_target .ship_value", goalBox).text( 99 );
-				}else{
-					$(".ship_target .ship_value", goalBox).text( 155 );
-				}
-				goalBox.appendTo(".section_expcalc .box_other");
 			});
 
 			//this.save();

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -83,9 +83,17 @@
 			return settings;
 		},
 
+		// settingModifier( oldSettings ) should return the new settings object.
+		// feel free to change fields in oldSettings in order to make the new one.
+		modifySettings: function(settingModifier) {
+			var newSettings = settingModifier(this.getSettings());
+			localStorage.srExpcalc = JSON.stringify( newSettings );
+			return newSettings;
+		},
+
 		configSectionToggles: function() {
 			var self = this;
-			var settings = self.getSettings();
+
 			var jqGoalTemplates = $(".gt_content");
 			var jqRecommended = $(".recom_content");
 			var jqOtherShips = $(".other_content");
@@ -94,41 +102,44 @@
 			var jqToggleRecom = $(".toggle_recommended");
 			var jqToggleOther = $(".toggle_other_ships");
 
-			jqGoalTemplates.toggle( settings.showGoalTemplates );
-			jqRecommended.toggle( settings.showRecommended );
-			jqOtherShips.toggle( settings.showOtherShips );
+			function updateUI() {
+				var settings = self.getSettings();
+				jqGoalTemplates.toggle( settings.showGoalTemplates );
+				jqRecommended.toggle( settings.showRecommended );
+				jqOtherShips.toggle( settings.showOtherShips );
 
-			jqToggleGT
-				.toggleClass("active", settings.showGoalTemplates)
-				.on("click", function() {
-					var settings = self.getSettings();
+				jqToggleGT
+					.toggleClass("active", settings.showGoalTemplates);
+				jqToggleRecom
+					.toggleClass("active", settings.showRecommended);
+				jqToggleOther
+					.toggleClass("active", settings.showOtherShips);
+			}
+
+			updateUI();
+
+			jqToggleGT.on("click", function() {
+				self.modifySettings( function(settings) {
 					settings.showGoalTemplates = !settings.showGoalTemplates;
-					localStorage.srExpcalc = JSON.stringify(settings);
-					jqGoalTemplates.toggle( settings.showGoalTemplates );
-					jqToggleGT
-						.toggleClass("active", settings.showGoalTemplates);
+					return settings;
 				});
-			jqToggleRecom
-				.toggleClass("active", settings.showRecommended)
-				.on("click", function() {
-					var settings = self.getSettings();
+				updateUI();
+			});
+			jqToggleRecom.on("click", function() {
+				self.modifySettings( function(settings) {
 					settings.showRecommended = !settings.showRecommended;
-					localStorage.srExpcalc = JSON.stringify(settings);
-					jqRecommended.toggle( settings.showRecommended );
-					jqToggleRecom
-						.toggleClass("active", settings.showRecommended);
+					return settings;
 				});
+				updateUI();
+			});
 
-			jqToggleOther
-				.toggleClass("active", settings.showOtherShips)
-				.on("click", function() {
-					var settings = self.getSettings();
+			jqToggleOther.on("click", function() {
+				self.modifySettings( function(settings) {
 					settings.showOtherShips = !settings.showOtherShips;
-					localStorage.srExpcalc = JSON.stringify(settings);
-					jqOtherShips.toggle( settings.showOtherShips );
-					jqToggleOther
-						.toggleClass("active", settings.showOtherShips);
+					return settings;
 				});
+				updateUI();
+			});
 		},
 
 		/* EXECUTE

--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -65,7 +65,7 @@
 
 			return possibleNextLevels.length > 0 ? possibleNextLevels[0] : false;
 		},
-		
+
 		getSettings: function() {
 			var defSettings = {
 				showGoalTemplates: true,
@@ -130,14 +130,14 @@
 						.toggleClass("active", settings.showOtherShips);
 				});
 		},
-		
+
 		/* EXECUTE
 		Places data onto the interface
 		---------------------------------*/
 		execute :function(){
 			var self = this;
 			self.configSectionToggles();
-		
+
 			// Add map list into the factory drop-downs
 			$.each(this.maplist, function(MapName, MapExp){
 				$(".tab_expcalc .factory .ship_map select").append("<option>"+MapName+"</option>");
@@ -392,9 +392,9 @@
 					if (GoalTemplateManager.checkShipType(stypeId, template))
 						targetShips.push( {
 							rosterId: rosterId,
-							shipDesc: 
-                              ThisShip.name() + " Lv." + ThisShip.level +
-                                " (" + rosterId + ")"
+							shipDesc:
+							  ThisShip.name() + " Lv." + ThisShip.level +
+								" (" + rosterId + ")"
 						}  );
 				});
 
@@ -462,7 +462,7 @@
 					var resp = confirm(
 						"Would you like to change your leveling goal for " +
 						ThisShip.name() + " (" + ShipRosterId + ") to level " +
-					    nextLevel + "?");
+						nextLevel + "?");
 					if (resp) {
 						self.goals["s"+ ShipRosterId][0] = nextLevel;
 						self.save();
@@ -470,7 +470,7 @@
 						return true;
 					}
 				}
-				
+
 				delete self.goals["s"+ editingBox.data("id") ];
 				self.save();
 				//window.location.reload();
@@ -547,7 +547,7 @@
 				if (goalLevel < 99) {
 					goalBox.appendTo(".section_expcalc .box_recommend");
 					// If is close to remodel
-					if(goalLevel - ThisShip.level <= ConfigManager.sr_lvl_difference) { 
+					if(goalLevel - ThisShip.level <= ConfigManager.sr_lvl_difference) {
 						goalBox.addClass("ship_closeToRemodel");
 					}
 					return true;
@@ -579,7 +579,7 @@
 			if(grindData.length === 0){
 				var goalLevel = self.computeNextLevel( ThisShip.masterId, ThisShip.level );
 				// if we ever want to run "recompute" on any ship, that particular ship
-				// should have already been added in this tab 
+				// should have already been added in this tab
 				// (those locked but have not yet reached Lv 155) in the first place.
 				console.assert( goalLevel !== false, "targeting ship that has no goal?" );
 				// As much as possible use arrays nowadays to shrink JSON size,


### PR DESCRIPTION
few improvements on leveling tab, also close #1445 

- remove blinking animation
- let RemodelDb help with goal level recommendation

    this makes it possible to do things like recommending Lv 78 as a goal for Souryuu on Lv 31 
    (you could have remodelled  Souryu to Souryuu Kai at Lv 30,
    but in current master branch when the level goes beyond 30 there's no more recommendation)

- suggest updating current goal instead of removing a completed goal

    when user is removing goals for ships that have not yet reached their final form,
    pop up a dialog to ask user if they want to update goal to next recommended level
    instead of removing the goal.
    (example: removing Souryuu on Lv 31 when the goal level was Lv 30, ask user if they'd like
    to change the goal to Lv 78)

- highlight color improvement (make color of close-to-remodel and can-be-remodelled different)

- controls on top for showing/hiding sections and turning different kinds of highlight on/off

- ~~provide a way to hide Lv 99 goals~~
    (I think hiding "Other Ships" section is in some sense an alternative solution already)

- make highlight mutually exclusive
    at most one kind of highlight at a time, as there are ships that satisfy more than
    one highlight condition, we'll have conflicts if all kinds of highlights are shown.

- close-to-model level difference setting is now moved to expcalc tab
    the setting is only visible when "Close To Remodel" is clicked

- give a better look to "New template" button