### PR TITLE
Update ledger DB recording

### DIFF
--- a/src/library/managers/SortieManager.js
+++ b/src/library/managers/SortieManager.js
@@ -375,21 +375,23 @@ Xxxxxxx
 			localStorage.setObject('sortie',this);
 		},
 		
-		endSortie :function(){
-			var
-				pvpData = JSON.parse(localStorage.statistics || "{}").pvp,
-				sentFleet = this.fleetSent,
-				self = this,
-				cons = {};
-			this.fleetSent = 1;
-			cons.name = self.isPvP() ? (
+		sortieName :function(diff){
+			var pvpData = JSON.parse(localStorage.statistics || "{}").pvp;
+			return this.isPvP() ? (
 				/* There's a possibility to encounter String bug
 				   -- if either win/lose counter is zero
 				*/
-				"pvp" + (self.onSortie = (Number(pvpData.win) + Number(pvpData.lose) + 1))
-			) : ("sortie" + self.onSortie);
+				"pvp" + (this.onSortie = (Number(pvpData.win) + Number(pvpData.lose) + (diff||1)))
+			) : ("sortie" + this.onSortie);
+		},
+		
+		endSortie :function(){
+			var sentFleet = this.fleetSent,
+				self = this,
+				cons = {};
+			this.fleetSent = 1;
+			cons.name = self.sortieName();
 			cons.resc = Array.apply(null,{length:8}).map(function(){return 0;});
-			console.log("Pre-%s State",cons.name,PlayerManager.hq.lastSortie);
 			// Calculate sortie difference with buffer
 			(PlayerManager.hq.lastSortie || []).forEach(function(fleet,fleet_id){
 				fleet.forEach(function(after,ship_fleet){
@@ -414,21 +416,23 @@ Xxxxxxx
 						repLen   = before.repair.length * !self.isPvP(),
 						repair   = [1,2,9].map(function(x){
 							return (x<repLen) ? Math.min(0,after.repair[x] - before.repair[x]) : 0;
-						});
+						}),
+						pendingCon = before.pendingConsumption[cons.name];
 					if(!self.isPvP())
 						before.lastSortie.unshift(cons.name);
-					if(!(supply.every(function(matr){return !matr;}) && repair.every(function(matr){return !matr;})))
-						if(true) {
-							console.log(rosterId,repair);
-							before.pendingConsumption[cons.name] = [supply,repair];
-						} else
-							[supply.repair].forEach(function(cost){
-								cost.forEach(function(matr,indx){
-									cons.resc[indx] -= matr;
-								});
-							});
+					console.log("Pending consumption",pendingCon);
+					// Count steel consumed by jet
+					if(Array.isArray(pendingCon) && pendingCon.length > 2) {
+						cons.resc[2] += pendingCon[2][0] || 0;
+						pendingCon.splice(2,1);
+					}
+					if(!(supply.every(function(matr){return !matr;}) && repair.every(function(matr){return !matr;}))){
+						console.log("Repair consumption",rosterId,repair);
+						before.pendingConsumption[cons.name] = [supply, repair];
+					}
 				});
 			});
+			console.log("Pre-%s State",cons.name,cons.resc,PlayerManager.hq.lastSortie);
 			// Ignore every resource gain if disconnected during sortie
 			if(this.onCat)
 				this.materialGain.fill(0);

--- a/src/library/objects/Fleet.js
+++ b/src/library/objects/Fleet.js
@@ -498,19 +498,31 @@ Contains summary information about a fleet and its 6 ships
 
 	KC3Fleet.prototype.calcResupplyCost = function() {
 		var self = this;
-		var totalFuel = 0;
-		var totalAmmo = 0;
-		var totalBauxite = 0;
+		var totalFuel = 0,
+			totalAmmo = 0,
+			totalSteel = 0,
+			totalBauxite = 0;
 		$.each( this.ships, function(i, shipId) {
 			if (shipId > -1) {
 				var shipObj = self.ship(i);
-				var cost = shipObj.calcResupplyCost(-1, -1, true);
+				var cost = shipObj.calcResupplyCost(-1, -1, true, true);
 				totalFuel += cost.fuel;
 				totalAmmo += cost.ammo;
+				totalSteel += cost.steel;
 				totalBauxite += cost.bauxite;
 			}
 		});
-		return {fuel: totalFuel, ammo: totalAmmo, bauxite:totalBauxite};
+		return {fuel: totalFuel, ammo: totalAmmo, steel: totalSteel, bauxite: totalBauxite};
+	};
+
+	KC3Fleet.prototype.calcJetsSteelCost = function(currentSortieId) {
+		var i, ship;
+		var totalSteel = 0;
+		for(i = 0; i < this.countShips(); i++) {
+			ship = this.ship(i);
+			totalSteel += ship.calcJetsSteelCost(currentSortieId);
+		}
+		return totalSteel;
 	};
 
 	/*--------------------------------------------------------*/

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -457,11 +457,13 @@ Used by SortieManager
 			}
 			// Jet planes consume steels each battle based on:
 			// pendingConsumingSteel = floor(jetMaster.api_cost * ship.slots[jetIdx] * 0.2)
-			/* Pseudocode of logic:
-			 PlayerManager.fleets[fleetId - 1].forEach(ship):
-			   if ship.equipment(i) === jet && ship.slots[i] > 0:
-			     ship.pendingConsuming[steel] = Math.floor(ship.slots[i] * jet.master().api_costs * 0.2)
-			*/
+			if(this.planeJetFighters.player[0] > 0
+				&& (KC3SortieManager.onSortie > 0 || KC3SortieManager.isPvP())){
+				var consumedSteel = PlayerManager.fleets[
+					(parseInt(fleetSent) || KC3SortieManager.fleetSent) - 1
+				].calcJetsSteelCost(KC3SortieManager.sortieName(2));
+				console.log("Jets consumed steel:", consumedSteel);
+			}
 		}
 		
 		// Boss Debuffed

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -1315,9 +1315,10 @@
 					$(".module.status .status_supply .status_text").addClass("bad");
 				}
 				$(".module.status .status_supply").attr("title",
-					FleetSummary.supplied ? "": KC3Meta.term("PanelResupplyCosts").format(
+					KC3Meta.term("PanelResupplyCosts").format(
 						FleetSummary.supplyCost.fuel, FleetSummary.supplyCost.ammo, FleetSummary.supplyCost.bauxite
-					)
+					) + (!FleetSummary.supplyCost.steel ? "" :
+						"\n" + KC3Meta.term("PanelConsumedSteel").format(FleetSummary.supplyCost.steel))
 				);
 
 				// STATUS: MORALE


### PR DESCRIPTION
Related to #1655, #1498, might be more.

Thanks to new game mechanism of LBAS and jet aircraft, the known fact that resources consumption for our Strategy Room ledger of these new stuffs are not correctly recorded yet. And unfortunately, these consumption are just counted at server-side, no any API data returned to client-side until player back to home port in game.

Known types of consumption not recorded for now:
 * LBAS sortie fuel and ammo, amounts are researched and verified, but may change for future events
 * LBAS losses of fuel or bauxite on enemy air raid, amount is verified but type is random
 * Jet bomber steel

Based on many verifier's hard works, and the timing confirmation of #1733, we could complete these data recording step by step.

This PR TODOs:
 * [x] Fuel and ammo consumption of sortied LBAS
 * [x] Steel consumption of Jet assault
 * ~~Possible amount of loss on enemy air raid~~ (only shown on panel activity, impossible to record). As not able to test for me, and not about DB recording, so leave it for another PR.