### PR TITLE
node tooltips for resource gain / loss

### DIFF
--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -158,6 +158,46 @@ Used by SortieManager
 		this.dameConConsumedEscort = [];
 		return this;
 	};
+
+	// (TODO) perhaps there are better places for holding this...
+	var resourceNames = {
+		1: "Fuel",
+		2: "Ammo",
+		3: "Steel",
+		4: "Bauxite",
+		5: "Blowtorch",
+		6: "Bucket",
+		7: "DevMat",
+		10: "Furniture Box (Small)",
+		11: "Furniture Box (Medium)",
+		12: "Furniture Box (Large)"
+	};
+
+	// for building up resource gain / loss descriptions
+	// internal use only.
+	function buildDescription(itemInfoAr) {
+		function vconcat(xs) {
+			if (xs.length > 0)
+				return xs.reduce(function(acc,cur) {
+					return acc + "\n" + cur;
+				});
+			else
+				return "";
+		}
+		var resourceDescs = [];
+		itemInfoAr.map(function(item) {
+			var rescKeyDesc = resourceNames[ item.api_icon_id ];
+			if (typeof rescKeyDesc === "undefined")
+				return;
+			if (typeof item.api_getcount !== "undefined")
+				resourceDescs.push( rescKeyDesc + ": " + item.api_getcount );
+			else if (typeof item.api_count !== "undefined")
+				resourceDescs.push( rescKeyDesc + ": -" + item.api_count );
+			else
+				return;
+		});
+		return vconcat( resourceDescs );
+	}
 	
 	KC3Node.prototype.defineAsResource = function( nodeData ){
 		var self = this;
@@ -168,6 +208,7 @@ Used by SortieManager
 		if (typeof nodeData.api_itemget == "object" && typeof nodeData.api_itemget.api_id != "undefined") {
 			nodeData.api_itemget = [nodeData.api_itemget];
 		}
+		this.tooltip = buildDescription( nodeData.api_itemget );
 		nodeData.api_itemget.forEach(function(itemget){
 			var icon_id = itemget.api_icon_id;
 			var getcount = itemget.api_getcount;
@@ -198,6 +239,10 @@ Used by SortieManager
 				[self.item-1]
 			)+".png";
 		};
+		this.tooltip = buildDescription(
+			[ { api_icon_id: nodeData.api_itemget_eo_comment.api_id,
+				api_getcount: nodeData.api_itemget_eo_comment.api_getcount
+			  } ] );
 		this.amount = nodeData.api_itemget_eo_comment.api_getcount;
 		KC3SortieManager.materialGain[this.item-1] += this.amount;
 		
@@ -215,6 +260,7 @@ Used by SortieManager
 				[nodeData.api_happening.api_icon_id-1]
 			)+".png";
 		};
+		this.tooltip = buildDescription( [nodeData.api_happening] );
 		this.amount = nodeData.api_happening.api_count;
 		return this;
 	};

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -1625,7 +1625,7 @@
 				case "resource":
 					$(".module.activity .sortie_node_"+numNodes)
 						.addClass("nc_resource")
-						.attr("title", thisNode.tooltip);
+						.attr("title", thisNode.nodeDesc);
 					var resBoxDiv = $(".module.activity .node_type_resource");
 					resBoxDiv.removeClass("node_type_maelstrom");
 					resBoxDiv.children().remove();
@@ -1644,7 +1644,7 @@
 				case "bounty":
 					$(".module.activity .sortie_node_"+numNodes)
 						.addClass("nc_resource")
-						.attr("title", thisNode.tooltip);
+						.attr("title", thisNode.nodeDesc);
 					$(".module.activity .node_type_resource").removeClass("node_type_maelstrom");
 					$(".module.activity .node_type_resource .node_res_icon img").attr("src",
 						thisNode.icon("../../../../assets/img/client/"));
@@ -1660,7 +1660,7 @@
 				case "maelstrom":
 					$(".module.activity .sortie_node_"+numNodes)
 						.addClass("nc_maelstrom")
-						.attr("title", thisNode.tooltip);
+						.attr("title", thisNode.nodeDesc);
 					$(".module.activity .node_type_resource").addClass("node_type_maelstrom");
 					$(".module.activity .node_type_resource .node_res_icon img").attr("src",
 						thisNode.icon("../../../../assets/img/client/"));

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -1593,7 +1593,8 @@
 			var map = KC3SortieManager.map_num;
 			var nodeId = KC3Meta.nodeLetter(world, map, thisNode.id );
 
-			$(".module.activity .sortie_node_"+numNodes).text( nodeId );
+			$(".module.activity .sortie_node_"+numNodes).text( nodeId ).removeAttr("title");
+
 			$(".module.activity .node_types").hide();
 
 			$(".module.activity .abyss_ship").hide();
@@ -1622,7 +1623,9 @@
 
 				// Resource node
 				case "resource":
-					$(".module.activity .sortie_node_"+numNodes).addClass("nc_resource");
+					$(".module.activity .sortie_node_"+numNodes)
+						.addClass("nc_resource")
+						.attr("title", thisNode.tooltip);
 					var resBoxDiv = $(".module.activity .node_type_resource");
 					resBoxDiv.removeClass("node_type_maelstrom");
 					resBoxDiv.children().remove();
@@ -1639,7 +1642,9 @@
 
 				// Bounty node on 1-6
 				case "bounty":
-					$(".module.activity .sortie_node_"+numNodes).addClass("nc_resource");
+					$(".module.activity .sortie_node_"+numNodes)
+						.addClass("nc_resource")
+						.attr("title", thisNode.tooltip);
 					$(".module.activity .node_type_resource").removeClass("node_type_maelstrom");
 					$(".module.activity .node_type_resource .node_res_icon img").attr("src",
 						thisNode.icon("../../../../assets/img/client/"));
@@ -1653,7 +1658,9 @@
 
 				// Maelstrom node
 				case "maelstrom":
-					$(".module.activity .sortie_node_"+numNodes).addClass("nc_maelstrom");
+					$(".module.activity .sortie_node_"+numNodes)
+						.addClass("nc_maelstrom")
+						.attr("title", thisNode.tooltip);
 					$(".module.activity .node_type_resource").addClass("node_type_maelstrom");
 					$(".module.activity .node_type_resource .node_res_icon img").attr("src",
 						thisNode.icon("../../../../assets/img/client/"));


### PR DESCRIPTION
hover on resource / maelstrom nodes to see resource gain / loss on that node.

![2017-01-06_174812_3840x1080_scrot](https://cloud.githubusercontent.com/assets/1096354/21735538/9cb4cdf0-d438-11e6-8328-754ff1668a7e.jpg)

already tested on resource / maelstrom / bounty (1-6 N) nodes.