### PR TITLE
Update recording properties of sortie IndexDB

### DIFF
--- a/src/library/managers/SortieManager.js
+++ b/src/library/managers/SortieManager.js
@@ -70,6 +70,7 @@ Xxxxxxx
 				fleet4: PlayerManager.fleets[3].sortieJson(),
 				support1: this.getSupportingFleet(false),
 				support2: this.getSupportingFleet(true),
+				lbas: this.getWorldLandBases(world),
 				time: stime
 			}, function(id){
 				self.onSortie = id;
@@ -117,6 +118,18 @@ Xxxxxxx
 					}
 				}
 			return 0;
+		},
+		
+		getWorldLandBases :function(world){
+			var lbas = [];
+			$.each(PlayerManager.bases, function(i, base){
+				if(base.rid > -1 && base.map === world
+					// Only sortie and defend needed
+					&& [1,2].indexOf(base.action) > -1){
+					lbas.push(base.sortieJson());
+				}
+			});
+			return lbas;
 		},
 		
 		getSortieFleet: function() {

--- a/src/library/objects/Fleet.js
+++ b/src/library/objects/Fleet.js
@@ -823,6 +823,20 @@ Contains summary information about a fleet and its 6 ships
 							ship.equipment(3).masterId,
 							ship.exItem().masterId
 						],
+						stars: [
+							ship.equipment(0).stars,
+							ship.equipment(1).stars,
+							ship.equipment(2).stars,
+							ship.equipment(3).stars,
+							ship.exItem().stars
+						],
+						ace: [
+							ship.equipment(0).ace,
+							ship.equipment(1).ace,
+							ship.equipment(2).ace,
+							ship.equipment(3).ace,
+							ship.exItem().ace
+						]
 					});
 				}
 			});

--- a/src/library/objects/LandBase.js
+++ b/src/library/objects/LandBase.js
@@ -43,4 +43,34 @@
 		});
 	};
 	
+	/**
+	 * Convert to new Object used to record sorties on indexedDB
+	 * Use masterId instead of rosterId, also record stars and ace of aircraft.
+	 */
+	KC3LandBase.prototype.sortieJson = function(){
+		var returnObj = {};
+		if(this.rid > -1){
+			returnObj.rid = this.rid;
+			returnObj.range = this.range;
+			returnObj.action = this.action;
+			returnObj.planes = [];
+			$.each(this.planes, function(index, squad){
+				if(squad.api_slotid > 0){
+					var gear = KC3GearManager.get(squad.api_slotid);
+					returnObj.planes.push({
+						//squadron: squad.api_squadron_id,
+						mst_id: gear.masterId,
+						count: squad.api_count,
+						//max_count: squad.api_max_count,
+						stars: gear.stars,
+						ace: gear.ace,
+						//state: squad.api_state,
+						morale: squad.api_cond
+					});
+				}
+			});
+		}
+		return returnObj;
+	};
+	
 })();


### PR DESCRIPTION
Related to #1712. Updated `sortie` table, tested on my side.

* Add new LBAS array to record land base objects of sortied world only, and action: sortie or defend (maybe other actions also needed?)
* Add stars & ace for ship equipments including ex-slot (also fixed length array)

Next TODOs
* Fleet manager loading from sortie history could get stars & ace
* Maps/Events history could show LBAS up
* Calculate and show eLoS & air power of sortieing (the values at beginning only) for Maps/Events history

Not supports:
* eLoS and air power calculation for every Nodes at Maps History. As after each battle (even during one battle, different phase) need to be recalculated based on latest slot count and proficiency of planes, but we don't record the change of slots.