### PR TITLE
Support Long Distance Air Raid rank prediction

### DIFF
--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -883,6 +883,7 @@ Previously known as "Reactor"
 		/* NORMAL: BATTLE STARTS
 		-------------------------------------------------------*/
 		"api_req_sortie/battle":function(params, response, headers){
+			response.api_data.api_name = response.api_data.api_name || "battle";
 			KC3SortieManager.engageBattle(
 				response.api_data,
 				Date.toUTCseconds(headers.Date)
@@ -890,15 +891,18 @@ Previously known as "Reactor"
 			KC3Network.trigger("BattleStart");
 		},
 		"api_req_sortie/airbattle":function(params, response, headers){
+			response.api_data.api_name = "airbattle";
 			this["api_req_sortie/battle"].apply(this,arguments);
 		},
 		"api_req_sortie/ld_airbattle":function(params, response, headers){
+			response.api_data.api_name = "ld_airbattle";
 			this["api_req_sortie/battle"].apply(this,arguments);
 		},
 		
 		/* PLAYER-ONLY COMBINED FLEET: BATTLE STARTS
 		-------------------------------------------------------*/
 		"api_req_combined_battle/battle":function(params, response, headers){
+			response.api_data.api_name = response.api_data.api_name || "fc_battle";
 			KC3SortieManager.engageBattle(
 				response.api_data,
 				Date.toUTCseconds(headers.Date)
@@ -906,18 +910,22 @@ Previously known as "Reactor"
 			KC3Network.trigger("BattleStart");
 		},
 		"api_req_combined_battle/airbattle":function(params, response, headers){
+			response.api_data.api_name = "fc_airbattle";
 			this["api_req_combined_battle/battle"].apply(this,arguments);
 		},
 		"api_req_combined_battle/battle_water":function(params, response, headers){
+			response.api_data.api_name = "fc_battle_water";
 			this["api_req_combined_battle/battle"].apply(this,arguments);
 		},
 		"api_req_combined_battle/ld_airbattle":function(params, response, headers){
+			response.api_data.api_name = "fc_ld_airbattle";
 			this["api_req_combined_battle/battle"].apply(this,arguments);
 		},
 		
 		/* BATTLE STARTS as NIGHT
 		-------------------------------------------------------*/
 		"api_req_battle_midnight/sp_midnight":function(params, response, headers){
+			response.api_data.api_name = response.api_data.api_name || "sp_midnight";
 			KC3SortieManager.engageBattleNight(
 				response.api_data,
 				Date.toUTCseconds(headers.Date)
@@ -925,19 +933,23 @@ Previously known as "Reactor"
 			KC3Network.trigger("BattleStart");
 		},
 		"api_req_combined_battle/sp_midnight":function(params, response, headers){
+			response.api_data.api_name = "fc_sp_midnight";
 			this["api_req_battle_midnight/sp_midnight"].apply(this,arguments);
 		},
 		"api_req_combined_battle/each_sp_midnight":function(params, response, headers){
+			response.api_data.api_name = "each_sp_midnight";
 			this["api_req_battle_midnight/sp_midnight"].apply(this,arguments);
 		},
 		
 		/* NIGHT BATTLES as SECOND PART
 		-------------------------------------------------------*/
 		"api_req_battle_midnight/battle":function(params, response, headers){
+			response.api_data.api_name = "midnight_battle";
 			KC3SortieManager.engageNight( response.api_data );
 			KC3Network.trigger("BattleNight");
 		},
 		"api_req_combined_battle/midnight_battle":function(params, response, headers){
+			response.api_data.api_name = "fc_midnight_battle";
 			KC3SortieManager.engageNight( response.api_data );
 			KC3Network.trigger("BattleNight");
 		},
@@ -945,6 +957,7 @@ Previously known as "Reactor"
 		/* ENEMY COMBINED FLEET
 		-------------------------------------------------------*/
 		"api_req_combined_battle/ec_battle":function(params, response, headers){
+			response.api_data.api_name = "ec_battle";
 			KC3SortieManager.engageBattle(
 				response.api_data,
 				Date.toUTCseconds(headers.Date)
@@ -952,6 +965,7 @@ Previously known as "Reactor"
 			KC3Network.trigger("BattleStart");
 		},
 		"api_req_combined_battle/ec_midnight_battle":function(params, response, headers){
+			response.api_data.api_name = "ec_midnight_battle";
 			KC3SortieManager.engageNight(
 				response.api_data,
 				Date.toUTCseconds(headers.Date)
@@ -962,6 +976,7 @@ Previously known as "Reactor"
 		/* BOTH COMBINED FLEET
 		-------------------------------------------------------*/
 		"api_req_combined_battle/each_battle":function(params, response, headers){
+			response.api_data.api_name = response.api_data.api_name || "each_battle";
 			KC3SortieManager.engageBattle(
 				response.api_data,
 				Date.toUTCseconds(headers.Date)
@@ -969,12 +984,15 @@ Previously known as "Reactor"
 			KC3Network.trigger("BattleStart");
 		},
 		"api_req_combined_battle/each_airbattle":function(params, response, headers){
+			response.api_data.api_name = "each_airbattle";
 			this["api_req_combined_battle/each_battle"].apply(this,arguments);
 		},
 		"api_req_combined_battle/each_battle_water":function(params, response, headers){
+			response.api_data.api_name = "each_battle_water";
 			this["api_req_combined_battle/each_battle"].apply(this,arguments);
 		},
 		"api_req_combined_battle/each_ld_airbattle":function(params, response, headers){
+			response.api_data.api_name = "each_ld_airbattle";
 			this["api_req_combined_battle/each_battle"].apply(this,arguments);
 		},
 		

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -23,7 +23,7 @@ Used by SortieManager
 	// arrays are all begins at 0
 	// Regular battle rules: https://github.com/andanteyk/ElectronicObserver/blob/master/ElectronicObserver/Other/Information/kcmemo.md#%E6%88%A6%E9%97%98%E5%8B%9D%E5%88%A9%E5%88%A4%E5%AE%9A
 	// Long distance air raid rules: https://github.com/andanteyk/ElectronicObserver/blob/master/ElectronicObserver/Other/Information/kcmemo.md#%E9%95%B7%E8%B7%9D%E9%9B%A2%E7%A9%BA%E8%A5%B2%E6%88%A6%E3%81%A7%E3%81%AE%E5%8B%9D%E5%88%A9%E5%88%A4%E5%AE%9A
-	KC3Node.predictRank = function(beginHPs, endHPs) {
+	KC3Node.predictRank = function(beginHPs, endHPs, battleName) {
 		console.assert( 
 			beginHPs.ally.length === endHPs.ally.length,
 			"ally data length mismatched");
@@ -93,6 +93,20 @@ Used by SortieManager
 		var equalOrMore = enemyGaugeRate > (0.9 * allyGaugeRate);
 		var superior = enemyGaugeRate > 0 && enemyGaugeRate > (2.5 * allyGaugeRate);
 
+		// For long distance air raid
+		if ( (battleName||"").indexOf("ld_airbattle") >-1 ) {
+			if (allyGaugeRate <= 0)
+				return "SS";
+			else if (allyGaugeRate < 10)
+				return "A";
+			else if (allyGaugeRate < 20)
+				return "B";
+			else if (allyGaugeRate < 50)
+				return "C";
+			else if (allyGaugeRate < 80)
+				return "D";
+			return "E";
+		}
 		if (allySunkCount === 0) {
 			if (enemySunkCount === enemyCount) {
 				return allyGauge === 0 ? "SS" : "S";
@@ -525,11 +539,12 @@ Used by SortieManager
 					}
 				}
 				
-				if(ConfigManager.info_btrank &&
-					// long distance aerial battle not predictable for now, see #1333
+				if(ConfigManager.info_btrank
+					// long distance aerial battle not accurate for now, see #1333
 					// but go for aerial battle (eventKind:4) possible Yasen
-					[6].indexOf(this.eventKind)<0 ){
-					this.predictedRank = KC3Node.predictRank( beginHPs, endHPs );
+					//&& [6].indexOf(this.eventKind)<0
+					){
+					this.predictedRank = KC3Node.predictRank( beginHPs, endHPs, battleData.api_name );
 					// console.debug("Rank Predict:", this.predictedRank);
 				}
 				


### PR DESCRIPTION
Although the ally gauge rate ranges may not be accurate by fully testing, as there is no night battle for LD Air Raid, I think it doesn't matter if prediction goes wrong. (tested on 6-4 ld_airbattle)

btw1: why it was not supported, see #1333 
btw2, rank predict for combined fleet (no matter which side) still not supported yet.

This PR main point is to recognize all the battle api call types on Node class side which hidden by re-invoking normal battle function on handling kcsapi (by adding a fake property `api_name` to API data)...