### PR TITLE
Fall 2016 history entry in strategy room

### DIFF
--- a/src/pages/strategy/tabs/event/event.html
+++ b/src/pages/strategy/tabs/event/event.html
@@ -21,7 +21,7 @@
 
 <!-- WORLD LIST -->
 <div class="world_list">
-	<div class="world_box hover" data-world_num="1">
+	<div class="world_box hover hidden" data-world_num="1">
 		<div class="world_icon"></div>
 		<div class="world_text">Spring 2015</div>
 	</div>
@@ -41,10 +41,15 @@
 		<div class="world_icon"></div>
 		<div class="world_text">Spring 2016</div>
 	</div>
-	<div class="world_box hover active" data-world_num="35">
+	<div class="world_box hover" data-world_num="35">
 		<div class="world_icon"></div>
 		<div class="world_text">Summer 2016</div>
 	</div>
+	<div class="world_box hover active" data-world_num="36">
+		<div class="world_icon"></div>
+		<div class="world_text">Fall 2016</div>
+	</div>
+
 	<div class="clear"></div>
 </div>
 


### PR DESCRIPTION
Make an entry for Fall 2016 and make it default for the Event tab.
However I have also hidden the tab "Spring 2015", otherwise there are too many contents in a row and the layout overflows. Some extra work might be required for a more proper fix.