### PR TITLE
Asynchronous loading of language files

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
     "newcap": false,
-    "laxbreak": true
+    "laxbreak": true,
+    "esversion": 6
 }

--- a/src/library/modules/Meta.js
+++ b/src/library/modules/Meta.js
@@ -23,6 +23,7 @@ Provides access to data on built-in JSON files
 		_stype:{},
 		_servers:{},
 		_battle:{},
+		_langcustom:{},
 		_quotes:{},
 		_terms:{
 			troll:{},
@@ -88,18 +89,29 @@ Provides access to data on built-in JSON files
 			this._gunfit	= JSON.parse( $.ajax(repo+'gunfit.json', { async: false }).responseText );
 			
 			// Load Translations
-			this._ship 		= KC3Translation.getJSON(repo, 'ships', true);
-			this._slotitem	= KC3Translation.getJSON(repo, 'items', true);
-			this._equiptype	= KC3Translation.getJSON(repo, 'equiptype', true);
-			this._quests	= KC3Translation.getJSON(repo, 'quests', true);
-			this._ranks		= KC3Translation.getJSON(repo, 'ranks', true);
-			this._stype		= KC3Translation.getJSON(repo, 'stype', true);
-			this._servers	= KC3Translation.getJSON(repo, 'servers', true);
-			this._battle	= KC3Translation.getJSON(repo, 'battle', true);
+			this.loadTranslations(repo);
+			
 			// troll language always loaded
 			this._terms.troll		= JSON.parse( $.ajax(repo+'lang/data/troll/terms.json', { async: false }).responseText );
+			
 			// other language loaded here
 			this._terms.lang		= KC3Translation.getJSON(repo, 'terms', true);
+		},
+		
+		loadTranslations: function(){
+			var self = this;
+			
+			KC3Translation.setSource(repo);
+			
+			KC3Translation.load('ships', function(data){ self._ship = data; });
+			KC3Translation.load('items', function(data){ self._slotitem = data; });
+			KC3Translation.load('equiptype', function(data){ self._equiptype = data; });
+			KC3Translation.load('quests', function(data){ self._quests = data; });
+			KC3Translation.load('ranks', function(data){ self._ranks = data; });
+			KC3Translation.load('stype', function(data){ self._stype = data; });
+			KC3Translation.load('servers', function(data){ self._servers = data; });
+			KC3Translation.load('battle', function(data){ self._battle = data; });
+			KC3Translation.load('custom', function(data){ self._langcustom = data; });
 		},
 		
 		loadQuotes :function(){

--- a/src/library/modules/Translation.js
+++ b/src/library/modules/Translation.js
@@ -85,140 +85,109 @@
 			return obj;
 		},
 
-		getJSONWithOptions: function(
-			repo, filename, extendEnglish, language,
-			info_force_ship_lang, info_eng_stype, track_source,
-			shouldAsync, callback
-		) {
-			this.translationBase = {};
-			this.enJSON = {};
-			this.localJSON = {};
-			
-			// default values of params
-			shouldAsync = typeof shouldAsync == "undefined" ? false : shouldAsync;
-			extendEnglish = typeof extendEnglish == "undefined" ? false : extendEnglish;
-			track_source = typeof track_source == "undefined" ? false : track_source;
+		getJSONWithOptions: function(repo, filename, extendEnglish,
+									 language, info_force_ship_lang, info_eng_stype,
+									 track_source) {
+			var self = this;
 
-			// if quotes.json is desired, use specialized function
 			if (filename === "quotes") {
 				console.log("warning: using KC3Translation.getQuotes to get quotes");
 				return this.getQuotes(repo);
 			}
 
+			// Check if desired to extend english files
+			if (typeof extendEnglish=="undefined") { extendEnglish=false; }
+			if (typeof track_source==="undefined") { track_source = false; }
+
 			// Japanese special case where ships and items sources are already in JP
 			if(
 				(["jp", "tcn"].indexOf(language) > -1)
-				&& (filename == "ships" || filename == "items")
+				&& (filename==="ships" || filename==="items")
 			){
 				extendEnglish = false;
 			}
-			
 			// make ships.json and items.json an option to be always in specified one
 			if (!!info_force_ship_lang
-				&& (filename==="ships" || filename==="items"))
-			{
+				&& (filename==="ships" || filename==="items")){
 				extendEnglish = false;
 				language = info_force_ship_lang;
 			}
-			
 			// make "stype.json" an option:
 			if (filename === "stype" && info_eng_stype){
 				language = "en";
 			}
-			
-			var tlfile = new KC3TranslationFile();
-			
+
+			var translationBase = {}, enJSON;
 			if(extendEnglish && language!=="en"){
-				tlfile.loadEnglish(function(){
-					if (track_source) {
-						tlfile.addTags("en");
-					}
-					if (filename === "quests") {
-						tlfile.unoverrideAttr("memo");
-					}
-					tlfile.loadLanguage(function(){
-						tlfile.process();
-					});
-				});
-			} else {
-				tlfile.loadLanguage(function(){
-					tlfile.process();
-				});
-			}
-		},
-		
-		loadDataENBase: function(callback){
-			self.loadData(
-				repo+'lang/data/en/' + filename + '.json',
-				shouldAsync,
-				function(data){
-					enJSON = data;
-					
-					
-					
-					// Make is as the translation base
-					translationBase = enJSON;
-					
-					callback();
-				}
-			);
-		},
-		
-		loadDataLocal: function(callback){
-			self.loadData(
-				repo+'lang/data/' +language+ '/' + filename + '.json',
-				shouldAsync,
-				function(data, err){
-					if (typeof err == "undefined") {
-						translation = data;
-						
-						if (track_source) {
-							self.addTags(translation, language);
-						}
-						
-						callback($.extend(true, translationBase, translation));
-						
-					} else {
-						// As EN can be used, fail-safe for other JSON syntax error
-						if (e instanceof SyntaxError && extendEnglish && language!=="en"){
-							console.warn(e.stack);/*RemoveLogging:skip*/
-							translation = null;
-							// Show error message for Strategy Room
-							if($("#error").length>0){
-								$("#error").append(
-									$("<p>Syntax error on {0} TL data of {1}: {2}</p>".format(filename, language, e.message))
-								);
-								$("#error").show();
-							}
-						}
-						
-						callback({}, e);
-					}
-				}
-			);
-		},
-		
-		loadData: function(targetUrl, doAsync, callback){
-			try {
-				if (doAsync) {
-					$.ajax({
-						url : targetUrl,
-						dataType: 'JSON',
-						sucess: function(response){
-							callback(JSON.parse(response));
-						}
-					});
-				} else {
-					var data = JSON.parse($.ajax({
-						url : targetUrl,
-						dataType: 'JSON',
+				// Load english file
+				try {
+					enJSON = JSON.parse($.ajax({
+						url : repo+'lang/data/en/' + filename + '.json',
 						async: false
 					}).responseText);
-					callback(data);
+
+					if (track_source) {
+						self.addTags(enJSON, "en");
+					}
+					if (filename === "quests") {
+						self.unoverrideAttr(enJSON, "memo");
+					}
+				} catch (e) {
+					console.error(e.stack);
+					var errMsg = $("<p>Fatal error when loading {0} en TL data: {1}</p>" +
+						"<p>Contact developers plz! &gt;_&lt;</p>".format(filename, e));
+					if($("#error").length>0){
+						$("#error").append(errMsg);
+						$("#error").show();
+					} else {
+						$(document.body).append(errMsg);
+					}
+					throw e;
+				}
+
+				// Make is as the translation base
+				translationBase = enJSON;
+			}
+
+			// if we can't fetch this file, the English
+			// version will be used instead
+			var translation;
+			try {
+				translation = JSON.parse($.ajax({
+					url : repo+'lang/data/' +language+ '/' + filename + '.json',
+					async: false
+				}).responseText);
+
+				if (track_source) {
+					self.addTags(translation, language);
 				}
 			} catch (e) {
-				callback({}, e);
+				// As EN can be used, fail-safe for other JSON syntax error
+				if (e instanceof SyntaxError && extendEnglish && language!=="en"){
+					console.warn(e.stack);/*RemoveLogging:skip*/
+					translation = null;
+					// Show error message for Strategy Room
+					if($("#error").length>0){
+						$("#error").append(
+							$("<p>Syntax error on {0} TL data of {1}: {2}</p>".format(filename, language, e.message))
+						);
+						$("#error").show();
+					}
+				} else {
+					// Unknown error still needs to be handled asap
+					console.error(e.stack);/*RemoveLogging:skip*/
+					var errMsg = $("<p>Fatal error when loading {0} TL data of {1}: {2}</p>" +
+						"<p>Contact developers plz! &gt;_&lt;</p>".format(filename, language, e));
+					if($("#error").length>0){
+						$("#error").append(errMsg);
+						$("#error").show();
+					} else {
+						$(document.body).append(errMsg);
+					}
+					throw e;
+				}
 			}
+			return $.extend(true, translationBase, translation);
 		},
 
 		getShipVoiceFlag: function (shipMasterId) {
@@ -481,19 +450,6 @@
 				ConfigManager.language,
 				ConfigManager.info_force_ship_lang,
 				ConfigManager.info_eng_stype);
-		},
-		
-		loadOnlineTranslations :function(filename, extendEnglish, language, info_force_ship_lang, info_eng_stype, track_source){
-			this.getJSONWithOptions(
-				"https://raw.githubusercontent.com/KC3Kai/kc3-translations/master/data",
-				filename,
-				extendEnglish,
-				language,
-				info_force_ship_lang,
-				info_eng_stype,
-				track_source,
-				true // async
-			);
 		}
 		
 	};

--- a/src/library/modules/Translation.js
+++ b/src/library/modules/Translation.js
@@ -11,45 +11,7 @@
 		},
 		
 		
-		/* APPLY WORDS
-		Change words inside visible DOM elements
-		-----------------------------------------*/
-		applyWords :function(){
-			// Interchange element contents with translations
-			$(".i18n").each(function(){
-				$(this).html( KC3Meta.term( $(this).text() ) );
-				$(this).css("visibility", "visible");
-			});
-			// Update title attribute with translations
-			$(".i18n_title").each(function(){
-				$(this).attr("title", KC3Meta.term( $(this).attr("title") ) );
-			});
-		},
 		
-		
-		/* APPLY HTML
-		Specialized Language HTML adjustments
-		-----------------------------------------*/
-		applyHTML :function(){
-			// Specialized fonts
-			var fontFamily = false;
-			switch(ConfigManager.language){
-				
-				case "scn": fontFamily = '"HelveticaNeue-Light","Helvetica Neue Light","Helvetica Neue",Helvetica,"Nimbus Sans L",Arial,"Lucida Grande","Liberation Sans","Microsoft YaHei UI","Microsoft YaHei","Hiragino Sans GB","Wenquanyi Micro Hei","WenQuanYi Zen Hei","ST Heiti",SimHei,"WenQuanYi Zen Hei Sharp",sans-serif'; break;
-				
-				case "tcn": fontFamily = '"Helvetica Neue", Helvetica, "Microsoft JhengHei", "Microsoft JhengHei UI", Arial,"Heiti TC", sans-serif'; break;
-				
-				case "jp": fontFamily = '"Helvetica Neue", "Tahoma", Helvetica, Arial, "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", Osaka, "メイリオ", "Meiryo", "Yu Gothic UI Semibold", "ＭＳ Ｐゴシック", "MS PGothic", sans-serif'; break;
-				
-				default: break;
-			}
-			
-			if(fontFamily){ $("body").css("font-family", fontFamily); }
-			
-			// Apply HTML language code
-			$("html").attr("lang", ConfigManager.language);
-		},
-
 		/*
 		  Recursively changing any non-object value "v" into "{val: v, tag: <tag>}".
 		 */

--- a/src/library/modules/Translations.js
+++ b/src/library/modules/Translations.js
@@ -1,0 +1,68 @@
+(function(){
+	"use strict";
+	
+	window.KC3Translation = {
+		/* EXECUTE
+		Triggers translations into current page
+		-----------------------------------------*/
+		execute :function(){
+			this.applyWords();
+			this.applyCustomFont();
+			this.applyHTML();
+		},
+		
+		
+		/* APPLY WORDS
+		Change words inside visible DOM elements
+		-----------------------------------------*/
+		applyWords :function(){
+			// Interchange element contents with translations
+			$(".i18n").each(function(){
+				$(this).html( KC3Meta.term( $(this).text() ) );
+				$(this).css("visibility", "visible");
+			});
+			
+			// Update title attribute with translations
+			$(".i18n_title").each(function(){
+				$(this).attr("title", KC3Meta.term( $(this).attr("title") ) );
+			});
+		},
+		
+		/* APPLY CUSTOM FONT
+		For languages read best in other fonts
+		-----------------------------------------*/
+		applyCustomFont: function(){
+			// Specialized fonts
+			var fontFamily = false;
+			// ConfigManager.language
+			// KC3Meta._langcustom.
+		},
+		
+		/* APPLY HTML
+		Specialized Language HTML adjustments
+		-----------------------------------------*/
+		applyHTML :function(){
+			if(fontFamily){ $("body").css("font-family", fontFamily); }
+			
+			// Apply HTML language code
+			$("html").attr("lang", ConfigManager.language);
+		},
+		
+		
+		load: function(){
+			
+		}
+	};
+
+	//---------------- PRIVATE FUNCTIONS ----------------//
+
+	function loadSync(targetUrl, callback){
+		var data = JSON.parse($.ajax({
+			url : targetUrl,
+			dataType: 'JSON',
+			async: false
+		}).responseText);
+		callback(data);
+	}
+
+})();

--- a/src/library/objects/TranslationFile.js
+++ b/src/library/objects/TranslationFile.js
@@ -1,0 +1,62 @@
+(function(){
+    "use strict";
+
+    window.KC3TranslationFile = function( source, filename, language, async ){
+        this.source = source;
+        this.filename = filename;
+        this.language = language;
+        this.async = typeof async == 'undefined' ? true : async;
+        
+        this.json_en = {};
+        this.json_local = {};
+    };
+    
+    //---------------- PUBLIC FUNCTIONS ----------------//
+    
+    KC3TranslationFile.prototype.loadEnglish = function(callback){
+        loadJSON(
+            repo+'lang/data/en/' + filename + '.json',
+            this.async,
+            callback
+        );
+    };
+    
+    KC3TranslationFile.prototype.loadLanguage = function(){
+        
+    };
+    
+    KC3TranslationFile.prototype.addTags = function(){
+        
+    };
+    
+    
+    //---------------- PRIVATE FUNCTIONS ----------------//
+    
+    function loadJSON(targetUrl, doAsync, callback){
+        try {
+            (doAsync ? loadAsync : loadSync )(targetUrl, callback);
+        } catch (e) {
+            callback({}, e);
+        }
+    }
+    
+    function loadSync(targetUrl, callback){
+        var data = JSON.parse($.ajax({
+            url : targetUrl,
+            dataType: 'JSON',
+            async: false
+        }).responseText);
+        callback(data);
+    }
+    
+    function loadAsync(targetUrl, callback){
+        $.ajax({
+            url : targetUrl,
+            dataType: 'JSON',
+            sucess: function(response){
+                callback(JSON.parse(response));
+            }
+        });
+    }
+
+})();

--- a/src/plugins/localization/localization.js
+++ b/src/plugins/localization/localization.js
@@ -1,0 +1,137 @@
+(function(){
+	
+	const PluginSettings = [
+		{
+			id : "language",
+			name : "SettingsLanguage",
+			type : "radio",
+			options : {
+				choices : [
+					[ "en", "English" ],
+					[ "de", "Deutsch" ],
+					[ "nl", "Dutch" ],
+					[ "es", "Español" ],
+					[ "fr", "Français" ],
+					[ "id", "Indonesian" ],
+					[ "it", "Italiano" ],
+					[ "jp", "日本語" ],
+					[ "kr", "한국어" ],
+					[ "pt", "Português" ],
+					[ "ru", "Русский" ],
+					[ "scn", "简体中文" ],
+					[ "tcn", "繁體中文" ],
+					[ "th", "ภาษาไทย" ],
+					[ "vi", "Tiếng Việt" ],
+					[ "ua", "Українська" ]
+				]
+			}
+		}
+	];
+	
+	const PluginLoaded = function(){
+		
+		KC3Translation.loadTranslationFile = function(filename, callback){
+			const tlfile = new KC3TranslationFile(source, filename, language, true);
+			
+			// tlfile
+			
+		};
+		
+		
+		KC3Meta.loadTranslations = function(){
+			var self = this;
+			
+			KC3Translation.setSource(repo);
+			
+			KC3Translation.loadTranslationFile('ships', function(data){ self._ship = data; });
+			KC3Translation.loadTranslationFile('items', function(data){ self._slotitem = data; });
+			KC3Translation.loadTranslationFile('equiptype', function(data){ self._equiptype = data; });
+			KC3Translation.loadTranslationFile('quests', function(data){ self._quests = data; });
+			KC3Translation.loadTranslationFile('ranks', function(data){ self._ranks = data; });
+			KC3Translation.loadTranslationFile('stype', function(data){ self._stype = data; });
+			KC3Translation.loadTranslationFile('servers', function(data){ self._servers = data; });
+			KC3Translation.loadTranslationFile('battle', function(data){ self._battle = data; });
+			KC3Translation.loadTranslationFile('custom', function(data){ self._langcustom = data; });
+		};
+		
+		/**
+		 * APPLY WORDS
+		 * Change words inside visible DOM elements
+		 */
+		KC3Translation.applyWords = function(){
+			// Interchange element contents with translations
+			$(".i18n").each(function(){
+				$(this).html( KC3Meta.term( $(this).text() ) );
+				$(this).css("visibility", "visible");
+			});
+			// Update title attribute with translations
+			$(".i18n_title").each(function(){
+				$(this).attr("title", KC3Meta.term( $(this).attr("title") ) );
+			});
+		};
+		
+		/**
+		 * APPLY CUSTOM FONTS
+		 * For specific languages that need custom font for readability
+		 */
+		KC3Translation.applyCustomFont = function(){
+			// Specialized fonts
+			var fontFamily = false;
+			switch(ConfigManager.language){
+				
+				case "scn": fontFamily = '"HelveticaNeue-Light","Helvetica Neue Light","Helvetica Neue",Helvetica,"Nimbus Sans L",Arial,"Lucida Grande","Liberation Sans","Microsoft YaHei UI","Microsoft YaHei","Hiragino Sans GB","Wenquanyi Micro Hei","WenQuanYi Zen Hei","ST Heiti",SimHei,"WenQuanYi Zen Hei Sharp",sans-serif'; break;
+				
+				case "tcn": fontFamily = '"Helvetica Neue", Helvetica, "Microsoft JhengHei", "Microsoft JhengHei UI", Arial,"Heiti TC", sans-serif'; break;
+				
+				case "jp": fontFamily = '"Helvetica Neue", "Tahoma", Helvetica, Arial, "ヒラギノ角ゴ Pro W3", "Hiragino Kaku Gothic Pro", Osaka, "メイリオ", "Meiryo", "Yu Gothic UI Semibold", "ＭＳ Ｐゴシック", "MS PGothic", sans-serif'; break;
+				
+				default: break;
+			}
+			
+			if(fontFamily){ $("body").css("font-family", fontFamily); }
+		};
+		
+		/**
+		 * APPLY HTML LANGUAGE TAG
+		 * Add attribute to HTML tag about language
+		 */
+		KC3Translation.applyHtmlLanguageTag = function(){
+			// Apply HTML language code
+			$("html").attr("lang", ConfigManager.language);
+		};
+		
+	};
+	
+	KC3Plugins.registerPlugin('localization', PluginLoaded, PluginSettings);
+	
+	KC3Plugins.registerHook.Game('localization', function(){
+		KC3Translation.applyWords();
+		KC3Translation.applyCustomFont();
+		KC3Translation.applyHtmlLanguageTag();
+	});
+	
+	KC3Plugins.registerHook.StrategyRoom('localization', function(){
+		KC3Translation.applyWords();
+		KC3Translation.applyCustomFont();
+		KC3Translation.applyHtmlLanguageTag();
+	});
+	
+	KC3Plugins.registerHook.Panel('localization', function(){
+		KC3Translation.applyWords();
+		KC3Translation.applyCustomFont();
+		KC3Translation.applyHtmlLanguageTag();
+	});
+	
+	KC3Plugins.registerHook.Page('localization', function(){
+		KC3Translation.applyWords();
+		KC3Translation.applyCustomFont();
+		KC3Translation.applyHtmlLanguageTag();
+	});
+	
+	KC3Plugins.registerHook.Menu('localization', function(){
+		KC3Translation.applyWords();
+		KC3Translation.applyCustomFont();
+		KC3Translation.applyHtmlLanguageTag();
+	});
+	
+})();

--- a/src/plugins/online-translation/Translation.js
+++ b/src/plugins/online-translation/Translation.js
@@ -1,0 +1,80 @@
+(function(){
+	"use strict";
+	
+	var super;
+	
+	super = KC3Translation.execute;
+	KC3Translation.execute = function(){
+		super();
+		this.applyCustomFont();
+	};
+	
+	
+	
+	
+	
+	
+	
+	 = {
+
+		execute :function(){
+			this.applyWords();
+			this.applyCustomFont();
+			this.applyHTML();
+		},
+		
+		
+		/* APPLY WORDS
+		Change words inside visible DOM elements
+		-----------------------------------------*/
+		applyWords :function(){
+			// Interchange element contents with translations
+			$(".i18n").each(function(){
+				$(this).html( KC3Meta.term( $(this).text() ) );
+				$(this).css("visibility", "visible");
+			});
+			
+			// Update title attribute with translations
+			$(".i18n_title").each(function(){
+				$(this).attr("title", KC3Meta.term( $(this).attr("title") ) );
+			});
+		},
+		
+		/* APPLY CUSTOM FONT
+		For languages read best in other fonts
+		-----------------------------------------*/
+		applyCustomFont: function(){
+			// Specialized fonts
+			var fontFamily = false;
+			// ConfigManager.language
+			// KC3Meta._langcustom.
+		},
+		
+		/* APPLY HTML
+		Specialized Language HTML adjustments
+		-----------------------------------------*/
+		applyHTML :function(){
+			if(fontFamily){ $("body").css("font-family", fontFamily); }
+			
+			// Apply HTML language code
+			$("html").attr("lang", ConfigManager.language);
+		},
+		
+		
+		load: function(){
+			
+		}
+	};
+
+	//---------------- PRIVATE FUNCTIONS ----------------//
+
+	function loadSync(targetUrl, callback){
+		var data = JSON.parse($.ajax({
+			url : targetUrl,
+			dataType: 'JSON',
+			async: false
+		}).responseText);
+		callback(data);
+	}
+
+})();

--- a/src/plugins/online-translation/TranslationFile.js
+++ b/src/plugins/online-translation/TranslationFile.js
@@ -1,6 +1,31 @@
+/**
+ * KC3 Translation File
+ * Used to laod a single translation file from a specifiable source
+ * 
+ * Browser compatibility
+ * Requires: Chrome 49.0 (ES6)
+ * https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Classes#Browser_compatibility
+ */
+class KC3TranslationFile {
+    
+    constructor(source, filename, language, async) {
+        this.source = source;
+        this.filename = filename;
+        this.language = language;
+        this.async = typeof async == 'undefined' ? true : async;
+        
+        this.json_en = {};
+        this.json_local = {};
+    }
+    
+    
+}
+
+
 (function(){
     "use strict";
 
+    
     window.KC3TranslationFile = function( source, filename, language, async ){
         this.source = source;
         this.filename = filename;

--- a/src/plugins/online-translation/online-translation.js
+++ b/src/plugins/online-translation/online-translation.js
@@ -1,0 +1,52 @@
+(function(){
+	
+	const PluginDepends = [
+		'localization'
+	];
+	
+	const PluginSettings = [
+		{
+			id: "onlinetl_source",
+			name: "Source URL",
+			type: "long_text"
+		}
+	];
+	
+	const PluginLoaded = function(){
+		const source = ConfigManager.onlinetl_source;
+		const language = ConfigManager.language;
+		
+		KC3Translation.checkOnlineTranslations = function(filename){
+			const self = this;
+			this.loadTranslationFile('custom', function(local){
+				$.ajax({
+					url: source + '/' + language + '/custom.json',
+					dataType: 'JSON',
+					success: function(online){
+						self.compareOnlineTranslations(local.fileVersions, online.fileVersions);
+					}
+				});
+			});
+		};
+		
+		KC3Translation.compareOnlineTranslations = function(localVersions, onlineVersions){
+			const self = this;
+			Object.keys(localVersions).map(function(key) {
+				// Local is different from online version
+				if (localVersions[key] !== onlineVersions[key]) {
+					self.loadTranslationFile(key, function(){
+						
+					});
+				}
+			});
+		};
+		
+	};
+	
+	KC3Plugins.registerPlugin('online-translation', PluginDepends, PluginSettings, PluginLoaded);
+	
+	KC3Plugins.registerHook.Game('online-translation', function(){
+		KC3Translation.checkOnlineTranslations();
+	});
+	
+})();


### PR DESCRIPTION
As a prerequisite to loading translation files online so we do not need to do webstore releases every time there is a quest or quote update.

This might be difficult to implement now, but will try my best not to break stuff :sweat_drops: 

If this proves to take longer to figure out, we might resort to synchronous loading online translations for the mean time, although this would involve having TL versioning so we dont download it each time.