### PR TITLE
Ship name translation method improvement

### DIFF
--- a/src/library/modules/Meta.js
+++ b/src/library/modules/Meta.js
@@ -15,6 +15,7 @@ Provides access to data on built-in JSON files
 		_exp_ship:{},
 		_gauges:{},
 		_ship:{},
+		_shipAffix:{},
 		_defeq:{},
 		_slotitem:{},
 		_equiptype:[],
@@ -89,6 +90,7 @@ Provides access to data on built-in JSON files
 			
 			// Load Translations
 			this._ship 		= KC3Translation.getJSON(repo, 'ships', true);
+			this._shipAffix	= KC3Translation.getJSON(repo, 'ship_affix', true);
 			this._slotitem	= KC3Translation.getJSON(repo, 'items', true);
 			this._equiptype	= KC3Translation.getJSON(repo, 'equiptype', true);
 			this._quests	= KC3Translation.getJSON(repo, 'quests', true);
@@ -133,95 +135,71 @@ Provides access to data on built-in JSON files
 			return this._battle.formation[formationId] || "";
 		},
 		
-		shipName :function( jp_name ){
-			// console.log( "---------request to TL---------", jp_name );
-			//if(typeof jp_name == "undefined"){ return "Unknown ship"; }
-			if(typeof this._cache[jp_name] !== "undefined"){ return this._cache[jp_name]; }
-			if(typeof this._ship[jp_name] !== "undefined"){
-				this._cache[jp_name] = this._ship[jp_name];
-				return this._cache[jp_name];
-			}
-			if(Object.keys(this._ship).length === 0){
-				return jp_name;
-			}
-			var
-				bare = jp_name,
-				combinPref = [],
-				combinSuf = [],
-				repPrefTab = {
-					"Xmas"	: "Xmas_",
-					"浴衣"   : "Yukata_",
-					"法被"   : "AkiHappi_",
-					"秋刀魚"  : "Saury_",
-					"夏2016" : "Summer2016_",
-					"夏"     : "Summer_",
-					"親子丼"  : "Oyakodon_",
-					"買い出し"  : "Shopping_",
-					"梅雨"   : "Rainy_",
-					"携帯"		: "Mobile_",
-					"記念日"   : "Anniversary_",
-				},
-				repSufTab = {
-					"甲"    : '_A',
-					"乙"    : '_B',
-					"丙"    : '_C',
-					"丁"    : '_D',
-					"改二"  : '_KaiNi',
-					"改"    : '_Kai',
-					" zwei" : '_Zwei',
-					" drei" : '_Drei'
-				},
-				repRes = null,
-				replaced = false;
-			// in here, the regular expression will read which one comes first (which mean, to be in the end of the name
-			// and then, the bare string will be chopped by how long the pattern match...
-			// the matched one, added to the combination stack (FILO)
-			// removing from the replacement table in order to prevent infinite loop ^^;
-			// if there's no match, it'll instantly stop and return the actual value
-			// just translate the items start with '_' in ships.json, and keep the necessary prefix space
-			while( !!(repRes = (new RegExp("^("+(Object.keys(repPrefTab).join("|"))+").+",'gi')).exec(bare)) ){
-				bare = bare.substr(repRes[1].length);
-				combinPref.unshift(this._ship[repPrefTab[repRes[1]]]);
-				delete repPrefTab[repRes[1]];
-				replaced = true;
-			}
-			
-			while( !!(repRes = (new RegExp(".+("+(Object.keys(repSufTab).join("|"))+")$",'gi')).exec(bare)) ){
-				bare = bare.substr(0, bare.length-repRes[1].length);
-				combinSuf.unshift(this._ship[repSufTab[repRes[1]]]);
-				delete repSufTab[repRes[1]];
-				replaced = true;
-			}
-			
-			
-			
-			// console.log("Remaining", bare, "with combination", combin.join(" "));
-			if(replaced) {
-				// console.log("this._ship", this._ship);
-				// console.log("this._ship[bare]", this._ship[bare]);
-				if(typeof this._ship[bare] !== "undefined"){
-				} else {
-					if (typeof this._cache[bare] !== "undefined") {
-						this._cache[bare] = bare;
-					}
-				}
-				
-				this._cache[jp_name] = (combinPref.length > 0 ? combinPref.join("") : "")+
-					(this._ship[bare] || this._cache[bare] || bare) +
-					(combinSuf.length > 0 ? combinSuf.join("") : "");
-				return this._cache[jp_name] ;
-				// console.log("this._cache[jp_name]", this._cache[jp_name]);
-				// return this._cache[jp_name]; // being here means the jp_name is not cached. there's already a cache checker at the start of this function
-			}
-			// console.log("returning original:", jp_name);
-			return jp_name;
+		shipNameAffix :function(affix){
+			// Just translate the prefixes and suffixes in `ship_affix.json`
+			// And keep the necessary space after or before the affixes
+			return this._shipAffix[affix] || {};
 		},
 		
-		gearName :function( jp_name ){
-			if(typeof this._slotitem[ jp_name ] !== "undefined"){
-				return this._slotitem[ jp_name ];
+		shipName :function(jpName){
+			// No translation needed for empty ship.json like JP
+			if(Object.keys(this._ship).length === 0){ return jpName; }
+			// If translation and combination done once, use the cache instantly
+			if(typeof this._cache[jpName] !== "undefined"){ return this._cache[jpName]; }
+			// If full string matched, no combination needed
+			if(typeof this._ship[jpName] !== "undefined"){
+				this._cache[jpName] = this._ship[jpName];
+				return this._cache[jpName];
 			}
-			return jp_name;
+			var root = jpName,
+				combinedPrefixes = [],
+				prefixesList = Object.keys(this.shipNameAffix("prefixes")),
+				combinedSuffixes = [],
+				suffixesList = Object.keys(this.shipNameAffix("suffixes")),
+				occurs = [],
+				replaced = false;
+			/**********************************************
+			// To combine the translations of root name and prefix/suffix,
+			// the regular expression will read which one comes first,
+			// which mean the prefixes and suffixes in the ship name.
+			// and then, the root string will be chopped to remove the affixes,
+			// the matched one, added to the combination stack (FILO)
+			// removing from the replacement table in order to prevent infinite loop.
+			// if there's no match, it'll instantly stop and return the actual value.
+			***********************************************/
+			if(prefixesList.length > 0){
+				while( !!(occurs = (new RegExp("^("+prefixesList.join("|")+").+$","i")).exec(root)) ){
+					root = root.replace(new RegExp("^"+occurs[1],"i"), "");
+					combinedPrefixes.unshift(this.shipNameAffix("prefixes")[occurs[1]]);
+					prefixesList.splice(prefixesList.indexOf(occurs[1]), 1);
+					replaced = true;
+				}
+			}
+			if(suffixesList.length > 0){
+				while( !!(occurs = (new RegExp(".+("+suffixesList.join("|")+")$","i")).exec(root)) ){
+					root = root.replace(new RegExp(occurs[1]+"$","i"), "");
+					combinedSuffixes.unshift(this.shipNameAffix("suffixes")[occurs[1]]);
+					suffixesList.splice(suffixesList.indexOf(occurs[1]), 1);
+					replaced = true;
+				}
+			}
+			if(replaced){
+				// Put combined name into cache
+				this._cache[jpName] = [
+					(combinedPrefixes.length > 0 ? combinedPrefixes.join("") : "") ,
+					(this._ship[root] || root) ,
+					(combinedSuffixes.length > 0 ? combinedSuffixes.join("") : "")
+				].join("");
+				return this._cache[jpName];
+			}
+			return root;
+		},
+		
+		gearName :function(jpName){
+			if(typeof this._slotitem[jpName] !== "undefined"){
+				return this._slotitem[jpName];
+			}
+			return jpName;
 		},
 		
 		gearTypeName :function(categoryType, categoryId){
@@ -239,8 +217,9 @@ Provides access to data on built-in JSON files
 			if(!shipMaster.api_name){
 				shipMaster = KC3Master.ship(Number(ship));
 			}
-			return [this.shipName(shipMaster.api_name), this.shipName(shipMaster.api_yomi)]
-				.filter(function(x){return !!x&&x!=="-";})
+			return [this.shipName(shipMaster.api_name),
+				this.shipNameAffix("yomi")[shipMaster.api_yomi] || this.shipName(shipMaster.api_yomi)
+				].filter(function(x){return !!x&&x!=="-";})
 				.join("");
 		},
 		

--- a/src/library/modules/Translation.js
+++ b/src/library/modules/Translation.js
@@ -102,13 +102,13 @@
 			// Japanese special case where ships and items sources are already in JP
 			if(
 				(["jp", "tcn"].indexOf(language) > -1)
-				&& (filename==="ships" || filename==="items")
+				&& (["ships", "items", "ship_affix"].indexOf(filename) > -1)
 			){
 				extendEnglish = false;
 			}
 			// make ships.json and items.json an option to be always in specified one
 			if (!!info_force_ship_lang
-				&& (filename==="ships" || filename==="items")){
+				&& (["ships", "items", "ship_affix"].indexOf(filename) > -1)){
 				extendEnglish = false;
 				language = info_force_ship_lang;
 			}


### PR DESCRIPTION
Refactor ship name meta method, allow ship names translated and combined by 'prefixes + root + suffixes' model sourced from #1696. The prefixes & suffixes (and abyssal's 'yomi') are separated into individual JSON file in TL repo named `ship_affix.json` for easier updating works.

Not only for the seasonal ship names, but also benefited for more automatic ship name (including abyssal's maybe) translation to reduce the lines of `ships.json`. For example, `軽巡ツ級` may be defined as prefix `Light Cruiser ` + root `Tsu-Class`; `駆逐イ級後期型` may be defined as prefix `Destroyer ` + root `I-Class` + suffix ` Late Model`.

For @KC3Kai/translators, the rules of affixes replacement should be known:
 * Lines of prefixes & suffixes table in `ship_affix.json` should be in correct order: 'first in first replacing', if multiply lines are intend to be applied to one ship name. Such as following:
 * For suffixes, as an example, the `甲(A)` of `瑞鶴改二甲(Zuikaku Kai Ni A)` should be replaced first, then for the left string `瑞鶴改二(Zuikaku Kai Ni)`, the `改二(Kai Ni)` becomes the real suffix. That's why in affixes table, line `甲" : " A"` should appears before `"改二" : " Kai Ni"`.
 * For prefixes, order of sub string in name to be replaced should be just reversed.
 * Don't forget the 'extending', for most languages, if some lines are not appeared in `??/ship_affix.json`, those lines in `en/ship_affix.json` will be used.
 * Also don't forget if there is a line in `ships.json` completely matched with JP name, it will be used. No replacement and combination will occur.
 * The old suffixes lines in `ships.json` will not be used any more, could be safely removed after this PR merged.
