### PR TITLE
Battle activity for Land-base Enemy Air Raid

### DIFF
--- a/src/library/managers/SortieManager.js
+++ b/src/library/managers/SortieManager.js
@@ -184,6 +184,7 @@ Xxxxxxx
 			// Battle Node
 			// api_event_kind = 1 (day battle)
 			// api_event_kind = 2 (start at night battle)
+			// api_event_kind = 3 (night battle first, then day battle)
 			// api_event_kind = 4 (aerial exchange)
 			// api_event_kind = 5 (enemy combined)
 			// api_event_kind = 6 (defensive aerial)
@@ -219,6 +220,10 @@ Xxxxxxx
 			thisNode = (new KC3Node( this.onSortie, nodeData.api_no, UTCTime ))['defineAs' + nodeKind](nodeData);
 			this.nodes.push(thisNode);
 			this.save();
+		},
+		
+		engageLandBaseAirRaid :function( battleData ){
+			this.currentNode().airBaseRaid( battleData );
 		},
 		
 		engageBattle :function( battleData, stime ){

--- a/src/library/modules/Meta.js
+++ b/src/library/modules/Meta.js
@@ -56,6 +56,17 @@ Provides access to data on built-in JSON files
 			"1471": 3 // whiteday 2015
 		},
 		
+		abyssKaiShipIds: [
+			565, 566, 567, 616, 617, 618, 714, 715
+		],
+		abyssNonBossIds: [
+			541, 542, 543, 549, 550, 551, 552, 553, 554, 555,
+			558, 559, 560, 561, 562, 563, 570, 571, 572, 575,
+			576, 577, 579, 580, 591, 592, 593, 594, 595, 614,
+			615, 621, 622, 623, 624, 637, 638, 639, 640, 665,
+			666, 667
+		],
+		
 		/* Initialization
 		-------------------------------------------------------*/
 		init :function( repo ){
@@ -194,6 +205,28 @@ Provides access to data on built-in JSON files
 			return [this.shipName(shipMaster.api_name), this.shipName(shipMaster.api_yomi)]
 				.filter(function(x){return !!x&&x!=="-";})
 				.join("");
+		},
+		
+		abyssShipBorderClass :function(ship){
+			var shipMaster = ship;
+			// No ship specified, return all possible class names
+			if(!ship){
+				return ["boss", "kai", "flagship", "elite"];
+			}
+			if(typeof shipMaster !== "object"){
+				shipMaster = KC3Master.ship(Number(ship));
+			}
+			// Abyssal Kai
+			if(this.abyssKaiShipIds.indexOf(shipMaster.api_id) > -1){
+				return "kai";
+			}
+			// Princesses and demons, using black-list
+			// To reduce updating work, consider new abyssal ships as boss by default
+			if(shipMaster.api_id > 538 && shipMaster.api_id <= 800 &&
+				this.abyssNonBossIds.indexOf(shipMaster.api_id) < 0){
+				return "boss";
+			}
+			return shipMaster.api_id > 500 ? shipMaster.api_yomi.replace("-", "") : "";
 		},
 		
 		exp :function(level){

--- a/src/library/modules/Meta.js
+++ b/src/library/modules/Meta.js
@@ -286,6 +286,10 @@ Provides access to data on built-in JSON files
 			return this._battle.airbattle[index] || ["","","Unknown"];
 		},
 		
+		airraiddamage :function(index){
+			return this._battle.airraiddamage[index] || "";
+		},
+		
 		engagement :function(index){
 			return this._battle.engagement[index] || ["","",""];
 		},

--- a/src/library/modules/Network.js
+++ b/src/library/modules/Network.js
@@ -27,6 +27,7 @@ Listens to network history and triggers callback if game events happen
 			Lbas: [],
 			SortieStart: [],
 			CompassResult: [],
+			LandBaseAirRaid: [],
 			BattleStart: [],
 			BattleNight: [],
 			BattleResult: [],

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -615,6 +615,22 @@ ABYSS FLEET
 	top:-1px;
 	left:-1px;
 }
+.module.activity .abyss_ships .boss {
+	border-color:#5ef;
+	box-shadow:0px 0px 1px 1px #fe5;
+}
+.module.activity .abyss_ships .kai {
+	border-color:#2af;
+	box-shadow:0px 0px 1px 0px #2af;
+}
+.module.activity .abyss_ships .flagship {
+	border-color:#fc3;
+	box-shadow:0px 0px 1px 0px #fc3;
+}
+.module.activity .abyss_ships .elite {
+	border-color:#f33;
+	box-shadow:0px 0px 1px 0px #f33;
+}
 .module.activity .abyss_single .abyss_hps {
 	width:180px;
 	height:4px;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -789,6 +789,8 @@ ABYSS FLEET
 	font-size:11px;
 	float:left;
 	color:#fff;
+	white-space:nowrap;
+	overflow:hidden;
 }
 .module.activity .battle_contact img {
 	width:15px;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -751,6 +751,7 @@
 	function clearBattleData(){
 		$(".module.activity .abyss_ship img").attr("src", KC3Meta.abyssIcon(-1));
 		$(".module.activity .abyss_ship img").attr("title", "");
+		$(".module.activity .abyss_ship").removeClass(KC3Meta.abyssShipBorderClass().join(" "));
 		$(".module.activity .abyss_ship").css("opacity", 1);
 		$(".module.activity .abyss_combined").hide();
 		$(".module.activity .abyss_single").show();
@@ -1652,6 +1653,7 @@
 				var eParam = thisNode.eParam[index];
 				if(eshipId > -1){
 					if ($(".module.activity .abyss_"+enemyFleetBox+" .abyss_ship_"+(index+1)).length > 0) {
+						$(".module.activity .abyss_"+enemyFleetBox+" .abyss_ship_"+(index+1)).addClass(KC3Meta.abyssShipBorderClass(eshipId));
 						$(".module.activity .abyss_"+enemyFleetBox+" .abyss_ship_"+(index+1)+" img").attr("src", KC3Meta.abyssIcon(eshipId));
 
 						var tooltip = "{0}: {1}\n".format(eshipId, KC3Meta.abyssShipName(eshipId));

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -769,7 +769,9 @@
 		$(".module.activity .battle_drop img").attr("src", "../../../../assets/img/ui/dark_shipdrop.png");
 		$(".module.activity .battle_drop").attr("title", "");
 		$(".module.activity .battle_cond_value").text("");
+		$(".module.activity .battle_engagement").prev().text(KC3Meta.term("BattleEngangement"));
 		$(".module.activity .battle_engagement").attr("title", "");
+		$(".module.activity .battle_detection").prev().text(KC3Meta.term("BattleDetection"));
 		$(".module.activity .battle_detection").attr("title", "");
 		$(".module.activity .battle_airbattle").attr("title", "");
 		$(".module.activity .plane_text span").text("");
@@ -1621,6 +1623,65 @@
 			}
 		},
 
+		LandBaseAirRaid: function(data){
+			var thisNode = KC3SortieManager.currentNode();
+			var battleData = thisNode.battleDestruction;
+			var self = this;
+			if(!battleData) { return false; }
+			var updateBattleActivityFunc = function(){
+				clearBattleData();
+				$(".module.activity .abyss_single").show();
+				$(".module.activity .abyss_combined").hide();
+				$.each(thisNode.eships, function(index, eshipId){
+					if(eshipId > -1 && $(".module.activity .abyss_single .abyss_ship_"+(index+1)).length > 0){
+						$(".module.activity .abyss_single .abyss_ship_"+(index+1)).addClass(KC3Meta.abyssShipBorderClass(eshipId));
+						$(".module.activity .abyss_single .abyss_ship_"+(index+1)+" img").attr("src", KC3Meta.abyssIcon(eshipId));
+						$(".module.activity .abyss_single .abyss_ship_"+(index+1)+" img")
+							.attr("title", "{0}: {1}\n".format(eshipId, KC3Meta.abyssShipName(eshipId)) );
+						$(".module.activity .abyss_single .abyss_ship_"+(index+1)).show();
+					}
+				});
+				if((typeof thisNode.eformation != "undefined") && (thisNode.eformation > -1)){
+					$(".module.activity .battle_eformation img").attr("src", KC3Meta.formationIcon(thisNode.eformation));
+					$(".module.activity .battle_eformation").css("-webkit-transform", "rotate(-90deg)");
+					$(".module.activity .battle_eformation").attr("title", KC3Meta.formationText(thisNode.eformation));
+				}
+				$(".module.activity .battle_detection").prev().text(KC3Meta.term("BattleAirDefend"));
+				var airDefender = (!thisNode.fplaneFrom || thisNode.fplaneFrom[0] === -1) ?
+					KC3Meta.term("BattleAirDefendNo") :
+					KC3Meta.term("BattleAirDefendYes").format(thisNode.fplaneFrom.join(","));
+				$(".module.activity .battle_detection").text(airDefender);
+				$(".module.activity .battle_detection").attr("title", airDefender);
+				$(".module.activity .battle_engagement").prev().text(KC3Meta.term("BattleAirBaseLoss"));
+				$(".module.activity .battle_engagement").text(KC3Meta.airraiddamage(thisNode.lostKind));
+				var contactSpan = buildContactPlaneSpan(thisNode.fcontactId, thisNode.fcontact, thisNode.econtactId, thisNode.econtact);
+				$(".module.activity .battle_contact").html($(contactSpan).html());
+				$(".module.activity .battle_airbattle").text( thisNode.airbattle[0] );
+				$(".module.activity .battle_airbattle").attr("title", thisNode.airbattle[2] || "" );
+				$(".fighter_ally .plane_before").text(thisNode.planeFighters.player[0]);
+				$(".fighter_enemy .plane_before").text(thisNode.planeFighters.abyssal[0]);
+				$(".bomber_ally .plane_before").text(thisNode.planeBombers.player[0]);
+				$(".bomber_enemy .plane_before").text(thisNode.planeBombers.abyssal[0]);
+				if(thisNode.planeFighters.player[1] > 0){
+					$(".fighter_ally .plane_after").text("-"+thisNode.planeFighters.player[1]);
+				}
+				if(thisNode.planeFighters.abyssal[1] > 0){
+					$(".fighter_enemy .plane_after").text("-"+thisNode.planeFighters.abyssal[1]);
+				}
+				if(thisNode.planeBombers.player[1] > 0){
+					$(".bomber_ally .plane_after").text("-"+thisNode.planeBombers.player[1]);
+				}
+				if(thisNode.planeBombers.abyssal[1] > 0){
+					$(".bomber_enemy .plane_after").text("-"+thisNode.planeBombers.abyssal[1]);
+				}
+				$(".module.activity .battle_support").show();
+				$(".module.activity .battle_fish").hide();
+				$(".module.activity .node_type_battle").show();
+			};
+			// Have to wait seconds for game animate and see compass results
+			setTimeout(updateBattleActivityFunc, 6500);
+		},
+
 		BattleStart: function(data){
 			// Clear battle details box just to make sure
 			clearBattleData();
@@ -1636,7 +1697,6 @@
 				$(".module.activity .abyss_single").show();
 				$(".module.activity .abyss_combined").hide();
 			}
-			
 			
 			if (thisNode.debuffed) {
 				$(".module.activity .map_world")

--- a/src/pages/strategy/sortielogs.js
+++ b/src/pages/strategy/sortielogs.js
@@ -504,6 +504,7 @@
 									$(".node_eship_"+(index+1)+" img", nodeBox).attr("alt", eship);
 									$(".node_eship_"+(index+1)+" img", nodeBox).click(shipClickFunc);
 									$(".node_eship_"+(index+1), nodeBox).addClass("hover");
+									$(".node_eship_"+(index+1), nodeBox).addClass( KC3Meta.abyssShipBorderClass( eship) );
 									$(".node_eship_"+(index+1), nodeBox).show();
 								}
 							});

--- a/src/pages/strategy/tabs/encounters/encounters.css
+++ b/src/pages/strategy/tabs/encounters/encounters.css
@@ -73,9 +73,21 @@
 	height:30px;
 	border-radius:15px;
 }
-.tab_encounters .encounter_icon img {
-	with:30px;
+.tab_encounters  .encounter_icon img {
+	width:30px;
 	height:30px;
+}
+.tab_encounters .encounter_ship .boss {
+	box-shadow:0px 0px 1px 1px #5ef, 0px 0px 3px 2px #fe5;
+}
+.tab_encounters .encounter_ship .kai {
+	box-shadow:0px 0px 3px 1px #2af;
+}
+.tab_encounters .encounter_ship .flagship {
+	box-shadow:0px 0px 3px 1px #fc3;
+}
+.tab_encounters .encounter_ship .elite {
+	box-shadow:0px 0px 3px 1px #f33;
 }
 .tab_encounters .encounter_ship .encounter_id {
 	width:30px;

--- a/src/pages/strategy/tabs/encounters/encounters.js
+++ b/src/pages/strategy/tabs/encounters/encounters.js
@@ -70,6 +70,7 @@
 						$.each(shipList, function(shipIndex, shipId){
 							if(shipId > 0){
 								shipBox = $(".tab_encounters .factory .encounter_ship").clone();
+								$(".encounter_icon", shipBox).addClass(KC3Meta.abyssShipBorderClass(shipId));
 								$(".encounter_icon img", shipBox).attr("src", KC3Meta.abyssIcon(shipId));
 								$(".encounter_icon img", shipBox).attr("alt", shipId);
 								$(".encounter_icon img", shipBox).click(shipClickFunc);

--- a/src/pages/strategy/tabs/event/event.css
+++ b/src/pages/strategy/tabs/event/event.css
@@ -412,6 +412,19 @@
 .tab_event .sortie_list .node_eship img {
 	width:20px;
 	height:20px;
+	vertical-align:top;
+}
+.tab_event .sortie_list .node_enemy .boss {
+	box-shadow:0px 0px 1px 1px #5ef;
+}
+.tab_event .sortie_list .node_enemy .kai {
+	box-shadow:0px 0px 1px 1px #2af;
+}
+.tab_event .sortie_list .node_enemy .flagship {
+	box-shadow:0px 0px 1px 1px #fc3;
+}
+.tab_event .sortie_list .node_enemy .elite {
+	box-shadow:0px 0px 1px 1px #f33;
 }
 
 .tab_event .sortie_list .node_details {

--- a/src/pages/strategy/tabs/maps/maps.css
+++ b/src/pages/strategy/tabs/maps/maps.css
@@ -382,6 +382,23 @@
 .tab_maps .sortie_list .node_eship img {
 	width:20px;
 	height:20px;
+	vertical-align:top;
+}
+.tab_maps .sortie_list .node_enemy .boss {
+	border-color:#5ef;
+	box-shadow:0px 0px 1px 1px #5ef;
+}
+.tab_maps .sortie_list .node_enemy .kai {
+	border-color:#2af;
+	box-shadow:0px 0px 1px 1px #2af;
+}
+.tab_maps .sortie_list .node_enemy .flagship {
+	border-color:#fc3;
+	box-shadow:0px 0px 1px 1px #fc3;
+}
+.tab_maps .sortie_list .node_enemy .elite {
+	border-color:#f33;
+	box-shadow:0px 0px 1px 1px #f33;
 }
 
 .tab_maps .sortie_list .node_details {


### PR DESCRIPTION
Add processing chain as additional data attached to a node for Enemy Air Raid (in API `api_req_map/next@api_data.api_destruction_battle`) to show land-base air raid battle result in battle activity panel.
As it's in request `/next`, no persistence supported yet, will be not in sortie history.


And as it has conflicted with #1612, I've merge that first. So that will be also merged when this PR merged.

ps. panel screenshot like this:
![image](https://cloud.githubusercontent.com/assets/160240/20670219/ea381824-b5b2-11e6-96b8-21f6fc5599a6.png)
