### PR TITLE
Improvements of Strategy Room Akashi page

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,6 +31,7 @@ module.exports = function(grunt) {
 					'assets/js/KanColleHelpers.js',
 					'assets/js/twbsPagination.min.js',
 					'assets/js/WhoCallsTheFleetShipDb.json',
+					'assets/js/WhoCallsTheFleetItemDb.json',
 					'assets/js/jszip.min.js',
 					'assets/js/bootstrap-slider.min.js',
 					'assets/js/no_ga.js'

--- a/src/library/managers/PlayerManager.js
+++ b/src/library/managers/PlayerManager.js
@@ -165,6 +165,7 @@ Does not include Ships and Gears which are managed by other Managers
 
 		setConsumables :function( data, stime ){
 			$.extend(this.consumables, data);
+			localStorage.consumables = JSON.stringify(this.consumables);
 
 			if(typeof localStorage.lastUseitem == "undefined"){ localStorage.lastUseitem = 0; }
 			var ResourceHour = Math.floor(stime/3600);
@@ -295,6 +296,12 @@ Does not include Ships and Gears which are managed by other Managers
 				this.fleets = this.fleets.map(function(x,i){
 					return (new KC3Fleet()).defineFormatted(oldFleets[i]);
 				});
+			}
+		},
+
+		loadConsumables :function(){
+			if(typeof localStorage.consumables != "undefined"){
+				this.consumables =  $.extend(this.consumables, JSON.parse(localStorage.consumables));
 			}
 		},
 

--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -296,6 +296,7 @@ Previously known as "Reactor"
 			}
 			
 			PlayerManager.setResources(myResources, UTCtime);
+			PlayerManager.setConsumables({}, UTCtime);
 			KC3Network.trigger("Consumables");
 		},
 		
@@ -338,6 +339,7 @@ Previously known as "Reactor"
 				}
 			}
 			console.log("useitems", PlayerManager.consumables);
+			PlayerManager.setConsumables({}, UTCtime);
 			KC3Network.trigger("Consumables");
 		},
 		

--- a/src/library/modules/WhoCallsTheFleetDb.js
+++ b/src/library/modules/WhoCallsTheFleetDb.js
@@ -86,6 +86,11 @@
 			return retVal;
 		},
 
+		getShipRemodel: function(shipId) {
+			var entry = this.db["s"+shipId];
+			return entry ? entry.remodel : false;
+		},
+
 		getItemImprovement: function(itemId) {
 			var entry = this.db["i"+itemId];
 			return !entry ? undefined : entry.improvement ? entry.improvement : false;

--- a/src/pages/strategy/tabs/akashi/akashi.css
+++ b/src/pages/strategy/tabs/akashi/akashi.css
@@ -43,7 +43,8 @@
 	padding:5px;
 }
 .tab_akashi .equipment.disabled {
-	
+	opacity:0.4;
+	background:#fcc;
 }
 
 .tab_akashi .equipment .eq_icon {
@@ -57,31 +58,26 @@
 	height:24px;
 }
 .tab_akashi .equipment .eq_name {
-	width:180px;
+	width:170px;
 	height:24px;
 	font-size:12px;
 	float:left;
 	overflow:hidden;
+	white-space:nowrap;
+	text-overflow:ellipsis;
 	margin:0px 5px 0px 0px;
 }
+
+
 .tab_akashi .equipment .eq_ships {
-	width:150px;
+	width:127px;
 	float:left;
 	padding:3px 0px;
+	margin:0px 2px 0px 0px;
 	min-height:24px;
 }
-.tab_akashi .equipment .eq_have {
-	height:24px;
-	float:left;
-}
-.tab_akashi .equipment .eq_next {
-	height:24px;
-	float:left;
-}
-
 
 .tab_akashi .eq_ship {
-	width:150px;
 	height:24px;
 }
 .tab_akashi .eq_ship .eq_ship_icon {
@@ -95,27 +91,103 @@
 	margin:2px;
 }
 .tab_akashi .eq_ship .eq_ship_name {
+	width:100px;
+	float:left;
+	overflow:hidden;
+	white-space:nowrap;
+	text-overflow:ellipsis;
+}
+
+
+.tab_akashi .equipment .eq_resources {
+	width:340px;
+	float:left;
+	padding:0px 0px;
+	min-height:78px;
+}
+
+.tab_akashi .eq_res {
+	margin:0px 0px 2px 0px;
+}
+.tab_akashi .eq_res .eq_res_line {
+	width:340px;
+	min-height:24px;
+	border-radius:7px;
+	margin:0px 0px 1px 0px;
+}
+.tab_akashi .eq_res .eq_res_line.insufficient {
+	background:#fcc;
+}
+.tab_akashi .eq_res .insufficient {
+	color:#f22 !important;
+}
+
+.tab_akashi .eq_res .eq_res_label {
+	width:60px;
+	font-size:12px;
+	color:#45a9a5;
+	float:left;
+	overflow:hidden;
+	white-space:nowrap;
+}
+.tab_akashi .eq_res .eq_res_icon {
+	width:20px;
+	height:20px;
 	float:left;
 }
-
-
-.tab_akashi .eq_inst {
-	width:40px;
-	height:22px;
-	margin:0px 2px 2px 0px;
-	border-radius:7px;
-	background:#def;
+.tab_akashi .eq_res .eq_res_value {
+	width:50px;
+	color:#333;
+	overflow:hidden;
+	white-space:nowrap;
+	float:left;
 }
-.tab_akashi .eq_inst .eq_inst_icon {
+.tab_akashi .eq_res .eq_res_value > span.cnt,
+.tab_akashi .eq_res .eq_res_value > div.cnt {
+	color:#7bcb52;
+}
+.tab_akashi .eq_res .eq_res_icon.consumed_icon img {
+	width:20px;
+	height:20px;
+}
+.tab_akashi .eq_res .eq_res_value.consumed_name {
+	width:120px;
+}
+.tab_akashi .eq_res .eq_res_value.consumed_name > div.val {
+	width:100px;
+	font-size:12px;
+	float:left;
+	overflow:hidden;
+	white-space:nowrap;
+	text-overflow:ellipsis;
+}
+.tab_akashi .eq_res .eq_res_value.consumed_name > div.cnt {
+	width:20px;
+}
+.tab_akashi .eq_res .eq_res_value.consumed_name > div.cnt.locked {
+	color:#ec0;
+}
+
+.tab_akashi .eq_res .eq_next {
+	margin-left:42px;
+}
+.tab_akashi .eq_res .eq_next .eq_arrow {
+	color:#7bcb52;
+	float:left;
+}
+.tab_akashi .eq_res .eq_next .eq_res_icon {
 	width:24px;
 	height:24px;
 	float:left;
 }
-.tab_akashi .eq_inst .eq_inst_upgrade img {
-	width:20px;
-	height:20px;
-	margin:2px;
+.tab_akashi .eq_res .eq_next .eq_res_icon img {
+	width:24px;
+	height:24px;
 }
-.tab_akashi .eq_inst .eq_ship_name {
-	float:left;
+.tab_akashi .eq_res .eq_next .eq_res_name {
+	width:260px;
+	font-size:12px;
+	overflow:hidden;
+	white-space:nowrap;
+	text-overflow:ellipsis;
 }

--- a/src/pages/strategy/tabs/akashi/akashi.css
+++ b/src/pages/strategy/tabs/akashi/akashi.css
@@ -13,6 +13,23 @@
 	text-align:center;
 }
 
+.tab_akashi .controls {
+	width:700px;
+	margin:0px 0px 0px 0px;
+	padding:5px 10px;
+}
+.tab_akashi .controls .control {
+	width:140px;
+	height:20px;
+	line-height:20px;
+	margin:0px 5px 0px 0px;
+	font-weight:bold;
+	font-size:12px;
+	text-align:center;
+	float:left;
+	border-radius:7px;
+}
+
 /* WEEKDAYS
 --------------------------------*/
 .tab_akashi .weekdays {
@@ -70,7 +87,7 @@
 
 
 .tab_akashi .equipment .eq_ships {
-	width:127px;
+	width:122px;
 	float:left;
 	padding:3px 0px;
 	margin:0px 2px 0px 0px;
@@ -91,7 +108,7 @@
 	margin:2px;
 }
 .tab_akashi .eq_ship .eq_ship_name {
-	width:100px;
+	width:95px;
 	float:left;
 	overflow:hidden;
 	white-space:nowrap;
@@ -100,7 +117,7 @@
 
 
 .tab_akashi .equipment .eq_resources {
-	width:340px;
+	width:345px;
 	float:left;
 	padding:0px 0px;
 	min-height:78px;
@@ -110,20 +127,14 @@
 	margin:0px 0px 2px 0px;
 }
 .tab_akashi .eq_res .eq_res_line {
-	width:340px;
+	width:345px;
 	min-height:24px;
 	border-radius:7px;
 	margin:0px 0px 1px 0px;
 }
-.tab_akashi .eq_res .eq_res_line.insufficient {
-	background:#fcc;
-}
-.tab_akashi .eq_res .insufficient {
-	color:#f22 !important;
-}
 
 .tab_akashi .eq_res .eq_res_label {
-	width:60px;
+	width:65px;
 	font-size:12px;
 	color:#45a9a5;
 	float:left;
@@ -137,7 +148,6 @@
 }
 .tab_akashi .eq_res .eq_res_value {
 	width:50px;
-	color:#333;
 	overflow:hidden;
 	white-space:nowrap;
 	float:left;

--- a/src/pages/strategy/tabs/akashi/akashi.css
+++ b/src/pages/strategy/tabs/akashi/akashi.css
@@ -175,7 +175,6 @@
 	width:20px;
 }
 .tab_akashi .eq_res .eq_res_value.consumed_name > div.cnt.locked {
-	color:#ec0;
 }
 
 .tab_akashi .eq_res .eq_next {

--- a/src/pages/strategy/tabs/akashi/akashi.html
+++ b/src/pages/strategy/tabs/akashi/akashi.html
@@ -6,16 +6,27 @@
 <!-- HELP TOPICS -->
 <div class="page_help">
 	<div class="help_q">What do the red boxes and colored numbers mean?</div>
-	<div class="help_a">Red equipment boxes mean you cannot execute this upgrade. It's either you do not have this item, or you do not have any of the required ships, insufficient resources, devmats, screws or related items to be consumed.<br />
-	Yellow numbers mean the amount of items to be consumed you already have, but they are currently locked.
+	<div class="help_a">Red text and equipment boxes mean you cannot execute this upgrade. It's either you do not have this item or item with these stars, or you do not have any of the required ships, insufficient resources, devmats, screws or related items to be consumed.<br />
+	Yellow numbers mean the amount of items to be consumed you already have, but they are currently equipped or locked.
 	</div>
 	
-	<div class="help_q">Why are some amounts question mark?</div>
+	<div class="help_q">Why are some amounts question mark? why are some improvable items in game not here?</div>
 	<div class="help_a">Database for these items are not up to date yet, please wait for the results of verifying and updating.<br />
-	Alternatively visit wiki page or utility site like: <a href="http://fleet.moe/arsenal/" target="_blank">WhoCallsTheFleet Arsenal</a>, <a href="http://akashi-list.me/" target="_blank">Simplified Chart for Akashi</a>.</div>
+	Alternatively visit wiki pages or utility sites like: <a href="http://fleet.moe/arsenal/" target="_blank">WhoCallsTheFleet Arsenal</a>, <a href="http://akashi-list.me/" target="_blank">Simplified Chart for Akashi</a>.</div>
+
+	<div class="help_q">What are those green amounts in brackets?</div>
+	<div class="help_a">They are amounts required to guarantee success.</div>
+
+	<div class="help_q">Why does the prerequisite checking not matched with my data in game?</div>
+	<div class="help_a">Go to home port in game once, then click on Heart Logo to refresh with latest data.</div>
 
 </div>
 
+<!-- CONTROLS -->
+<div class="controls">
+	<div class="control hover" id="disabled_toggle">Toggle Improvable</div>
+	<div class="clear"></div>
+</div>
 <!-- CONTENT -->
 <div class="page_padding">
 	<div class="weekdays">
@@ -28,7 +39,6 @@
 		<div class="weekday hover bscolor4" id="weekday-6" data-value="sat">SAT</div>
 	</div>
 	<div class="equipment_list">
-		
 	</div>
 </div>
 

--- a/src/pages/strategy/tabs/akashi/akashi.html
+++ b/src/pages/strategy/tabs/akashi/akashi.html
@@ -5,9 +5,15 @@
 
 <!-- HELP TOPICS -->
 <div class="page_help">
-	<div class="help_q">What do the red boxes mean?</div>
-	<div class="help_a">Red equipment boxes mean you cannot execute this upgrade. It's either you do not have this item, or you do not have any of the required ships.</div>
+	<div class="help_q">What do the red boxes and colored numbers mean?</div>
+	<div class="help_a">Red equipment boxes mean you cannot execute this upgrade. It's either you do not have this item, or you do not have any of the required ships, insufficient resources, devmats, screws or related items to be consumed.<br />
+	Yellow numbers mean the amount of items to be consumed you already have, but they are currently locked.
+	</div>
 	
+	<div class="help_q">Why are some amounts question mark?</div>
+	<div class="help_a">Database for these items are not up to date yet, please wait for the results of verifying and updating.<br />
+	Alternatively visit wiki page or utility site like: <a href="http://fleet.moe/arsenal/" target="_blank">WhoCallsTheFleet Arsenal</a>, <a href="http://akashi-list.me/" target="_blank">Simplified Chart for Akashi</a>.</div>
+
 </div>
 
 <!-- CONTENT -->
@@ -33,8 +39,7 @@
 		<div class="eq_icon hover"><img/></div>
 		<div class="eq_name"></div>
 		<div class="eq_ships"></div>
-		<div class="eq_have"></div>
-		<div class="eq_next"></div>
+		<div class="eq_resources"></div>
 		<div class="clear"></div>
 	</div>
 	
@@ -44,8 +49,41 @@
 		<div class="clear"></div>
 	</div>
 	
-	<div class="eq_inst">
-		<div class="eq_inst_upgrade"></div>
+	<div class="eq_res">
+		<div class="eq_res_line material">
+			<div class="eq_res_label material">&nbsp;</div>
+			<div class="eq_res_icon fuel"><img src="../../../../assets/img/client/fuel.png" /></div><div class="eq_res_value fuel"></div>
+			<div class="eq_res_icon ammo"><img src="../../../../assets/img/client/ammo.png" /></div><div class="eq_res_value ammo"></div>
+			<div class="eq_res_icon steel"><img src="../../../../assets/img/client/steel.png" /></div><div class="eq_res_value steel"></div>
+			<div class="eq_res_icon bauxite"><img src="../../../../assets/img/client/bauxite.png" /></div><div class="eq_res_value bauxite"></div>
+		</div>
+		<div class="clear"></div>
+		<div class="eq_res_line plus0_5">
+			<div class="eq_res_label plus0_5">&#x2605;+0~+5</div>
+			<div class="eq_res_icon devmats plus0_5"><img src="../../../../assets/img/client/devmat.png" /></div><div class="eq_res_value devmats plus0_5"><span class="val">0</span> <span class="cnt">(0)</span></div>
+			<div class="eq_res_icon screws plus0_5"><img src="../../../../assets/img/client/screws.png" /></div><div class="eq_res_value screws plus0_5"><span class="val">0</span> <span class="cnt">(0)</span></div>
+			<div class="eq_res_icon consumed_icon plus0_5 hover"><img /></div><div class="eq_res_value consumed_name plus0_5"><div class="val"></div> <div class="cnt">x1</div></div>
+		</div>
+		<div class="clear"></div>
+		<div class="eq_res_line plus6_9">
+			<div class="eq_res_label plus6_9">&#x2605;+6~+9</div>
+			<div class="eq_res_icon devmats plus6_9"><img src="../../../../assets/img/client/devmat.png" /></div><div class="eq_res_value devmats plus6_9"><span class="val">0</span> <span class="cnt">(0)</span></div>
+			<div class="eq_res_icon screws plus6_9"><img src="../../../../assets/img/client/screws.png" /></div><div class="eq_res_value screws plus6_9"><span class="val">0</span> <span class="cnt">(0)</span></div>
+			<div class="eq_res_icon consumed_icon plus6_9 hover"><img /></div><div class="eq_res_value consumed_name plus6_9"><div class="val"></div> <div class="cnt">x1</div></div>
+		</div>
+		<div class="clear"></div>
+		<div class="eq_res_line plusmax">
+			<div class="eq_res_label plusmax">&#x2605;max</div>
+			<div class="eq_res_icon devmats plusmax"><img src="../../../../assets/img/client/devmat.png" /></div><div class="eq_res_value devmats plusmax"><span class="val">0</span> <span class="cnt">(0)</span></div>
+			<div class="eq_res_icon screws plusmax"><img src="../../../../assets/img/client/screws.png" /></div><div class="eq_res_value screws plusmax"><span class="val">0</span> <span class="cnt">(0)</span></div>
+			<div class="eq_res_icon consumed_icon plusmax hover"><img /></div><div class="eq_res_value consumed_name plusmax"><div class="val"></div> <div class="cnt">x1</div></div>
+		</div>
+		<div class="clear"></div>
+		<div class="eq_next">
+			<div class="eq_arrow">&#x279c;</div>
+			<div class="eq_res_icon hover"><img/></div>
+			<div class="eq_res_name"></div>
+		</div>
 		<div class="clear"></div>
 	</div>
 	

--- a/src/pages/strategy/tabs/akashi/akashi.js
+++ b/src/pages/strategy/tabs/akashi/akashi.js
@@ -7,6 +7,7 @@
 		tabSelf: KC3StrategyTabs.akashi,
 		upgrades: {},
 		today: {},
+		todaySortedIds: [],
 		ships: [],
 		gears: [],
 		instances: {},
@@ -26,6 +27,8 @@
 		---------------------------------*/
 		reload :function(){
 			var self = this;
+			PlayerManager.hq.load();
+			PlayerManager.loadConsumables();
 			KC3ShipManager.load();
 			KC3GearManager.load();
 			
@@ -47,13 +50,17 @@
 				}
 				
 				if(typeof self.instances[ThisGear.masterId] == "undefined"){
-					self.instances[ThisGear.masterId] = [];
+					self.instances[ThisGear.masterId] = {
+						total:0,star0_5:0,star6_9:0,starmax:0,unlocked:0
+					};
 				}
-				self.instances[ThisGear.masterId].push(ThisGear);
+				self.instances[ThisGear.masterId].id = ThisGear.masterId;
+				self.instances[ThisGear.masterId].total += 1;
+				self.instances[ThisGear.masterId].star0_5 += (!ThisGear.stars || ThisGear.stars < 6) & 1;
+				self.instances[ThisGear.masterId].star6_9 += (ThisGear.stars >= 6 && ThisGear.stars < 10) & 1;
+				self.instances[ThisGear.masterId].starmax += (ThisGear.stars == 10) & 1;
+				self.instances[ThisGear.masterId].unlocked += (ThisGear.lock === 0) & 1;
 			});
-			
-			//console.log(this.ships);
-			//console.log(this.gears);
 		},
 		
 		/* EXECUTE
@@ -83,20 +90,60 @@
 			$(".weekdays .weekday[data-value={0}]".format(dayName)).addClass("active");
 			
 			this.today = this.upgrades[ dayName ];
+			// Sort gears order by category ID asc, master ID asc
+			this.todaySortedIds = Object.keys(this.today).sort(function(a, b){
+				return KC3Master.slotitem(a).api_type[2] - KC3Master.slotitem(b).api_type[2]
+					|| Number(a) - Number(b);
+			});
 			
 			$(".equipment_list").empty();
 			
 			var ThisBox, MasterItem, ItemName;
 			var hasShip, hasGear, ctr;
 			var ShipBox, ShipId;
+			var ResBox;
 			var shipClickFunc = function(e){
 				KC3StrategyTabs.gotoTab("mstship", $(this).attr("alt"));
 			};
 			var gearClickFunc = function(e){
 				KC3StrategyTabs.gotoTab("mstgear", $(this).attr("alt"));
 			};
+			var toAmount = function(v){
+				return typeof v === "undefined" || v < 0  ? "?" : String(v);
+			};
+			var checkDevScrew = function(stars, itemId, devmats, screws){
+				if(!hasGear || !hasShip) return;
+				var redLine = false;
+				if(PlayerManager.consumables.devmats < devmats){
+					redLine = true;
+					$(".eq_res_value.devmats.plus{0} .val".format(stars), ResBox).addClass("insufficient");
+				}
+				if(PlayerManager.consumables.screws < screws){
+					redLine = true;
+					$(".eq_res_value.screws.plus{0} .val".format(stars), ResBox).addClass("insufficient");
+				}
+				if(!!self.instances[itemId] && self.instances[itemId]["star"+stars] === 0){
+					redLine = true;
+					$(".eq_res_label.plus{0}".format(stars), ResBox).addClass("insufficient");
+				}
+				if(redLine){
+					$(".eq_res_line.plus{0}".format(stars), ResBox).addClass("insufficient");
+				}
+			};
+			var checkConsumedItem = function(stars, consumedItem, unlocked){
+				if(!hasGear || !hasShip) return;
+				if(!self.instances[consumedItem.api_id]
+					|| self.instances[consumedItem.api_id].total < unlocked){
+					$(".eq_res_line.plus{0}".format(stars), ResBox).addClass("insufficient");
+					$(".eq_res_value.consumed_name.plus{0} .cnt".format(stars), ResBox).addClass("insufficient");
+				} else if(!!self.instances[consumedItem.api_id]
+					&& self.instances[consumedItem.api_id].unlocked < unlocked){
+					$(".eq_res_value.consumed_name.plus{0} .cnt".format(stars), ResBox).addClass("locked");
+				}
+			};
 			
-			$.each(this.today, function(itemId, shipList){
+			$.each(this.todaySortedIds, function(idx, itemId){
+				var shipList = self.today[itemId];
 				MasterItem = KC3Master.slotitem(itemId);
 				ItemName = KC3Meta.gearName( MasterItem.api_name );
 				
@@ -106,11 +153,22 @@
 				$(".eq_icon img", ThisBox).attr("alt", MasterItem.api_id);
 				$(".eq_icon img", ThisBox).click(gearClickFunc);
 				
-				$(".eq_icon", ThisBox).attr("title", ItemName );
 				$(".eq_name", ThisBox).text( ItemName );
-				ThisBox.attr("title", ItemName );
+				$(".eq_name", ThisBox).attr("title", "[{0}] {1}".format(itemId, ItemName) );
+				//ThisBox.attr("title", ItemName );
 				
 				hasShip = false;
+				// If shipList not empty means all ships can upgrade this item
+				if(shipList.length === 0){
+					hasShip = true;
+				}
+				
+				// If player has this item, check for marking
+				hasGear = false;
+				if(self.gears.indexOf(parseInt(itemId,10)) > -1){
+					hasGear = true;
+				}
+				
 				for(ctr in shipList){
 					ShipId = shipList[ctr];
 					
@@ -125,23 +183,97 @@
 					$(".eq_ship_icon img", ShipBox).attr("alt", ShipId );
 					$(".eq_ship_icon img", ShipBox).click(shipClickFunc);
 					$(".eq_ship_name", ShipBox).text( KC3Meta.shipName( KC3Master.ship(ShipId).api_name ) );
+					$(".eq_ship_name", ShipBox).attr("title", KC3Meta.shipName( KC3Master.ship(ShipId).api_name ) );
 					$(".eq_ships", ThisBox).append(ShipBox);
 				}
 				
-				// If shipList not empty means all ships can upgrade this item
-				if(shipList.length === 0){
-					hasShip = true;
-				}
-				
-				// If player has this item, check for marking
-				hasGear = false;
-				if(self.gears.indexOf(parseInt(itemId,10)) > -1){
-					hasGear = true;
-					
-					// Show all instances of this equipment from player inventory
-					for(ctr in self.instances[itemId]){
+				var imps = WhoCallsTheFleetDb.getItemImprovement(MasterItem.api_id);
+				var consumedItem, upgradedItem;
+				if(Array.isArray(imps) && imps.length > 0){
+					$.each(imps, function(_, imp){
+						ResBox = $(".tab_akashi .factory .eq_res").clone();
+						var resArr = imp.resource;
+						$(".eq_res_value.fuel", ResBox).text(resArr[0][0]);
+						$(".eq_res_value.ammo", ResBox).text(resArr[0][1]);
+						$(".eq_res_value.steel", ResBox).text(resArr[0][2]);
+						$(".eq_res_value.bauxite", ResBox).text(resArr[0][3]);
+						if(PlayerManager.hq.lastMaterial[0] < resArr[0][0]
+							|| PlayerManager.hq.lastMaterial[1] < resArr[0][1]
+							|| PlayerManager.hq.lastMaterial[2] < resArr[0][2]
+							|| PlayerManager.hq.lastMaterial[3] < resArr[0][3]){
+							$(".eq_res_line.material", ResBox).addClass("insufficient");
+						}
 						
-					}
+						$(".eq_res_value.devmats.plus0_5 .val", ResBox).text( toAmount(resArr[1][0]) );
+						$(".eq_res_value.devmats.plus0_5 .cnt", ResBox).text( "({0})".format(toAmount(resArr[1][1])) );
+						$(".eq_res_value.screws.plus0_5 .val", ResBox).text( toAmount(resArr[1][2]));
+						$(".eq_res_value.screws.plus0_5 .cnt", ResBox).text( "({0})".format(toAmount(resArr[1][3])) );
+						checkDevScrew("0_5", itemId, resArr[1][1], resArr[1][3]);
+						if(resArr[1][4] > 0){
+							consumedItem = KC3Master.slotitem(resArr[1][4]);
+							$(".eq_res_icon.consumed_icon.plus0_5 img", ResBox).attr("src", "../../assets/img/items/"+consumedItem.api_type[3]+".png");
+							$(".eq_res_icon.consumed_icon.plus0_5", ResBox).attr("alt", consumedItem.api_id);
+							$(".eq_res_icon.consumed_icon.plus0_5", ResBox).click(gearClickFunc);
+							$(".eq_res_value.consumed_name.plus0_5 .val", ResBox).text( KC3Meta.gearName(consumedItem.api_name) );
+							$(".eq_res_value.consumed_name.plus0_5 .val", ResBox).attr("title", KC3Meta.gearName(consumedItem.api_name) );
+							$(".eq_res_value.consumed_name.plus0_5 .cnt", ResBox).text( "x{0}".format(toAmount(resArr[1][5])) );
+							checkConsumedItem("0_5", consumedItem, resArr[1][5]);
+						} else {
+							$(".eq_res_icon.consumed_icon.plus0_5", ResBox).hide();
+							$(".eq_res_value.consumed_name.plus0_5", ResBox).hide();
+						}
+						
+						$(".eq_res_value.devmats.plus6_9 .val", ResBox).text( toAmount(resArr[2][0]) );
+						$(".eq_res_value.devmats.plus6_9 .cnt", ResBox).text( "({0})".format(toAmount(resArr[2][1])) );
+						$(".eq_res_value.screws.plus6_9 .val", ResBox).text( toAmount(resArr[2][2]) );
+						$(".eq_res_value.screws.plus6_9 .cnt", ResBox).text( "({0})".format(toAmount(resArr[2][3])) );
+						checkDevScrew("6_9", itemId, resArr[2][1], resArr[2][3]);
+						if(resArr[2][4] > 0){
+							consumedItem = KC3Master.slotitem(resArr[2][4]);
+							$(".eq_res_icon.consumed_icon.plus6_9 img", ResBox).attr("src", "../../assets/img/items/"+consumedItem.api_type[3]+".png");
+							$(".eq_res_icon.consumed_icon.plus6_9", ResBox).attr("alt", consumedItem.api_id);
+							$(".eq_res_icon.consumed_icon.plus6_9", ResBox).click(gearClickFunc);
+							$(".eq_res_value.consumed_name.plus6_9 .val", ResBox).text( KC3Meta.gearName(consumedItem.api_name) );
+							$(".eq_res_value.consumed_name.plus6_9 .val", ResBox).attr("title", KC3Meta.gearName(consumedItem.api_name) );
+							$(".eq_res_value.consumed_name.plus6_9 .cnt", ResBox).text( "x{0}".format(toAmount(resArr[2][5])) );
+							checkConsumedItem("6_9", consumedItem, resArr[2][5]);
+						} else {
+							$(".eq_res_icon.consumed_icon.plus6_9", ResBox).hide();
+							$(".eq_res_value.consumed_name.plus6_9", ResBox).hide();
+						}
+						if(imp.upgrade && imp.upgrade[0] > 0){
+							$(".eq_res_value.devmats.plusmax .val", ResBox).text( toAmount(resArr[3][0]) );
+							$(".eq_res_value.devmats.plusmax .cnt", ResBox).text( "({0})".format(toAmount(resArr[3][1])) );
+							$(".eq_res_value.screws.plusmax .val", ResBox).text( toAmount(resArr[3][2]) );
+							$(".eq_res_value.screws.plusmax .cnt", ResBox).text( "({0})".format(toAmount(resArr[3][3])) );
+							checkDevScrew("max", itemId, resArr[3][1], resArr[3][3]);
+							if(resArr[3][4] > 0){
+								consumedItem = KC3Master.slotitem(resArr[3][4]);
+								$(".eq_res_icon.consumed_icon.plusmax img", ResBox).attr("src", "../../assets/img/items/"+consumedItem.api_type[3]+".png");
+								$(".eq_res_icon.consumed_icon.plusmax", ResBox).attr("alt", consumedItem.api_id);
+								$(".eq_res_icon.consumed_icon.plusmax", ResBox).click(gearClickFunc);
+								$(".eq_res_value.consumed_name.plusmax .val", ResBox).text( KC3Meta.gearName(consumedItem.api_name) );
+								$(".eq_res_value.consumed_name.plusmax .val", ResBox).attr("title", KC3Meta.gearName(consumedItem.api_name) );
+								$(".eq_res_value.consumed_name.plusmax .cnt", ResBox).text( "x{0}".format(toAmount(resArr[3][5])) );
+								checkConsumedItem("max", consumedItem, resArr[3][5]);
+							} else {
+								$(".eq_res_icon.consumed_icon.plusmax", ResBox).hide();
+								$(".eq_res_value.consumed_name.plusmax", ResBox).hide();
+							}
+							upgradedItem = KC3Master.slotitem(imp.upgrade[0]);
+							$(".eq_next .eq_res_icon img", ResBox).attr("src", "../../assets/img/items/"+upgradedItem.api_type[3]+".png");
+							$(".eq_next .eq_res_icon", ResBox).attr("alt", upgradedItem.api_id);
+							$(".eq_next .eq_res_icon", ResBox).click(gearClickFunc);
+							$(".eq_next .eq_res_name", ResBox).text( KC3Meta.gearName(upgradedItem.api_name) );
+							$(".eq_next .eq_res_name", ResBox).attr("title", KC3Meta.gearName(upgradedItem.api_name) );
+						} else {
+							$(".eq_res_line.plusmax", ResBox).hide();
+							$(".eq_next", ResBox).hide();
+						}
+						$(".eq_resources", ThisBox).append(ResBox);
+					});
+				} else {
+					$(".eq_resources", ThisBox).hide();
 				}
 				
 				// If doesn't have either ship or gear, and 

--- a/src/pages/strategy/tabs/akashi/akashi.js
+++ b/src/pages/strategy/tabs/akashi/akashi.js
@@ -112,7 +112,7 @@
 			var ThisBox, MasterItem, ItemName;
 			var hasShip, hasGear, ctr;
 			var ShipBox, ShipId;
-			var ResBox, checkConsumedItem;
+			var ResBox, improveList;
 			var consumedItem, upgradedItem;
 			
 			var shipClickFunc = function(e){
@@ -236,19 +236,22 @@
 				
 				var imps = WhoCallsTheFleetDb.getItemImprovement(MasterItem.api_id);
 				if(Array.isArray(imps) && imps.length > 0){
-					$.each(imps, function(idx, imp){
+					improveList = [];
+					$.each(imps, function(_, imp){
 						var dowReq = false;
 						imp.req.forEach(function(reqArr){
 							// DOW check
 							dowReq |= !Array.isArray(reqArr[0]) || reqArr[0][dayIdx];
 							// Yet another has ship check on reqArr[1]
 						});
-						if(!dowReq) return;
+						if(dowReq) improveList.push(imp);
+					});
+					$.each(improveList, function(_, imp){
 						ResBox = $(".tab_akashi .factory .eq_res").clone();
 						var resArr = imp.resource || [[]];
 						
 						// Add some precondition ship icons as not check them yet
-						if(imps.length > 1){
+						if(improveList.length > 1){
 							var shipIcons = $(".eq_res_label.material", ResBox).empty();
 							imp.req.forEach(function(reqArr){
 								if(reqArr[0][dayIdx] && reqArr[1]){

--- a/src/pages/strategy/tabs/profile/profile.js
+++ b/src/pages/strategy/tabs/profile/profile.js
@@ -20,13 +20,8 @@
 		Prepares latest player data
 		---------------------------------*/
 		reload :function(){
-			// Check for player statstics
-			if(typeof localStorage.player != "undefined"){
-				this.player = JSON.parse(localStorage.player);
-			}else{
-				this.player = {};
-			}
-			
+			// Check for player HQ info
+			PlayerManager.hq.load();
 			// Check for player statstics
 			if(typeof localStorage.statistics != "undefined"){
 				this.statistics = JSON.parse(localStorage.statistics);

--- a/src/pages/strategy/themes/dark.css
+++ b/src/pages/strategy/themes/dark.css
@@ -926,13 +926,17 @@ a:hover {
 }
 
 /* Akashi */
+.tab_akashi .control {
+	background:#444;
+	color:#fff;
+}
 .tab_akashi .weekday {
 	color:#ffffff;
 	background:#555555;
 }
 .tab_akashi .weekday.active {
 	color:#333333;
-	background:#CCCCCC;
+	background:#cccccc;
 }
 .tab_akashi .equipment {
 	border-bottom:1px solid #777;
@@ -941,6 +945,21 @@ a:hover {
 .tab_akashi .equipment.disabled {
 	opacity:0.4;
 	background:#621f1f;
+}
+.tab_akashi .eq_res .eq_res_line.insufficient {
+	background:#710 !important;
+}
+.tab_akashi .eq_res .insufficient {
+	color:#f10 !important;
+}
+.tab_akashi .equipment {
+	color:#9e9e9e;
+}
+.tab_akashi .eq_res .eq_res_value {
+	color:#9e9e9e;
+}
+.tab_akashi .eq_res .eq_res_value.consumed_name > div.cnt.locked {
+	color:#ec0;
 }
 
 /* Fleet */

--- a/src/pages/strategy/themes/legacy.css
+++ b/src/pages/strategy/themes/legacy.css
@@ -627,6 +627,14 @@ body {
 }
 
 /* Akashi */
+.tab_akashi .controls {
+	background:#f0f5ff;
+	border-bottom:1px solid #369;
+}
+.tab_akashi .control {
+	background:#369;
+	color:#fff;
+}
 .tab_akashi .weekday {
 	color:#0033CC;
 }
@@ -641,6 +649,18 @@ body {
 .tab_akashi .equipment.disabled {
 	opacity:0.4;
 	background:#fcc;
+}
+.tab_akashi .eq_res .eq_res_line.insufficient {
+	background:#fcc;
+}
+.tab_akashi .eq_res .insufficient {
+	color:#f22 !important;
+}
+.tab_akashi .eq_res .eq_res_value {
+	color:#333;
+}
+.tab_akashi .eq_res .eq_res_value.consumed_name > div.cnt.locked {
+	color:#ec0;
 }
 
 /* Fleet */

--- a/src/pages/strategy/themes/legacy.css
+++ b/src/pages/strategy/themes/legacy.css
@@ -660,7 +660,7 @@ body {
 	color:#333;
 }
 .tab_akashi .eq_res .eq_res_value.consumed_name > div.cnt.locked {
-	color:#ec0;
+	color:#f90;
 }
 
 /* Fleet */


### PR DESCRIPTION
Related #1621 , #1183 , #944 and so on.

A simple improvement by importing WhoCallsTheFleetDb of items, thanks for @Diablohu first.
Features like a 'planner', 'scheduler' or 'simulator' not planned yet.

 * [x] List up consuming resources, devmats, screws and items
 * [x] Do precondition checking on things above based on player current resources, ships and equipment
 * [x] Sort items list by category first
 * [x] Add a filter button to hide those items not improvable currently

Screenshot for now (also added WhoCallsTheFleet link to FAQ) :
![image](https://cloud.githubusercontent.com/assets/160240/22027069/95d99104-dd0d-11e6-9cf2-2d491d101597.png)

New screenshot for dark theme:
![image](https://cloud.githubusercontent.com/assets/160240/22055176/c9427a06-dd94-11e6-8a67-dda594f30dbd.png)

TODO:
 * Required weekdays and ships not based on the DB, we still have to update `akashi.json`. Question: get rid of `akashi.json` or not?