### PR TITLE
Add colored border to abyssal ship icons

### DIFF
--- a/src/library/modules/Meta.js
+++ b/src/library/modules/Meta.js
@@ -56,6 +56,17 @@ Provides access to data on built-in JSON files
 			"1471": 3 // whiteday 2015
 		},
 		
+		abyssKaiShipIds: [
+			565, 566, 567, 616, 617, 618, 714, 715
+		],
+		abyssNonBossIds: [
+			541, 542, 543, 549, 550, 551, 552, 553, 554, 555,
+			558, 559, 560, 561, 562, 563, 570, 571, 572, 575,
+			576, 577, 579, 580, 591, 592, 593, 594, 595, 614,
+			615, 621, 622, 623, 624, 637, 638, 639, 640, 665,
+			666, 667
+		],
+		
 		/* Initialization
 		-------------------------------------------------------*/
 		init :function( repo ){
@@ -194,6 +205,28 @@ Provides access to data on built-in JSON files
 			return [this.shipName(shipMaster.api_name), this.shipName(shipMaster.api_yomi)]
 				.filter(function(x){return !!x&&x!=="-";})
 				.join("");
+		},
+		
+		abyssShipBorderClass :function(ship){
+			var shipMaster = ship;
+			// No ship specified, return all possible class names
+			if(!ship){
+				return ["boss", "kai", "flagship", "elite"];
+			}
+			if(typeof shipMaster !== "object"){
+				shipMaster = KC3Master.ship(Number(ship));
+			}
+			// Abyssal Kai
+			if(this.abyssKaiShipIds.indexOf(shipMaster.api_id) > -1){
+				return "kai";
+			}
+			// Princesses and demons, using black-list
+			// To reduce updating work, consider new abyssal ships as boss by default
+			if(shipMaster.api_id > 538 && shipMaster.api_id <= 800 &&
+				this.abyssNonBossIds.indexOf(shipMaster.api_id) < 0){
+				return "boss";
+			}
+			return shipMaster.api_id > 500 ? shipMaster.api_yomi.replace("-", "") : "";
 		},
 		
 		exp :function(level){

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -615,6 +615,22 @@ ABYSS FLEET
 	top:-1px;
 	left:-1px;
 }
+.module.activity .abyss_ships .boss {
+	border-color:#5ef;
+	box-shadow:0px 0px 1px 1px #fe5;
+}
+.module.activity .abyss_ships .kai {
+	border-color:#2af;
+	box-shadow:0px 0px 1px 0px #2af;
+}
+.module.activity .abyss_ships .flagship {
+	border-color:#fc3;
+	box-shadow:0px 0px 1px 0px #fc3;
+}
+.module.activity .abyss_ships .elite {
+	border-color:#f33;
+	box-shadow:0px 0px 1px 0px #f33;
+}
 .module.activity .abyss_single .abyss_hps {
 	width:180px;
 	height:4px;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -751,6 +751,7 @@
 	function clearBattleData(){
 		$(".module.activity .abyss_ship img").attr("src", KC3Meta.abyssIcon(-1));
 		$(".module.activity .abyss_ship img").attr("title", "");
+		$(".module.activity .abyss_ship").removeClass(KC3Meta.abyssShipBorderClass().join(" "));
 		$(".module.activity .abyss_ship").css("opacity", 1);
 		$(".module.activity .abyss_combined").hide();
 		$(".module.activity .abyss_single").show();
@@ -1638,6 +1639,7 @@
 				var eParam = thisNode.eParam[index];
 				if(eshipId > -1){
 					if ($(".module.activity .abyss_"+enemyFleetBox+" .abyss_ship_"+(index+1)).length > 0) {
+						$(".module.activity .abyss_"+enemyFleetBox+" .abyss_ship_"+(index+1)).addClass(KC3Meta.abyssShipBorderClass(eshipId));
 						$(".module.activity .abyss_"+enemyFleetBox+" .abyss_ship_"+(index+1)+" img").attr("src", KC3Meta.abyssIcon(eshipId));
 
 						var tooltip = "{0}: {1}\n".format(eshipId, KC3Meta.abyssShipName(eshipId));

--- a/src/pages/strategy/sortielogs.js
+++ b/src/pages/strategy/sortielogs.js
@@ -504,6 +504,7 @@
 									$(".node_eship_"+(index+1)+" img", nodeBox).attr("alt", eship);
 									$(".node_eship_"+(index+1)+" img", nodeBox).click(shipClickFunc);
 									$(".node_eship_"+(index+1), nodeBox).addClass("hover");
+									$(".node_eship_"+(index+1), nodeBox).addClass( KC3Meta.abyssShipBorderClass( eship) );
 									$(".node_eship_"+(index+1), nodeBox).show();
 								}
 							});

--- a/src/pages/strategy/tabs/encounters/encounters.css
+++ b/src/pages/strategy/tabs/encounters/encounters.css
@@ -64,9 +64,21 @@
 	height:30px;
 	border-radius:15px;
 }
-.tab_encounters .encounter_icon img {
-	with:30px;
+.tab_encounters  .encounter_icon img {
+	width:30px;
 	height:30px;
+}
+.tab_encounters .encounter_ship .boss {
+	box-shadow:0px 0px 1px 1px #5ef, 0px 0px 3px 2px #fe5;
+}
+.tab_encounters .encounter_ship .kai {
+	box-shadow:0px 0px 3px 1px #2af;
+}
+.tab_encounters .encounter_ship .flagship {
+	box-shadow:0px 0px 3px 1px #fc3;
+}
+.tab_encounters .encounter_ship .elite {
+	box-shadow:0px 0px 3px 1px #f33;
 }
 .tab_encounters .encounter_ship .encounter_id {
 	with:30px;

--- a/src/pages/strategy/tabs/encounters/encounters.js
+++ b/src/pages/strategy/tabs/encounters/encounters.js
@@ -70,6 +70,7 @@
 						$.each(shipList, function(shipIndex, shipId){
 							if(shipId > 0){
 								shipBox = $(".tab_encounters .factory .encounter_ship").clone();
+								$(".encounter_icon", shipBox).addClass(KC3Meta.abyssShipBorderClass(shipId));
 								$(".encounter_icon img", shipBox).attr("src", KC3Meta.abyssIcon(shipId));
 								$(".encounter_icon img", shipBox).attr("alt", shipId);
 								$(".encounter_icon img", shipBox).click(shipClickFunc);

--- a/src/pages/strategy/tabs/event/event.css
+++ b/src/pages/strategy/tabs/event/event.css
@@ -412,6 +412,19 @@
 .tab_event .sortie_list .node_eship img {
 	width:20px;
 	height:20px;
+	vertical-align:top;
+}
+.tab_event .sortie_list .node_enemy .boss {
+	box-shadow:0px 0px 1px 1px #5ef;
+}
+.tab_event .sortie_list .node_enemy .kai {
+	box-shadow:0px 0px 1px 1px #2af;
+}
+.tab_event .sortie_list .node_enemy .flagship {
+	box-shadow:0px 0px 1px 1px #fc3;
+}
+.tab_event .sortie_list .node_enemy .elite {
+	box-shadow:0px 0px 1px 1px #f33;
 }
 
 .tab_event .sortie_list .node_details {

--- a/src/pages/strategy/tabs/maps/maps.css
+++ b/src/pages/strategy/tabs/maps/maps.css
@@ -382,6 +382,23 @@
 .tab_maps .sortie_list .node_eship img {
 	width:20px;
 	height:20px;
+	vertical-align:top;
+}
+.tab_maps .sortie_list .node_enemy .boss {
+	border-color:#5ef;
+	box-shadow:0px 0px 1px 1px #5ef;
+}
+.tab_maps .sortie_list .node_enemy .kai {
+	border-color:#2af;
+	box-shadow:0px 0px 1px 1px #2af;
+}
+.tab_maps .sortie_list .node_enemy .flagship {
+	border-color:#fc3;
+	box-shadow:0px 0px 1px 1px #fc3;
+}
+.tab_maps .sortie_list .node_enemy .elite {
+	border-color:#f33;
+	box-shadow:0px 0px 1px 1px #f33;
 }
 
 .tab_maps .sortie_list .node_details {


### PR DESCRIPTION
As discussion at #1500 . Implemented by adding CSS styles of `border-color` or `border-shadow`.

Supported colors:
* Princess / Demon: glow lightblue
* Kai: blue
* Flagship: golden
* Elite: crimson

Flagship & Elite is recognized by mater data `api_yomi`, but Kai / Bosses are not. Hard-coded IDs is current shortcoming. If devs add more abyssal ships, the ID list needs to be updated too.

Affected pages:
* natsuiro panel: battle activity
* SRoom: Map / Event history
* SRoom: Encounters

Feel free to adjust colors or styles for more clearly visual effect.
