### PR TITLE
Prevent a call stack overflow when Math.stdev is called with too many arguments

### DIFF
--- a/src/assets/js/global.js
+++ b/src/assets/js/global.js
@@ -655,15 +655,26 @@ String.prototype.hashCode = function() {
  - Population based deviation
 -------------------------------*/
 Math.stdev  = function(p1f /*, data*/){
-	var args = [].map.call(arguments,function(val){
+	// obtain a real array for carrying data
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments
+	var data = Array.prototype.slice.call( arguments );
+	if(typeof p1f === 'boolean') {
+		data.splice(0,1);
+	} else {
+		p1f = false;
+	}
+	// special handling for cases:
+	// * Math.stdev( <bool>, <an array object> )
+	// * Math.stdev( <an array object> )
+	if (data.length > 0 && (data[0] instanceof Array)) {
+		if (data.length !== 1)
+			throw "Math.stdev called with unexpected form";
+		data = data[0];
+	}
+	var args = [].map.call(data,function(val){
 		return Number(val);
 	});
-	if(typeof p1f !== 'boolean') {
-		p1f = false;
-	} else {
-		args.splice(0,1);
-	}
-	
+
 	if(args.length <= 0)
 		return 0;
 

--- a/src/assets/js/global.js
+++ b/src/assets/js/global.js
@@ -37,29 +37,29 @@ var dateFormat = function () {
 			while (val.length < len) val = "0" + val;
 			return val;
 		};
-	
+
 	// Regexes and supporting functions are cached through closure
 	return function (date, mask, utc) {
 		var dF = dateFormat;
-		
+
 		// You can't provide utc if you skip other args (use the "UTC:" mask prefix)
 		if (arguments.length == 1 && Object.prototype.toString.call(date) == "[object String]" && !/\d/.test(date)) {
 			mask = date;
 			date = undefined;
 		}
-		
+
 		// Passing date through Date applies Date.parse, if necessary
 		date = date ? new Date(date) : new Date();
 		if (isNaN(date)) throw SyntaxError("invalid date");
-		
+
 		mask = String(dF.masks[mask] || mask || dF.masks["default"]);
-		
+
 		// Allow setting the utc argument via the mask
 		if (mask.slice(0, 4) == "UTC:") {
 			mask = mask.slice(4);
 			utc = true;
 		}
-		
+
 		var _ = utc ? "getUTC" : "get",
 			d = date[_ + "Date"](),
 			D = date[_ + "Day"](),
@@ -230,13 +230,13 @@ String.prototype.toHHMMSS = function () {
 		time = "--:--:--";
 	} else {
 		var isNeg   = sec_num < 0;
-		
+
 		if(isNeg) sec_num = -sec_num;
-		
+
 		var hours   = (Math.floor(sec_num / 3600)).toDigits(2);
 		var minutes = (Math.floor((sec_num - (hours * 3600)) / 60)).toDigits(2);
 		var seconds = (sec_num - (hours * 3600) - (minutes * 60)).toDigits(2);
-		
+
 		time    = (isNeg ? "-" : "")+hours+':'+minutes+':'+seconds;
 	}
 	return time;
@@ -246,11 +246,11 @@ String.prototype.toHHMMSS = function () {
 -------------------------------*/
 String.prototype.plusCurrentTime = function() {
 	var currentTime = new Date();
-	var secondsAfterMidnight = 
+	var secondsAfterMidnight =
 		3600 * currentTime.getHours() +
 		60   * currentTime.getMinutes() +
 		       currentTime.getSeconds();
-		
+
 	var secondsRemaining = parseInt(this, 10);
 	var timeFinished = (secondsAfterMidnight + secondsRemaining) % 86400;
 	return String(timeFinished).toHHMMSS();
@@ -287,17 +287,17 @@ String.prototype.hashCode = function() {
 		bRight = parseInt(bRight,10);
 		iLeft  = typeof iLeft  == 'undefined' ? true : !!iLeft;
 		iRight = typeof iRight == 'undefined' ? true : !!iRight;
-		
+
 		bLeft  = isNaN(bLeft)  ? -Infinity : bLeft ;
 		bRight = isNaN(bRight) ? +Infinity : bRight;
-		
+
 		if(bLeft > bRight) { return this.inside(bRight,bLeft,iRight,iLeft); }
 		return (
 			(iLeft  ? this >= bLeft  : this > bLeft ) &&
 			(iRight ? this <= bRight : this < bRight)
 		);
 	};
-	
+
 	/* Number Padding
 	 * Supplied Argument:
 	 * <Optional> Digits (any invalid value / less than 1, forced to 1)
@@ -327,7 +327,7 @@ String.prototype.hashCode = function() {
 		sgnArray : ['-','','+'],
 		metPrefx : ['','k','M','G','T','P','E','Z','Y']
 	};
-	
+
 	Number.prototype.shorten = function(decimals) {
 		var ret = this.toString();
 		try{
@@ -342,10 +342,10 @@ String.prototype.hashCode = function() {
 					sgof = shorten.expRegex.exec(this.toExponential()),
 					sgch = shorten.sgnArray.indexOf(sgof[1]) - 1,
 					udfg = sgof[3] == '-';
-				
+
 				if (!isFinite(decimals)) { decimals = undefined; }
 				decimals = Math.min(Math.max(decimals || 1,1),3);
-				
+
 				if(ret == this.toExponential()){
 					throw [sgch < 0 ? "Ng" : "Ps",(udfg ? 'Under' : 'Over') + 'flow'].join(' ');
 				} else {
@@ -392,7 +392,7 @@ String.prototype.hashCode = function() {
 					if (!array)
 						return false;
 
-					// compare lengths - can save a lot of time 
+					// compare lengths - can save a lot of time
 					if (this.length != array.length)
 						return false;
 
@@ -411,7 +411,7 @@ String.prototype.hashCode = function() {
 				},
 				configurable:true
 			},
-			
+
 			/*
 				Fill method polyfill
 				https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/fill
@@ -422,21 +422,21 @@ String.prototype.hashCode = function() {
 					if (this === null) {
 						throw new TypeError('this is null or not defined');
 					}
-					
+
 					var O = Object(this);
-					
+
 					// Steps 3-5.
 					var len = O.length >>> 0;
-					
+
 					// Steps 6-7.
 					var start = arguments[1];
 					var relativeStart = start >> 0;
-					
+
 					// Step 8.
 					var k = relativeStart < 0 ?
 						Math.max(len + relativeStart, 0) :
 						Math.min(relativeStart, len);
-					
+
 					// Steps 9-10.
 					var end = arguments[2];
 					var relativeEnd = end === undefined ?
@@ -459,7 +459,7 @@ String.prototype.hashCode = function() {
 				configurable:true
 			},
 		};
-	
+
 	Object.keys(over).forEach((function(method){
 		over[method][(!this.prototype[method])>>0].call(this);
 	}).bind(this));
@@ -478,26 +478,26 @@ String.prototype.hashCode = function() {
 		},[[],[]]),
 		ResetableKeys = ['Milliseconds', 'Seconds','Minutes','Hours','Date','Month'],
 		ShiftableKeys = ResetableKeys.concat(['FullYear']);
-	
+
 	function shiftTime(key,step,clear,offset) {
 		var self = this;
-		
+
 		if(ShiftableKeys.indexOf(key) < 0) {
 			console.log(arguments);
 			throw new Error("Cannot shift invalid time key ("+key+")");
 		}
-		
+
 		clear  = !!clear;
 		step   = parseInt(step,10);
 		step   = (!isNaN(step) && isFinite(step)) ? (step+clear) : 1;
 		offset = $.extend({},offset);
-		
+
 		var ki = ShiftableKeys.indexOf(key);
-		
+
 		if(clear) {
 			this.resetTime(ResetableKeys.filter(function(k,i){return i < ki;}));
 		}
-		
+
 		Object.keys(offset).forEach(function(k){
 			if(ResetableKeys.indexOf(k) < ki &&
 				['number','string'].some(function(desiredType){
@@ -507,17 +507,17 @@ String.prototype.hashCode = function() {
 				offset[k] = parseInt(offset[k],10);
 				if(isNaN(offset[k]) || !isFinite(offset[k]))
 					return false;
-				
+
 				self['setUTC'+k](self['getUTC'+k]()+(offset[k]));
 			} else {
 				delete offset.k;
 			}
 		});
-		
+
 		this['setUTC'+key](this['getUTC'+key]()+(step));
 		return this;
 	}
-	
+
 	Object.defineProperties(Date.prototype,{
 		format: { value: function format(mask, utc) {
 			return dateFormat(this, mask, utc);
@@ -535,14 +535,14 @@ String.prototype.hashCode = function() {
 				var args = Array.apply(null,arguments);
 				lookType = parseInt(lookType,10);
 				lookType = isFinite(lookType) && lookType || 0;
-				
+
 				switch(typeof target){
 					case 'number':
 						var check = WeekStrings.map(function(array){return array[target];})
 							.filter(function(value){return typeof value == 'string';}).pop();
 						if(typeof check !== 'undefined') {
 							// Correct index detection
-							
+
 						} else {
 							// Invalid index detection
 							throw new RangeError(["Invalid range (",String(target),")"].join(''));
@@ -558,14 +558,14 @@ String.prototype.hashCode = function() {
 							args[0] = undefined;
 							return this.shiftWeek.apply(this,args);
 						}
-						
+
 						var checkKey = parseInt(target,10);
 						if(!isNaN(checkKey)) {
 							// Number (on string) detection
 							args[0] = checkKey;
 							return this.shiftWeek.apply(this,args);
 						}
-						
+
 						// Any type detection
 						checkKey = WeekStrings.filter(function(array){return array.indexOf(target)>=0;}).pop();
 						if(typeof checkKey === 'undefined') {
@@ -576,23 +576,23 @@ String.prototype.hashCode = function() {
 						}
 					break;
 				}
-				
+
 				calibr = (target - this.getDay());
 				// Adjust calibrator boundary
 				while(calibr >  3 && lookType <= 0) calibr -= 7;
 				while(calibr < -3 && lookType >= 0) calibr += 7;
 				calibr -= parseInt(calibr / 7,10) * 7 * Math.sign(lookType);
-				
+
 				args.splice(0,2);
-				
+
 				step = parseInt(step,10);
 				if(isNaN(step) || !isFinite(step))
 					step = 0;
-				
+
 				/*
 				  UTCD DATE CALB
-					 20   21   -1 
-					  2    1   +1 
+					 20   21   -1
+					  2    1   +1
 					  1   30  -29? => +1
 					 31    1  +30? => -1
 				*/
@@ -607,7 +607,7 @@ String.prototype.hashCode = function() {
 			var
 				self = this,
 				cFunc = function(){return false;};
-			
+
 			switch(typeof clearTable) {
 				case 'number':
 				case 'string':
@@ -615,7 +615,7 @@ String.prototype.hashCode = function() {
 					// Invalid >> pick all elements
 					clearTable = parseInt(clearTable,10);
 					clearTable = ((clearTable >= 0) && !isNaN(clearTable) && isFinite(clearTable) || ResetableKeys.length) && clearTable;
-					
+
 					// Provided String or Number ->
 					// Pick nth+1 elements from start
 					cFunc = function(x,i){
@@ -626,7 +626,7 @@ String.prototype.hashCode = function() {
 					// Pick any matching element from Resetable Array
 					// Invalid >> pick all elements
 					clearTable = ((typeof clearTable === 'object' && clearTable instanceof Array && clearTable) || ResetableKeys);
-					
+
 					// Provided Anything else
 					// Pick any element that match the clearTable data (either value or index)
 					// ['Seconds',2,3] => ['Seconds','Hours','Date']
@@ -635,9 +635,9 @@ String.prototype.hashCode = function() {
 					};
 					break;
 			}
-			
+
 			clearTable = ResetableKeys.filter(cFunc);
-			
+
 			clearTable.forEach(function(k){
 				self['setUTC' + k](k === 'Date' ? 1 : 0);
 			});
@@ -666,12 +666,12 @@ Math.stdev  = function(p1f /*, data*/){
 	
 	if(args.length <= 0)
 		return 0;
-	
+
 	var avg;
 	avg = args.reduce(function(cAve,nVal,nInd){
 		return ((cAve * nInd) + nVal) / (nInd + 1);
 	},0);
-	
+
 	return Math.sqrt(args.reduce(function(tDev,nVal,nInd){
 		return tDev + Math.pow(nVal - avg,2);
 	},0)/(args.length - !p1f));
@@ -687,7 +687,7 @@ Math.qckInt = function(command,value,rate,rev,magn) {
 	rate    = rate    || 0;
 	rev     = !rev;
 	magn    = !!magn;
-	
+
 	var shift = Math.pow(10,rate);
 	return (magn ? Math.sign(value) : 1) *
 		Math[command]((magn ? Math.abs(value) : value) * shift) / (rev ? shift : 1);
@@ -718,7 +718,7 @@ Storage.prototype.getObject = function(key) {
 (function(){
 	/*jshint: validthis true*/
 	Object.defineProperties(this.prototype,{
-		/* ELEMENT OVERFLOW CHECK 
+		/* ELEMENT OVERFLOW CHECK
 		------------------------------------ */
 		overflow:{
 			get:function(){ return this.overflowHorz || this.overflowVert; },
@@ -741,7 +741,7 @@ Storage.prototype.getObject = function(key) {
 \*******************************/
 (function(){
 	var base = Object.freeze([-Infinity,+Infinity,true,true]);
-	
+
 	function exclusiveClamp(rangeObj){
 		if(rangeObj instanceof Range) {
 			if(
@@ -754,7 +754,7 @@ Storage.prototype.getObject = function(key) {
 			return false;
 		}
 	}
-	
+
 	window.Range = function Range(b1,b2,i1,i2){
 		/*jshint: validthis true*/
 		if(!(this instanceof Range)){ return new Range(b1,b2,i1,i2); } else {
@@ -767,52 +767,52 @@ Storage.prototype.getObject = function(key) {
 				i2 = b2[1]; i1 = b2[0];
 				b2 = b1[1]; b1 = b1[0];
 			}
-			
+
 			b1 = parseInt(b1,10);
 			b2 = parseInt(b2,10);
 			i1 = typeof i1 == 'undefined' ? base[2] : !!i1;
 			i2 = typeof i2 == 'undefined' ? base[3] : !!i2;
-			
+
 			b1 = isNaN(b1) ? base[0] : b1;
 			b2 = isNaN(b2) ? base[1] : b2;
-			
+
 			if(b1 > b2){
 			// Swap bad ranges
 				var tp;
 				tp = b2; b2 = b1; b1 = tp;
 				tp = i2; i2 = i1; i1 = tp;
 			}
-			
+
 			Object.defineProperties(this,{
 				begin  :{get:function(){return b1;},set:function(v){v = parseInt(v,10); b1 = isNaN(v) ? base[0] : v;}},
 				end    :{get:function(){return b2;},set:function(v){v = parseInt(v,10); b2 = isNaN(v) ? base[1] : v;}},
 				inFirst:{get:function(){return i1;},set:function(v){v = !!v; i1 = v;}},
 				inLast :{get:function(){return i2;},set:function(v){v = !!v; i2 = v;}},
-				
+
 				first  :{get:function(){return this.begin;},set:function(v){this.begin=v;exclusiveClamp(this);}},
 				last   :{get:function(){return this.end  ;},set:function(v){this.end  =v;exclusiveClamp(this);}},
 			});
 		}
 	};
-	
+
 	Object.defineProperties(Range.prototype,{
 		begin    :{get:function(){return base[0];}},
 		first    :{get:function(){return base[0];}},
-		
+
 		last     :{get:function(){return base[1];}},
 		end      :{get:function(){return base[1];}},
-		
+
 		inFirst  :{get:function(){return !!base[2];}},
 		inLast   :{get:function(){return !!base[3];}},
-		
+
 		inside   :{value:function(x){return Number(x).inside(this);}},
 		exclusive:{value:function( ){return this.inFirst || this.inLast;}},
-		
+
 		0        :{get:function(){return this.begin;}  ,set:function(v){this.begin=v;}  },
 		1        :{get:function(){return this.end;}    ,set:function(v){this.end=v;}    },
 		2        :{get:function(){return this.inFirst;},set:function(v){this.inFirst=v;}},
 		3        :{get:function(){return this.inLast;} ,set:function(v){this.inLast=v;} },
-		
+
 		toJSON   :{value:function(){ return Array.apply(null,this); }},
 		toString :{value:function(){
 			return ("%L%B,%E%R")
@@ -822,6 +822,5 @@ Storage.prototype.getObject = function(key) {
 		valueOf  :{value:function(){return [this.begin,this.end,this.inFirst,this.inLast];}},
 		length   :{value:4}, // for array operation
 	});
-	
-})();
 
+})();

--- a/src/library/managers/PlayerManager.js
+++ b/src/library/managers/PlayerManager.js
@@ -7,7 +7,7 @@ Does not include Ships and Gears which are managed by other Managers
 */
 (function(){
 	"use strict";
-	
+
 	window.PlayerManager = {
 		hq: {},
 		consumables: {},
@@ -19,7 +19,7 @@ Does not include Ships and Gears which are managed by other Managers
 		buildSlots: 2,
 		combinedFleet: 0,
 		statistics: {},
-	
+
 		init :function(){
 			this.hq = new KC3Player();
 			this.consumables = {
@@ -43,7 +43,7 @@ Does not include Ships and Gears which are managed by other Managers
 				new KC3LandBase()
 			];
 		},
-		
+
 		setHQ :function( data ){
 			// Check if player suddenly changed
 			if(this.hq.id !== 0 && this.hq.id != data.mid){
@@ -54,7 +54,7 @@ Does not include Ships and Gears which are managed by other Managers
 			this.hq.update( data );
 			this.hq.save();
 		},
-		
+
 		setFleets :function( data ){
 			var self = this;
 			[0,1,2,3].forEach(function(i){
@@ -62,7 +62,7 @@ Does not include Ships and Gears which are managed by other Managers
 			});
 			localStorage.fleets = JSON.stringify(this.fleets);
 		},
-		
+
 		setBases :function( data ){
 			var self = this;
 			[0,1,2,3].forEach(function(i){
@@ -70,7 +70,7 @@ Does not include Ships and Gears which are managed by other Managers
 			});
 			localStorage.bases = JSON.stringify(self.bases);
 		},
-		
+
 		setRepairDocks :function( data ){
 			var lastRepair = this.repairShips.map(function(x){return x;}); // clone
 			this.repairShips.splice(0);
@@ -80,10 +80,10 @@ Does not include Ships and Gears which are managed by other Managers
 				if(lastRepair[ndock.api_id] != ndock.api_ship_id) { // check if not in the list (repaired)
 					KC3ShipManager.get(lastRepair[ndock.api_id]).applyRepair();
 				}
-				
+
 				if(ndock.api_state > 0){
 					self.repairShips[ ndock.api_id ] = ndock.api_ship_id;
-					var repairInfo = 
+					var repairInfo =
 						{ id: ndock.api_ship_id,
 						  completeTime: ndock.api_complete_time
 						};
@@ -140,7 +140,7 @@ Does not include Ships and Gears which are managed by other Managers
 				}
 			});
 		},
-		
+
 		setResources :function( data, stime ){
 			if(typeof localStorage.lastResource == "undefined"){ localStorage.lastResource = 0; }
 			var ResourceHour = Math.floor(stime/3600);
@@ -155,10 +155,10 @@ Does not include Ships and Gears which are managed by other Managers
 				hour : ResourceHour
 			});
 		},
-		
+
 		setConsumables :function( data, stime ){
 			$.extend(this.consumables, data);
-			
+
 			if(typeof localStorage.lastUseitem == "undefined"){ localStorage.lastUseitem = 0; }
 			var ResourceHour = Math.floor(stime/3600);
 			if(ResourceHour == localStorage.lastUseitem){ return false; }
@@ -171,7 +171,7 @@ Does not include Ships and Gears which are managed by other Managers
 				hour : ResourceHour
 			});
 		},
-		
+
 		setStatistics :function( data ){
 			var oldStatistics = JSON.parse(localStorage.statistics || "{\"exped\":{},\"pvp\":{},\"sortie\":{}}");
 			var newStatistics = {
@@ -205,7 +205,7 @@ Does not include Ships and Gears which are managed by other Managers
 			// console.log("rates", newStatistics.sortie.rate, newStatistics.pvp.rate, newStatistics.exped.rate);
 			localStorage.statistics = JSON.stringify(newStatistics);
 		},
-		
+
 		setNewsfeed :function( data, stime ){
 			//console.log("newsfeed", data);
 			$.each(data, function( index, element){
@@ -220,13 +220,13 @@ Does not include Ships and Gears which are managed by other Managers
 				}
 			});
 		},
-		
+
 		portRefresh :function( data ){
 			var
 				self      = this,
 				// get server time (as usual)
 				ctime     = Math.hrdInt("floor",(new Date(data.time)).getTime(),3,1);
-			
+
 			if(!(this.hq.lastPortTime && this.hq.lastMaterial)) {
 				if(!this.hq.lastPortTime)
 					this.hq.lastPortTime = ctime;
@@ -234,9 +234,9 @@ Does not include Ships and Gears which are managed by other Managers
 					this.hq.lastMaterial = data.matAbs;
 				return false;
 			}
-			
+
 			this.fleets.forEach(function(fleet){ fleet.checkAkashi(); });
-			
+
 			var
 				// get current player regen cap
 				regenCap  = this.hq.getRegenCap(),
@@ -267,10 +267,10 @@ Does not include Ships and Gears which are managed by other Managers
 				data:regenVal.concat([0,0,0,0])
 			});
 			this.hq.lastMaterial = data.matAbs || this.hq.lastMaterial;
-			
+
 			this.hq.save();
 		},
-		
+
 		loadFleets :function(){
 			if(typeof localStorage.fleets != "undefined"){
 				var oldFleets =JSON.parse( localStorage.fleets );
@@ -279,7 +279,7 @@ Does not include Ships and Gears which are managed by other Managers
 				});
 			}
 		},
-		
+
 		loadBases :function(){
 			if(typeof localStorage.bases != "undefined"){
 				var oldBases = JSON.parse( localStorage.bases );
@@ -298,5 +298,5 @@ Does not include Ships and Gears which are managed by other Managers
 		}
 		
 	};
-	
+
 })();

--- a/src/pages/strategy/tabs/docking/docking.js
+++ b/src/pages/strategy/tabs/docking/docking.js
@@ -26,7 +26,7 @@
 			// in order to get more up-to-date info
 			// we need to refresh the Ship Manager
 			KC3ShipManager.load();
-			
+
 			var ctr, ThisShip, MasterShip, ThisShipData;
 			this.shipCache = [];
 			for(ctr in KC3ShipManager.list){
@@ -193,11 +193,11 @@
 					case "hp": returnVal = b.hp	 - a.hp; break;
 					case "status": returnVal = a.hp / a.maxhp  - b.hp / b.maxhp; break;
 					case "repair_docking":
-						returnVal = b.repairDocking - a.repairDocking; 
+						returnVal = b.repairDocking - a.repairDocking;
 						if (returnVal === 0 || (!isFinite(a.repairDocking) && !isFinite(b.repairDocking)))
 							returnVal = b.repairAkashi - a.repairAkashi;
 						break;
-					case "repair_akashi": 
+					case "repair_akashi":
 						returnVal = b.repairAkashi - a.repairAkashi;
 						if (returnVal === 0 || (!isFinite(a.repairAkashi) && !isFinite(b.repairAkashi)))
 							returnVal = b.repairDocking - a.repairDocking;
@@ -231,7 +231,7 @@
 
 					var hpStatus = cShip.hp.toString() + " / " + cShip.maxhp.toString();
 					$(".ship_status", cElm).text( hpStatus );
-					
+
 					$(".ship_hp_val", cElm).css("width", parseInt(cShip.hp/cShip.maxhp*100, 10)+"px");
 
 					$(".ship_repair_docking", cElm).text( String(cShip.repairDocking).toHHMMSS() );

--- a/src/pages/strategy/tabs/overlodger/overlodger.js
+++ b/src/pages/strategy/tabs/overlodger/overlodger.js
@@ -1695,7 +1695,7 @@
 		sRatio  = Math.pow(dcCoef,-0.4);
 		aRating = (aRating * (1-sRatio) + (new KC3LedgerBuffer(null,null,dataSum,"overall")).bRating * sRatio);
 		
-		dRating = dataAvg.length > 1 ? Math.stdev.apply(null,dataAvg) : 0;
+		dRating = dataAvg.length > 1 ? Math.stdev(dataAvg) : 0;
 		pRatio  = Math.pow(Math.max(0,1 - Math.abs(aRating)),1.5) * Math.sign(aRating);
 		
 		bResult = {bRating: aRating + dRating * pRatio};


### PR DESCRIPTION
seems the Ledger is relying on `Math.stdev` for some calculation and I got an call stack overflow because of a long sortie history (~ 60000 elements). fixed by calling `Math.stdev([bool,] <an array>)` instead.

sorry for the noise in the diff view, the end of line gets messed up so I reindented them before working on this patch, the real changes are just 318796d and 39cd6ba .

I think @ReiFan49 is the original author of this part, could you take a look and see if this patch is good enough?
