### PR TITLE
expedition panel: great success condition checker

### DIFF
--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -1524,7 +1524,9 @@ ABYSS FLEET
 	font-size: 14px;
 	color:#ccc
 }
-.module.activity .activity_expeditionPlanner .expPlanner_text_passed{	
+.module.activity .activity_expeditionPlanner .expPlanner_text.gsrate_content.golden {	
+	color:gold;
+}
 	font-size: 14px;
 	color:#00CC00
 }

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -21,7 +21,7 @@ html,body {
 	transition: all 0.4s;
 }
 #critical.anim2 {
-	box-shadow:inset 0px 0px 60px rgba(255,0,0,0.8); 
+	box-shadow:inset 0px 0px 60px rgba(255,0,0,0.8);
 }
 
 /* MODALS
@@ -255,7 +255,7 @@ html,body {
 	line-height:24px;
 	font-size:18px;
 	float:left;
-	white-space:nowrap; 
+	white-space:nowrap;
 	overflow:hidden;
 	text-overflow: ellipsis;
 	-webkit-user-select: none;
@@ -271,7 +271,7 @@ html,body {
 	line-height:16px;
 	font-size:12px;
 	float:left;
-	white-space:nowrap; 
+	white-space:nowrap;
 	overflow:hidden;
 	text-overflow: ellipsis;
 	color:#aaa;
@@ -335,7 +335,7 @@ html,body {
 
 /*------- ACTIVITY: BASIC -------*/
 .module.activity .activity_basic {
-	
+
 }
 /* Consumables */
 .module.activity .consumables {
@@ -697,7 +697,7 @@ ABYSS FLEET
 	margin:0px 0px 1px 0px;
 }
 .module.activity .abyss_combined .abyss_fleet_1 {
-	
+
 }
 .module.activity .abyss_combined .abyss_fleet_2 {
 	margin:0px 0px 0px 10px;
@@ -1044,7 +1044,7 @@ ABYSS FLEET
 	margin:0px 5px 0px 0px;
 	background:#fff;
 	border-radius:10px;
-	
+
 }
 .module.activity .activity_crafting .equipStatIcon img {
 	width:16px;
@@ -1364,10 +1364,10 @@ ABYSS FLEET
     text-align:center;
     white-space:nowrap;
 }
-.module.activity .activity_expeditionPlanner .dropdown_title.expPlanner_text_passed{	
+.module.activity .activity_expeditionPlanner .dropdown_title.expPlanner_text_passed{
 	color:#006600;
 }
-.module.activity .activity_expeditionPlanner .dropdown_title.expPlanner_text_failed{	
+.module.activity .activity_expeditionPlanner .dropdown_title.expPlanner_text_failed{
 	color:#cc0000;
 }
 
@@ -1518,26 +1518,27 @@ ABYSS FLEET
 	margin-right:10px;
 }
 .module.activity .activity_expeditionPlanner .requirements_textbox {
-	display:inline-block;	
+	display:inline-block;
 }
-.module.activity .activity_expeditionPlanner .expPlanner_text{	
+.module.activity .activity_expeditionPlanner .expPlanner_text {
 	font-size: 14px;
 	color:#ccc
 }
-.module.activity .activity_expeditionPlanner .expPlanner_text.gsrate_content.golden {	
+.module.activity .activity_expeditionPlanner .expPlanner_text.gsrate_content.golden {
 	color:gold;
 }
+.module.activity .activity_expeditionPlanner .expPlanner_text_passed {
 	font-size: 14px;
-	color:#00CC00
+	color:#00CC00;
 }
-.module.activity .activity_expeditionPlanner .expPlanner_text_failed{	
+.module.activity .activity_expeditionPlanner .expPlanner_text_failed {
 	font-size: 14px;
-	color:#FF5555
+	color:#FF5555;
 }
-.module.activity .activity_expeditionPlanner .expedition_entry.cond_passed {	
+.module.activity .activity_expeditionPlanner .expedition_entry.cond_passed {
 	color:green
 }
-.module.activity .activity_expeditionPlanner .expedition_entry.cond_failed {	
+.module.activity .activity_expeditionPlanner .expedition_entry.cond_failed {
 	color:red
 }
 /*------- ACTIVITY: FIT -------*/
@@ -1615,7 +1616,7 @@ ABYSS FLEET
 	background:#a55;
 }
 .module.activity .activity_gunfit .fit_value.fit_unknown {
-	
+
 }
 .module.activity .activity_gunfit .fit_more {
 	color:#aaa;
@@ -1623,7 +1624,7 @@ ABYSS FLEET
 
 /*------- QUESTS -------*/
 .module.quests {
-	
+
 }
 .module.quests .quest {
 	height:20px;
@@ -1662,7 +1663,7 @@ ABYSS FLEET
 	/*background:#0f0;*/
 	float:left;
 	font-size:11px;
-	white-space:nowrap; 
+	white-space:nowrap;
 	overflow:hidden;
 	text-overflow: ellipsis;
 	color:#eee;
@@ -1685,7 +1686,7 @@ ABYSS FLEET
 
 /*------- CONTROLS -------*/
 .module.controls {
-	
+
 }
 .module.controls .control {
 	height:30px;
@@ -1771,7 +1772,7 @@ ABYSS FLEET
 
 /*------- SUMMARY -------*/
 .module.summary {
-	
+
 }
 .module.summary .summary_box {
 	width:73px;
@@ -1924,7 +1925,7 @@ ABYSS FLEET
 	float:left;
 	color:#ddd;
 	font-weight:bold;
-	white-space:nowrap; 
+	white-space:nowrap;
 	overflow:hidden;
 	text-overflow:ellipsis;
 }
@@ -2286,7 +2287,7 @@ ABYSS FLEET
 	float:left;
 	color:#ddd;
 	font-weight:bold;
-	white-space:nowrap; 
+	white-space:nowrap;
 	overflow:hidden;
 	text-overflow:ellipsis;
 }
@@ -2426,7 +2427,7 @@ ABYSS FLEET
 	color:#fff;
 	text-shadow:0px 0px 5px #000;
 	font-size:13px;
-	white-space:nowrap; 
+	white-space:nowrap;
 	overflow:hidden;
 	text-overflow: ellipsis;
 	-webkit-user-select: none;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -1512,7 +1512,7 @@ ABYSS FLEET
     margin-bottom:4px;
 }
 .module.activity .activity_expeditionPlanner .expPlanner_checker_criterias {
-	margin-bottom:2px;
+	margin-bottom:1px;
 }
 .module.activity .activity_expeditionPlanner .expPlanner_shipReqBox {
 	margin-right:10px;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -1447,7 +1447,6 @@ ABYSS FLEET
     margin-right: 3px;
 }
 
-
 .module.activity .activity_expeditionPlanner .expPlanner_resos_title {
     text-align: center;
     height: 20px;
@@ -1513,12 +1512,12 @@ ABYSS FLEET
     margin-bottom:4px;
 }
 .module.activity .activity_expeditionPlanner .expPlanner_checker_criterias {
-	margin-bottom:3px;
+	margin-bottom:2px;
 }
 .module.activity .activity_expeditionPlanner .expPlanner_shipReqBox {
 	margin-right:10px;
 }
-.module.activity .activity_expeditionPlanner .requirements_textbox{
+.module.activity .activity_expeditionPlanner .requirements_textbox {
 	display:inline-block;	
 }
 .module.activity .activity_expeditionPlanner .expPlanner_text{	

--- a/src/pages/devtools/themes/natsuiro/natsuiro.html
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.html
@@ -135,6 +135,10 @@
 							<div class="expres_greatbtn hover"><img src="../../../../assets/img/ui/btn-xgs.png" /></div>
 						</div>
 						<div class="expPlanner_requirements">
+							<div class="expPlanner_checker_criterias row_gsrate">
+								<div class="requirements_textbox expPlanner_text gsrate_description i18n">ExpedGSRate</div>
+								<div class="requirements_textbox expPlanner_text gsrate_content">???</div>
+							</div>
 							<div class="expPlanner_checker_criterias">
 								<div class="requirements_textbox expPlanner_text i18n">ExpedFSLv</div>
 								<div class="requirements_textbox expPlanner_text_passed flagshipLv">65</div>

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -2699,12 +2699,13 @@
 					 ? fleetDrumCount >= gsDrumCount
 					 : true) );
 
+			var tooltipText = KC3Meta.term("ExpedGSRateExplainSparkle").format(sparkedCount);
 			// apply tooltip to overdrum expeds
-			if (typeof gsDrumCount !== "undefined") {
-				jqGSRate.attr("title", "text TODO {0}/{1}".format(fleetDrumCount, gsDrumCount));
-			} else {
-				jqGSRate.removeAttr( "title" );
-			}
+			if (typeof gsDrumCount !== "undefined")
+				tooltipText += "\n" + KC3Meta.term("ExpedGSRateExplainExtraDrum").format(fleetDrumCount, gsDrumCount);
+
+			jqGSRate.attr("title", tooltipText);
+
 			// hide GS rate if user does not intend doing so.
 			$(".module.activity .activity_expeditionPlanner .row_gsrate")
 				.toggle( plannerIsGreatSuccess );

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -2680,7 +2680,31 @@
 			// "???" instead of "?" to make it more noticable.
 			var sparkedCount = fleetObj.ship().filter( function(s) { return s.morale >= 50; } ).length;
 			var estSuccessRate = "~" + Math.min( 99, 19 * sparkedCount ) + "%";
+			var fleetDrumCount = fleetObj.countDrums();
 			jqGSRate.text( sparkedCount < 4 ? "???" : estSuccessRate );
+			// reference: http://wikiwiki.jp/kancolle/?%B1%F3%C0%AC
+			var gsDrumCountTable = {
+				21: 3+1,
+				37: 4+1,
+				38: 8+2,
+				24: 0+4,
+				40: 0+4 };
+			var gsDrumCount = gsDrumCountTable[selectedExpedition];
+			// apply golden text when we have >= 4 sparked ships.
+			// for overdrum expeds, we further require extra number of drums
+			jqGSRate.toggleClass(
+				"golden",
+				(sparkedCount >= 4) &&
+					(typeof gsDrumCount !== "undefined"
+					 ? fleetDrumCount >= gsDrumCount
+					 : true) );
+
+			// apply tooltip to overdrum expeds
+			if (typeof gsDrumCount !== "undefined") {
+				jqGSRate.attr("title", "text TODO {0}/{1}".format(fleetDrumCount, gsDrumCount));
+			} else {
+				jqGSRate.removeAttr( "title" );
+			}
 
 			var markFailed = function (jq) {
 				jq.addClass("expPlanner_text_failed").removeClass("expPlanner_text_passed");

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -2673,6 +2673,15 @@
 				jqObj.attr( 'title', tooltipText.text );
 			});
 
+			var jqGSRate = $(".module.activity .activity_expeditionPlanner .row_gsrate .gsrate_content");
+
+			// success rate is forced to be unknown when there are less than 4 ships
+			// and is capped at 99%.
+			// "???" instead of "?" to make it more noticable.
+			var sparkedCount = fleetObj.ship().filter( function(s) { return s.morale >= 50; } ).length;
+			var estSuccessRate = "~" + Math.min( 99, 19 * sparkedCount ) + "%";
+			jqGSRate.text( sparkedCount < 4 ? "???" : estSuccessRate );
+
 			var markFailed = function (jq) {
 				jq.addClass("expPlanner_text_failed").removeClass("expPlanner_text_passed");
 				return jq;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -2705,6 +2705,9 @@
 			} else {
 				jqGSRate.removeAttr( "title" );
 			}
+			// hide GS rate if user does not intend doing so.
+			$(".module.activity .activity_expeditionPlanner .row_gsrate")
+				.toggle( plannerIsGreatSuccess );
 
 			var markFailed = function (jq) {
 				jq.addClass("expPlanner_text_failed").removeClass("expPlanner_text_passed");


### PR DESCRIPTION
Implement #1690.

Added "GS Rate" together with some hint texts:
![2017-01-08_121759_3840x1080_scrot](https://cloud.githubusercontent.com/assets/1096354/21751885/a8b9890a-d59c-11e6-96a9-c516121c7440.jpg)

- only visible when "great success" toggle is on
- great success rate is only available when having >=4 sparkled ships in fleet (otherwise the text is always `???` because we lack an accurate estimation for this situation)
- the text turns golden when having >=4 sparked ships
    - exceptions are expedition 21, 24, 37, 38, 40, for these expeditions we further require carrying sufficient drums before the text can turn golden. 

