### PR TITLE
leaving DMM login enforcement an option

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -59,6 +59,11 @@
 				"id": "devOnlyPages",
 				"name": "SettingsDevOnlyPages",
 				"type": "check"
+			},
+			{
+				"id": "forceDMMLogin",
+				"name": "SettingsForceDMMLogin",
+				"type": "check"
 			}
 		]
 	},

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -21,6 +21,7 @@ Retreives when needed to apply on components
 				marryLevelFormat	: 0,
 				checkLiveQuests		: true,
 				devOnlyPages		: false,
+				forceDMMLogin       : true,
 
 				DBSubmission_enabled: 0,
 				DBSubmission_key : '',

--- a/src/pages/popup/popup.js
+++ b/src/pages/popup/popup.js
@@ -189,6 +189,12 @@
 	});
 	
 	function checkDMMLogin(callback){
+		// should be exactly of value "false",
+		// so we can fallback as if it's default value "true"
+		if (ConfigManager.forceDMMLogin === false) {
+			callback(true);
+			return;
+		}
 		// Check if user is already logged in on DMM
 		chrome.cookies.get({
 			url: "http://www.dmm.com/netgame/social/-/gadgets/=/app_id=854854/",


### PR DESCRIPTION
addressing (reopened) #1535
added an option under "Global" part of the setting page, checked by default. this allows user to bypass DMM login requirement when un-checked.
btw the DMM login checking might have some problems, I always need to go to DMM website first before I can see 3 play options in the menu despite that I've logged in.