### PR TITLE
Optimize menu: show instantly

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,8 @@ module.exports = function(grunt) {
 					'assets/js/twbsPagination.min.js',
 					'assets/js/WhoCallsTheFleetShipDb.json',
 					'assets/js/jszip.min.js',
-					'assets/js/bootstrap-slider.min.js'
+					'assets/js/bootstrap-slider.min.js',
+					'assets/js/no_ga.js'
 				],
 				dest: 'build/release/'
 			},

--- a/src/assets/js/global.js
+++ b/src/assets/js/global.js
@@ -3,13 +3,15 @@
 \*******************************/
 /* GOOGLE ANALYTICS
 -------------------------------*/
-var _gaq = _gaq || [];
-_gaq.push(['_setAccount', 'UA-9789944-12']);
-(function() {
-	var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-	ga.src = 'https://ssl.google-analytics.com/ga.js';
-	var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-})();
+if (typeof NO_GA == "undefined") {
+	var _gaq = _gaq || [];
+	_gaq.push(['_setAccount', 'UA-9789944-12']);
+	(function() {
+		var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+		ga.src = 'https://ssl.google-analytics.com/ga.js';
+		var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+	})();
+}
 
 /*
  * Date Format 1.2.3

--- a/src/assets/js/no_ga.js
+++ b/src/assets/js/no_ga.js
@@ -1,0 +1,1 @@
+var NO_GA = true;

--- a/src/pages/popup/popup.html
+++ b/src/pages/popup/popup.html
@@ -91,13 +91,13 @@
 						<input type="hidden" name="cmd" value="_s-xclick">
 						<input type="hidden" name="hosted_button_id" value="P7USFE8PKSGJL">
 						<input type="image" src="../../assets/img/ui/donate.png" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-						<img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
 					</form>
 				</div>
 				<div class="footLink" id="foot-servers"><em><a href="https://github.com/KC3Kai/kc3-website" target="_blank">for KC3 servers</a></em></div>
 			</div>
 		</div>
 		
+		<script type="text/javascript" src="../../assets/js/no_ga.js"></script>
 		<script type="text/javascript" src="../../assets/js/global.js"></script>
 		<!-- @buildimportjs ../../library/objects.js -->
 		<!-- @buildimportjs ../../library/managers.js -->

--- a/src/pages/popup/popup.js
+++ b/src/pages/popup/popup.js
@@ -1,6 +1,5 @@
 (function(){
 	"use strict";
-	_gaq.push(['_trackPageview']);
 	
 	var myVersion = chrome.runtime.getManifest().version;
 	


### PR DESCRIPTION
* Removed Google Analytics from Popup Menu (Gold Heart icon)
  * Having GA there loads an external file which waits to be loaded before menu is shown. This makes is very long to show up for those with slower internet
  * Having GA tracking on the menu breaks our average session time metric since menu is tracked but is opened and closed in a short period
* Removed Paypal pixel that is an external link, and will wait or it to be loaded before menu is shown. This won't be the case anymore.