### PR TITLE
List up recent news feed

### DIFF
--- a/src/library/managers/PlayerManager.js
+++ b/src/library/managers/PlayerManager.js
@@ -218,10 +218,14 @@ Does not include Ships and Gears which are managed by other Managers
 
 		setNewsfeed :function( data, stime ){
 			//console.log("newsfeed", data);
+			localStorage.playerNewsFeed = JSON.stringify({ time: stime, log: data });
+			// Give up to save into DB, just keep recent 6 logs
+			return;
+			// No way to track which logs are already recorded,
+			// because no cursor/timestamp/state could be found in API
+			/*
 			$.each(data, function( index, element){
-				//console.log("checking newsfeed item", element);
 				if(parseInt(element.api_state, 10) !== 0){
-					//console.log("saved news", element);
 					KC3Database.Newsfeed({
 						type: element.api_type,
 						message: element.api_message,
@@ -229,6 +233,7 @@ Does not include Ships and Gears which are managed by other Managers
 					});
 				}
 			});
+			*/
 		},
 
 		// make sure to "loadFleets" before calling this function.

--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -146,7 +146,7 @@ Previously known as "Reactor"
 				}
 			});
 			
-			PlayerManager.setNewsfeed(response.api_data.api_log, UTCtime );
+			PlayerManager.setNewsfeed(response.api_data.api_log, UTCtime * 1000 );
 			
 			PlayerManager.combinedFleet = response.api_data.api_combined_flag || 0;
 			

--- a/src/pages/strategy/tabs/profile/profile.css
+++ b/src/pages/strategy/tabs/profile/profile.css
@@ -108,6 +108,38 @@
 	font-weight:bold;
 }
 
+/* NEWS FEED
+--------------------------------*/
+.tab_profile .feed_item {
+	width:500px;
+	height:22px;
+	margin:0px 0px 0px 0px;
+	font-size:12px;
+}
+.tab_profile .feed_item .colorbox {
+	width:20px;
+	height:20px;
+	border-radius:5px;
+	margin:1px 1px 1px 1px;
+	float:left;
+}
+.tab_profile .feed_item .time {
+	width:80px;
+	height:20px;
+	line-height:20px;
+	padding:0px 0px 0px 5px;
+	margin:1px 1px 1px 1px;
+	float:left;
+}
+.tab_profile .feed_item .feed_text {
+	width:394px;
+	height:20px;
+	line-height:20px;
+	padding:0px 0px 0px 5px;
+	margin:1px 1px 1px 1px;
+	float:left;
+}
+
 /* MANAGEMENT
 --------------------------------*/
 .tab_profile .import_file {

--- a/src/pages/strategy/tabs/profile/profile.css
+++ b/src/pages/strategy/tabs/profile/profile.css
@@ -130,6 +130,8 @@
 	padding:0px 0px 0px 5px;
 	margin:1px 1px 1px 1px;
 	float:left;
+	overflow:hidden;
+	white-space:nowrap;
 }
 .tab_profile .feed_item .feed_text {
 	width:394px;
@@ -138,6 +140,9 @@
 	padding:0px 0px 0px 5px;
 	margin:1px 1px 1px 1px;
 	float:left;
+	overflow:hidden;
+	white-space:nowrap;
+	text-overflow:ellipsis;
 }
 
 /* MANAGEMENT

--- a/src/pages/strategy/tabs/profile/profile.html
+++ b/src/pages/strategy/tabs/profile/profile.html
@@ -190,6 +190,51 @@
 	</div>
 	<br />
 	
+	<!-- NEWS FEED -->
+	<div class="page_section">News Feed</div>
+	<div class="section_body newsfeed">
+		<div class="feed_item feed_item_1">
+			<div class="colorbox bscolor3"></div>
+			<div class="time bscolor3"></div>
+			<div class="feed_text bscolor3"></div>
+			<div class="clear"></div>
+		</div>
+		<div class="feed_item feed_item_2">
+			<div class="colorbox bscolor3"></div>
+			<div class="time bscolor3"></div>
+			<div class="feed_text bscolor3"></div>
+			<div class="clear"></div>
+		</div>
+		<div class="feed_item feed_item_3">
+			<div class="colorbox bscolor3"></div>
+			<div class="time bscolor3"></div>
+			<div class="feed_text bscolor3"></div>
+			<div class="clear"></div>
+		</div>
+		<div class="feed_item feed_item_4">
+			<div class="colorbox bscolor3"></div>
+			<div class="time bscolor3"></div>
+			<div class="feed_text bscolor3"></div>
+			<div class="clear"></div>
+		</div>
+		<div class="feed_item feed_item_5">
+			<div class="colorbox bscolor3"></div>
+			<div class="time bscolor3"></div>
+			<div class="feed_text bscolor3"></div>
+			<div class="clear"></div>
+		</div>
+		<div class="feed_item feed_item_6">
+			<div class="colorbox bscolor3"></div>
+			<div class="time bscolor3"></div>
+			<div class="feed_text bscolor3"></div>
+			<div class="clear"></div>
+		</div>
+		<div class="feed_button">
+			[ <a href="#" id="translate_newsfeed" class="fscolor3">Translate messages</a> ]
+		</div>
+	</div>
+	<br />
+	
 	<!-- MANAGEMENT -->
 	<div class="page_section">Profile Data</div>
 	<div class="section_body management">

--- a/src/pages/strategy/tabs/profile/profile.js
+++ b/src/pages/strategy/tabs/profile/profile.js
@@ -8,6 +8,8 @@
 		
 		player: {},
 		statistics: false,
+		newsfeed: {},
+		englishNewsfeed: false,
 		
 		/* INIT
 		Prepares static data needed
@@ -29,6 +31,8 @@
 			}else{
 				this.statistics = false;
 			}
+			// Check for player news feed
+			this.newsfeed = JSON.parse(localStorage.playerNewsFeed || "{}");
 		},
 		
 		/* EXECUTE
@@ -88,6 +92,15 @@
 				$(".stat_exped .stat_success .stat_value").html(this.statistics.exped.success);
 				$(".stat_exped .stat_total .stat_value").html(this.statistics.exped.total);
 			}
+			
+			// Show news feed
+			this.refreshNewsfeed();
+			// Toggle news feed translation
+			$("#translate_newsfeed").on("click", function(){
+				self.englishNewsfeed = !self.englishNewsfeed;
+				self.refreshNewsfeed();
+				return false;
+			});
 			
 			// Fix ledger data of IndexedDB, current:
 			// 0: LBAS type, 1: Consumables empty useitem
@@ -388,6 +401,59 @@
 					});
 				});
 			});
+		},
+		
+		refreshNewsfeed: function(){
+			var self = this;
+			if(this.newsfeed && this.newsfeed.time){
+				this.newsfeed.log.forEach(function(log, i){
+					self.showFeedItem(i, self.newsfeed.time, log, !self.englishNewsfeed);
+				});
+				$(".newsfeed").show();
+			} else {
+				$(".newsfeed").hide();
+			}
+		},
+		
+		showFeedItem: function(index, time, log, showRawMessage){
+			var selector = ".newsfeed .feed_item_{0}".format(index + 1);
+			$(selector + " .time").text(new Date(time).format("mm/dd HH:MM"));
+			switch(log.api_type){
+			case "1":
+				$(selector + " .colorbox").css("background", "#ffcc00");
+				$(selector + " .feed_text").text(!!showRawMessage ? log.api_message : "Repairs Complete");
+				break;
+			case "2":
+				$(selector + " .colorbox").css("background", "#996600");
+				$(selector + " .feed_text").text(!!showRawMessage ? log.api_message : "Construction Complete");
+				break;
+			case "3":
+				$(selector + " .colorbox").css("background", "#ace");
+				$(selector + " .feed_text").text(!!showRawMessage ? log.api_message : "Expedition fleet has returned");
+				break;
+			case "5":
+				$(selector + " .colorbox").css("background", "#98e75f");
+				var opponent = log.api_message.substring(1, log.api_message.indexOf("」"));
+				if(log.api_message.indexOf("勝利") > -1){
+					$(selector + " .feed_text").html(!!showRawMessage ? log.api_message : "You were attacked in PvP by \"<strong>{0}</strong>\" but won!".format(opponent) );
+				}else if(log.api_message.indexOf("敗北") > -1){
+					$(selector + " .feed_text").html(!!showRawMessage ? log.api_message : "You were attacked in PvP by \"<strong>{0}</strong>\" and lost!".format(opponent));
+				}
+				break;
+			case "7":
+				$(selector + " .colorbox").css("background", "#d75048");
+				$(selector + " .feed_text").text(!!showRawMessage ? log.api_message : "Unlocked a new map");
+				break;
+			case "11":
+				$(selector + " .colorbox").css("background", "#9999ff");
+				$(selector + " .feed_text").text(!!showRawMessage ? log.api_message : "Your ship library has been updated");
+				break;
+			default:
+				$(selector + " .colorbox").css("background", "#ccc");
+				$(selector + " .feed_text").html(!!showRawMessage ? log.api_message :
+					"<span style='color:red;'>Unknown. To help, report that type {0} is \"{1}\"</span>".format(log.api_type, log.api_message) );
+				break;
+			}
 		},
 		
 		makeFilename: function(type, ext){

--- a/src/pages/strategy/tabs/profile/profile.js
+++ b/src/pages/strategy/tabs/profile/profile.js
@@ -9,7 +9,7 @@
 		player: {},
 		statistics: false,
 		newsfeed: {},
-		englishNewsfeed: false,
+		showRawNewsfeed: false,
 		
 		/* INIT
 		Prepares static data needed
@@ -94,11 +94,11 @@
 			}
 			
 			// Show news feed
-			this.refreshNewsfeed();
+			this.refreshNewsfeed(this.showRawNewsfeed);
 			// Toggle news feed translation
 			$("#translate_newsfeed").on("click", function(){
-				self.englishNewsfeed = !self.englishNewsfeed;
-				self.refreshNewsfeed();
+				self.showRawNewsfeed = !self.showRawNewsfeed;
+				self.refreshNewsfeed(self.showRawNewsfeed);
 				return false;
 			});
 			
@@ -403,11 +403,11 @@
 			});
 		},
 		
-		refreshNewsfeed: function(){
+		refreshNewsfeed: function(showRawNewsfeed){
 			var self = this;
 			if(this.newsfeed && this.newsfeed.time){
 				this.newsfeed.log.forEach(function(log, i){
-					self.showFeedItem(i, self.newsfeed.time, log, !self.englishNewsfeed);
+					self.showFeedItem(i, self.newsfeed.time, log, !!showRawNewsfeed);
 				});
 				$(".newsfeed").show();
 			} else {
@@ -415,43 +415,44 @@
 			}
 		},
 		
-		showFeedItem: function(index, time, log, showRawMessage){
+		showFeedItem: function(index, time, log, showRawNewsfeed){
+			var isRaw = !!showRawNewsfeed || ConfigManager.language == "jp";
 			var selector = ".newsfeed .feed_item_{0}".format(index + 1);
 			$(selector + " .time").text(new Date(time).format("mm/dd HH:MM"));
 			switch(log.api_type){
 			case "1":
 				$(selector + " .colorbox").css("background", "#ffcc00");
-				$(selector + " .feed_text").text(!!showRawMessage ? log.api_message : "Repairs Complete");
+				$(selector + " .feed_text").html(isRaw ? log.api_message : KC3Meta.term("NewsfeedRepair"));
 				break;
 			case "2":
 				$(selector + " .colorbox").css("background", "#996600");
-				$(selector + " .feed_text").text(!!showRawMessage ? log.api_message : "Construction Complete");
+				$(selector + " .feed_text").html(isRaw ? log.api_message : KC3Meta.term("NewsfeedConstrct"));
 				break;
 			case "3":
 				$(selector + " .colorbox").css("background", "#ace");
-				$(selector + " .feed_text").text(!!showRawMessage ? log.api_message : "Expedition fleet has returned");
+				$(selector + " .feed_text").html(isRaw ? log.api_message : KC3Meta.term("NewsfeedExped"));
 				break;
 			case "5":
 				$(selector + " .colorbox").css("background", "#98e75f");
 				var opponent = log.api_message.substring(1, log.api_message.indexOf("」"));
 				if(log.api_message.indexOf("勝利") > -1){
-					$(selector + " .feed_text").html(!!showRawMessage ? log.api_message : "You were attacked in PvP by \"<strong>{0}</strong>\" but won!".format(opponent) );
+					$(selector + " .feed_text").html(isRaw ? log.api_message : KC3Meta.term("NewsfeedPvPWin").format(opponent) );
 				}else if(log.api_message.indexOf("敗北") > -1){
-					$(selector + " .feed_text").html(!!showRawMessage ? log.api_message : "You were attacked in PvP by \"<strong>{0}</strong>\" and lost!".format(opponent));
+					$(selector + " .feed_text").html(isRaw ? log.api_message : KC3Meta.term("NewsfeedPvPLose").format(opponent));
 				}
 				break;
 			case "7":
 				$(selector + " .colorbox").css("background", "#d75048");
-				$(selector + " .feed_text").text(!!showRawMessage ? log.api_message : "Unlocked a new map");
+				$(selector + " .feed_text").html(isRaw ? log.api_message : KC3Meta.term("NewsfeedUnlockMap"));
 				break;
 			case "11":
 				$(selector + " .colorbox").css("background", "#9999ff");
-				$(selector + " .feed_text").text(!!showRawMessage ? log.api_message : "Your ship library has been updated");
+				$(selector + " .feed_text").html(isRaw ? log.api_message : KC3Meta.term("NewsfeedUpdateLib"));
 				break;
 			default:
 				$(selector + " .colorbox").css("background", "#ccc");
-				$(selector + " .feed_text").html(!!showRawMessage ? log.api_message :
-					"<span style='color:red;'>Unknown. To help, report that type {0} is \"{1}\"</span>".format(log.api_type, log.api_message) );
+				$(selector + " .feed_text").html(isRaw ? log.api_message :
+					KC3Meta.term("NewsfeedUnknown").format(log.api_type, log.api_message) );
 				break;
 			}
 		},

--- a/src/pages/strategy/tabs/profile/profile.js
+++ b/src/pages/strategy/tabs/profile/profile.js
@@ -436,9 +436,11 @@
 				$(selector + " .colorbox").css("background", "#98e75f");
 				var opponent = log.api_message.substring(1, log.api_message.indexOf("」"));
 				if(log.api_message.indexOf("勝利") > -1){
-					$(selector + " .feed_text").html(isRaw ? log.api_message : KC3Meta.term("NewsfeedPvPWin").format(opponent) );
-				}else if(log.api_message.indexOf("敗北") > -1){
+					$(selector + " .feed_text").html(isRaw ? log.api_message : KC3Meta.term("NewsfeedPvPWin").format(opponent));
+				} else if(log.api_message.indexOf("敗北") > -1){
 					$(selector + " .feed_text").html(isRaw ? log.api_message : KC3Meta.term("NewsfeedPvPLose").format(opponent));
+				} else {
+					$(selector + " .feed_text").html(isRaw ? log.api_message : KC3Meta.term("NewsfeedUnknown").format(log.api_type, log.api_message) );
 				}
 				break;
 			case "7":
@@ -451,8 +453,7 @@
 				break;
 			default:
 				$(selector + " .colorbox").css("background", "#ccc");
-				$(selector + " .feed_text").html(isRaw ? log.api_message :
-					KC3Meta.term("NewsfeedUnknown").format(log.api_type, log.api_message) );
+				$(selector + " .feed_text").html(isRaw ? log.api_message : KC3Meta.term("NewsfeedUnknown").format(log.api_type, log.api_message) );
 				break;
 			}
 		},


### PR DESCRIPTION
This [old designed feature](https://github.com/KC3Kai/KC3Kai/blob/857f35e984bd50e136e70f3c55a033d15b68b879/src/pages/strategy/tabs/TabHome.js) is requested again... XD
Limited by API data, only the recent logs of news feed will be saved into local storage since last time back to home port in game.
Then list them up at Profile page of Strategy Room. Support translating messages into English based on type ID.

Profile SS:
![image](https://cloud.githubusercontent.com/assets/160240/22236557/53e52d1a-e241-11e6-9b50-1c80238c9671.png)
Homeport SS:
![image](https://cloud.githubusercontent.com/assets/160240/22236601/9fbe24d0-e241-11e6-8ff0-97f89261719d.png)
(so why are there 6 lines in API? dunno... 😂 )