### PR TITLE
Show PvP opponents info

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -196,6 +196,12 @@
 				"options" : {}
 			},
 			{
+				"id" : "info_pvp_info",
+				"name" : "SettingsPvPInfoActivity",
+				"type" : "check",
+				"options" : {}
+			},
+			{
 				"id" : "info_eng_stype",
 				"name" : "SettingsEnglishShipType",
 				"type" : "check",

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -54,6 +54,7 @@ Retreives when needed to apply on components
 				info_delta 			: false,
 				info_auto_exped_tab : true,
 				info_auto_fleet_view: true,
+				info_pvp_info		: true,
 				info_eng_stype		: false,
 				info_force_ship_lang: "",
 				info_salt 			: false,

--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -1418,24 +1418,33 @@ Previously known as "Reactor"
 		-------------------------------------------------------*/
 		"api_get_member/practice":function(params, response, headers){
 			/* 
-				{
-					"api_member_id":16015130,
-					"api_id":1,
-					"api_enemy_id":16131426,
-					"api_enemy_name":"\u3057\u304a\u3093",
-					"api_enemy_name_id":"135471996",
-					"api_enemy_level":100,
-					"api_enemy_rank":"\u5143\u5e25",
-					"api_enemy_flag":3,
-					"api_enemy_flag_ship":401,
-					"api_enemy_comment":"\u7d50\u5c40\u521d\u96ea\u306f\u53ef\u611b\u3059\u304e\u308b\uff01",
-					"api_enemy_comment_id":"146585663",
-					"api_state":0,
-					"api_medals":0
-				},
+			{
+				"api_create_kind":0,
+				"api_selected_kind":0,
+				"api_entry_limit":28861,
+				"api_list":[
+					{
+						"api_enemy_id":300560,
+						"api_enemy_name":"\u99AC\u5834\u4FE1\u623F",
+						"api_enemy_name_id":"79708727",
+						"api_enemy_level":113,
+						"api_enemy_rank":"\u5927\u5C06",
+						"api_enemy_flag":3,
+						"api_enemy_flag_ship":196,
+						"api_enemy_comment":"\u5272\u3068\u4F55\u5EA6\u3082\u8A2A\u308C\u308B",
+						"api_enemy_comment_id":"155281085",
+						"api_state":0,
+						"api_medals":1
+					} * 5
+				]
+			}
 			*/
-			var
-				data = response.api_data;
+			var data = response.api_data;
+			KC3Network.trigger("PvPList", data);
+		},
+		
+		"api_req_practice/change_matching_kind":function(params, response, headers){
+			var selectedKind = parseInt(params.api_selected_kind, 10);
 		},
 		
 		/* PVP Fleet List
@@ -1469,9 +1478,9 @@ Previously known as "Reactor"
 					}
 				}
 			*/
-			var
-				data    = response.api_data,
+			var data    = response.api_data,
 				enemyId = parseInt(params.api_member_id,10);
+			KC3Network.trigger("PvPFleet", data);
 		},
 		
 		/* PVP Start

--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -1417,30 +1417,7 @@ Previously known as "Reactor"
 		/* PVP Enemy List
 		-------------------------------------------------------*/
 		"api_get_member/practice":function(params, response, headers){
-			/* 
-			{
-				"api_create_kind":0,
-				"api_selected_kind":0,
-				"api_entry_limit":28861,
-				"api_list":[
-					{
-						"api_enemy_id":300560,
-						"api_enemy_name":"\u99AC\u5834\u4FE1\u623F",
-						"api_enemy_name_id":"79708727",
-						"api_enemy_level":113,
-						"api_enemy_rank":"\u5927\u5C06",
-						"api_enemy_flag":3,
-						"api_enemy_flag_ship":196,
-						"api_enemy_comment":"\u5272\u3068\u4F55\u5EA6\u3082\u8A2A\u308C\u308B",
-						"api_enemy_comment_id":"155281085",
-						"api_state":0,
-						"api_medals":1
-					} * 5
-				]
-			}
-			*/
-			var data = response.api_data;
-			KC3Network.trigger("PvPList", data);
+			KC3Network.trigger("PvPList", response.api_data);
 		},
 		
 		"api_req_practice/change_matching_kind":function(params, response, headers){
@@ -1450,34 +1427,6 @@ Previously known as "Reactor"
 		/* PVP Fleet List
 		-------------------------------------------------------*/
 		"api_req_member/get_practice_enemyinfo":function(params, response, headers){
-			/*
-				{
-					"api_member_id":16131426,
-					"api_nickname":"\u3057\u304a\u3093",
-					"api_nickname_id":"135471996",
-					"api_cmt":"\u7d50\u5c40\u521d\u96ea\u306f\u53ef\u611b\u3059\u304e\u308b\uff01",
-					"api_cmt_id":"146585663",
-					"api_level":100,
-					"api_rank":1,
-					"api_experience":[1322118,1600000],
-					"api_friend":0,
-					"api_ship":[100,100],
-					"api_slotitem":[394,497],
-					"api_furniture":46,
-					"api_deckname":"\u306d\u3048\u4eca\u3069\u3093\u306a\u6c17\u6301\u3061\uff1f",
-					"api_deckname_id":"143652014",
-					"api_deck":{
-						"api_ships":[
-							{"api_id":402539759,"api_ship_id":401,"api_level":85,"api_star":4},
-							{"api_id":287256299,"api_ship_id":398,"api_level":63,"api_star":4},
-							{"api_id":416504460,"api_ship_id":399,"api_level":74,"api_star":4},
-							{"api_id":302286234,"api_ship_id":400,"api_level":77,"api_star":4},
-							{"api_id":-1},
-							{"api_id":-1}
-						]
-					}
-				}
-			*/
 			var data    = response.api_data,
 				enemyId = parseInt(params.api_member_id,10);
 			KC3Network.trigger("PvPFleet", data);

--- a/src/library/modules/Network.js
+++ b/src/library/modules/Network.js
@@ -35,6 +35,8 @@ Listens to network history and triggers callback if game events happen
 			CraftShip: [],
 			Modernize: [],
 			ClearedMap: [],
+			PvPList: [],
+			PvPFleet: [],
 			PvPStart: [],
 			PvPNight: [],
 			PvPEnd: [],

--- a/src/library/objects/Fleet.js
+++ b/src/library/objects/Fleet.js
@@ -823,21 +823,27 @@ Contains summary information about a fleet and its 6 ships
 	 */
 	KC3Fleet.prototype.lookupKatoriClassBonus = function() {
 		var ctBonusTable = [
+			// ~9,  ~29,  ~59,  ~99, ~155?
 			[ 1.0,  1.0,  1.0,  1.0,  1.0], // No CT
 			[1.05, 1.08, 1.12, 1.15, 1.20], // CT x 1 as flagship
 			[1.03, 1.05, 1.07, 1.10, 1.15], // CT x 1
 			[1.10, 1.13, 1.16, 1.20, 1.25], // CT x 2, 1 flagship
 			[1.04, 1.06, 1.08, 1.12, 1.175] // CT x 2
 		];
-		var maxCtLevel = 0, katoriIndex = 0;
+		var fsCtLevel = 0, maxCtLevel = 0, katoriIndex = 0;
 		this.ship(function(rid, idx, ship){
 			if(ship.master().api_stype == 21){
 				if(ship.level > maxCtLevel) maxCtLevel = ship.level;
-				if(idx === 0) katoriIndex = 1;
-				else katoriIndex = katoriIndex < 3 ?
-					katoriIndex + 2 : katoriIndex;
+				if(idx === 0){
+					katoriIndex = 1;
+					fsCtLevel = ship.level;
+				} else {
+					katoriIndex = katoriIndex < 3 ?
+						katoriIndex + 2 : katoriIndex;
+				}
 			}
 		});
+		if(katoriIndex === 3) maxCtLevel = fsCtLevel;
 		var levelIndex =
 			(maxCtLevel < 10)  ? 0 :
 			(maxCtLevel < 30)  ? 1 :

--- a/src/library/objects/Fleet.js
+++ b/src/library/objects/Fleet.js
@@ -880,9 +880,9 @@ Contains summary information about a fleet and its 6 ships
 			&& [13, 14].indexOf(opponentFlagshipMst.api_stype) > -1){
 			return 4; // Echelon
 		}
-		// flagship is CV/CVL/AV and ships >= 5 in enemy fleet
+		// flagship is CV/CVL/AV/CVB and ships >= 5 in enemy fleet
 		if(opponentFleetShips.length >= 5
-			&& [7, 11, 16].indexOf(opponentFlagshipMst.api_stype) > -1){
+			&& [7, 11, 16, 18].indexOf(opponentFlagshipMst.api_stype) > -1){
 			return 3; // Diamond
 		}
 		return 1; // Line Ahead

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -1902,7 +1902,9 @@ ABYSS FLEET
 	height: 13px;
 	line-height: 13px;
 	margin: 0px 0px 1px 0px;
+	float: left;
 	font-size: 11px;
+	text-align: right;
 }
 
 .module.activity .activity_pvp .pvp_fleet_name {

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -1739,10 +1739,12 @@ ABYSS FLEET
 	height: 35px;
 	float: left;
 	margin-right: 1px;
+	border: 1px solid #000;
+	border-radius: 20px;
 }
 .module.activity .activity_pvp .pvp_enemy_pic img {
-	width: 35px;
-	height: 35px;
+	width: 33px;
+	height: 33px;
 }
 .module.activity .activity_pvp .pvp_enemy_name {
 	width: 53px;
@@ -1820,7 +1822,7 @@ ABYSS FLEET
 
 .module.activity .activity_pvp .pvp_admiral {
 	width: 170px;
-	height: 84px;
+	height: 92px;
 	margin: 0px 0px 1px 0px;
 	white-space: nowrap;
 }
@@ -1844,6 +1846,7 @@ ABYSS FLEET
 .module.activity .activity_pvp .pvp_admiral .pvp_admiral_level {
 	width: 42px;
 	height: 15px;
+	line-height: 15px;
 	margin: 0px 1px 1px 0px;
 	float: left;
 }
@@ -1853,22 +1856,28 @@ ABYSS FLEET
 	float: left;
 }
 .module.activity .activity_pvp .pvp_admiral .pvp_admiral_rank {
-	width: 127px;
+	width: 76px;
 	height: 15px;
-	line-height: 17px;
-	margin: 0px 0px 1px 0px;
+	line-height: 15px;
+	margin: 0px 1px 1px 0px;
 	float: left;
 	font-size: 11px;
 	overflow: hidden;
 	text-overflow: ellipsis;
+}
+.module.activity .activity_pvp .pvp_admiral .pvp_admiral_exp {
+	width: 50px;
+	height: 15px;
+	line-height: 15px;
+	float: left;
+	font-size: 11px;
 }
 .module.activity .activity_pvp .pvp_admiral .pvp_admiral_comment {
 	width: 170px;
 	height: 17px;
 	line-height: 17px;
 	padding: 0px 0px 0px 3px;
-	margin: 0px 0px 1px 0px;
-	float: left;
+	margin: 0px 0px 2px 0px;
 	color: #222;
 	font-size: 11px;
 	background-color: #eee;
@@ -1878,7 +1887,8 @@ ABYSS FLEET
 }
 .module.activity .activity_pvp .pvp_admiral .pvp_admiral_label {
 	width: 110px;
-	height: 15px;
+	height: 13px;
+	line-height: 13px;
 	margin: 0px 1px 1px 0px;
 	float: left;
 	overflow: hidden;
@@ -1889,9 +1899,9 @@ ABYSS FLEET
 .module.activity .activity_pvp .pvp_admiral .pvp_admiral_gears,
 .module.activity .activity_pvp .pvp_admiral .pvp_admiral_furniture {
 	width: 59px;
-	height: 15px;
+	height: 13px;
+	line-height: 13px;
 	margin: 0px 0px 1px 0px;
-	float: left;
 	font-size: 11px;
 }
 
@@ -1900,7 +1910,7 @@ ABYSS FLEET
 	height: 17px;
 	line-height: 17px;
 	padding: 0px 0px 0px 3px;
-	margin: 0px 0px 1px 0px;
+	margin: 1px 0px 2px 0px;
 	color: #222;
 	font-size: 11px;
 	background-color: #eee;
@@ -1911,13 +1921,13 @@ ABYSS FLEET
 }
 .module.activity .activity_pvp .pvp_fleet_list {
 	width: 170px;
-	height: 98px;
-	margin: 0px 0px 1px 0px;
+	height: 93px;
+	margin: 0px 0px 2px 0px;
 	white-space: nowrap;
 }
 .module.activity .activity_pvp .pvpFleetShip {
 	width: 83px;
-	height: 32px;
+	height: 30px;
 	margin: 0px 2px 1px 0px;
 	float: left;
 	font-size: 11px;
@@ -1926,45 +1936,93 @@ ABYSS FLEET
 	background-color: #555;
 }
 .module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_icon {
-	width: 30px;
-	height: 30px;
-	margin: 0px 2px 1px 0px;
+	width: 28px;
+	height: 28px;
+	margin: 0px 3px 1px 0px;
 	float: left;
 }
 .module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_icon img {
-	width: 30px;
-	height: 30px;
+	width: 28px;
+	height: 28px;
 }
 .module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_name {
 	width: 49px;
-	height: 15px;
+	height: 13px;
+	line-height: 13px;
 	margin: 0px 0px 1px 0px;
 	float: left;
 	overflow: hidden;
 }
 .module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_level {
-	width: 31px;
-	height: 15px;
+	width: 32px;
+	height: 13px;
+	line-height: 13px;
 	margin: 0px 0px 0px 0px;
 	float: left;
 }
 .module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_level .i18n {
+	width: 13px;
+	float: left;
+	overflow: hidden;
 	color: #3ec0bf;
+}
+.module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_level .value {
+	width: 19px;
+	float: left;
 }
 .module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_star {
 	width: 18px;
-	height: 15px;
+	height: 13px;
+	line-height: 13px;
 	margin: 0px 0px 0px 0px;
 	float: left;
 }
 .module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_star .star {
 	color: #eedab1;
 }
-.module.activity .activity_pvp .pvp_formation {
+.module.activity .activity_pvp .pvp_prediction {
 	width: 170px;
-	float: left;
-	margin: 0px 0px 1px 0px;
+	height: 15px;
+	line-height: 15px;
+	font-size: 11px;
+	margin: 2px 0px 1px 0px;
 	white-space: nowrap;
+}
+.module.activity .activity_pvp .pvp_base_exp {
+	width: 88px;
+	height: 15px;
+	float: left;
+	margin: 0px 1px 0px 0px;
+}
+.module.activity .activity_pvp .pvp_base_exp .i18n {
+	width: 59px;
+	float: left;
+	margin: 0px 1px 0px 0px;
+	color: #3ec0bf;
+	overflow: hidden;
+}
+.module.activity .activity_pvp .pvp_base_exp .value {
+	width: 28px;
+	float: left;
+}
+.module.activity .activity_pvp .pvp_formation {
+	width: 81px;
+	height: 15px;
+	float: left;
+}
+.module.activity .activity_pvp .pvp_formation .i18n {
+	width: 64px;
+	float: left;
+	margin: 0px 1px 0px 0px;
+	color: #3ec0bf;
+	overflow: hidden;
+}
+.module.activity .activity_pvp .pvp_formation img {
+	width: 15px;
+	height: 15px;
+	background-color: #fff;
+	border-radius: 10px;
+	vertical-align: inherit;
 }
 
 /*------- QUESTS -------*/

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -1707,6 +1707,265 @@ ABYSS FLEET
 .module.activity .activity_gunfit .aaci .aaciPattern.triggerable {
 	background:#777;
 }
+/*------- ACTIVITY: PvP Info -------*/
+.module.activity .activity_pvp {
+	padding: 5px 10px;
+	color: #ddd;
+	font-size: 12px;
+}
+.module.activity .activity_pvp .pvp_header {
+	width: 170px;
+	margin: 0px 0px 1px 0px;
+	white-space: nowrap;
+}
+.module.activity .activity_pvp .pvp_title {
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.module.activity .activity_pvp .pvp_create_kind {
+	color: #86b465;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.module.activity .activity_pvp .pvp_list {
+}
+.module.activity .activity_pvp .pvpEnemyInfo {
+	width: 170px;
+	margin-bottom: 2px;
+	white-space: nowrap;
+}
+.module.activity .activity_pvp .pvp_enemy_pic {
+	width: 35px;
+	height: 35px;
+	float: left;
+	margin-right: 1px;
+}
+.module.activity .activity_pvp .pvp_enemy_pic img {
+	width: 35px;
+	height: 35px;
+}
+.module.activity .activity_pvp .pvp_enemy_name {
+	width: 53px;
+	height: 17px;
+	line-height: 17px;
+	float: left;
+	padding-left: 2px;
+	margin: 0px 1px 1px 0px;
+	color: #3ec0bf;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.module.activity .activity_pvp .pvp_enemy_level {
+	width: 20px;
+	height: 17px;
+	line-height: 17px;
+	float: left;
+	padding-left: 2px;
+	margin: 0px 1px 1px 0px;
+	font-size: 11px;
+}
+.module.activity .activity_pvp .pvp_enemy_rank {
+	width: 38px;
+	height: 17px;
+	line-height: 17px;
+	float: left;
+	padding-left: 2px;
+	margin: 0px 1px 1px 0px;
+	overflow: hidden;
+	font-size: 11px;
+}
+.module.activity .activity_pvp .pvp_enemy_comment {
+	width: 95px;
+	height: 17px;
+	line-height: 15px;
+	float: left;
+	padding: 0px 0px 0px 3px;
+	margin: 0px 1px 0px 0px;
+	border: 1px solid #222;
+	border-radius: 5px;
+	color: #222;
+	font-size: 11px;
+	background-color: #eee;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.module.activity .activity_pvp .pvp_enemy_medals {
+	width: 17px;
+	height: 18px;
+	float: left;
+}
+.module.activity .activity_pvp .pvp_enemy_medals img {
+	width: 13px;
+	height: 13px;
+}
+.module.activity .activity_pvp .pvp_enemy_medals span {
+	font-size: 10px;
+	position: relative;
+	float: right;
+	margin-top: -12px;
+	margin-right: 1px;
+}
+.module.activity .activity_pvp .pvp_enemy_state {
+	width: 20px;
+	height: 36px;
+	margin-top: -18px;
+	float: right;
+}
+.module.activity .activity_pvp .pvp_enemy_state img {
+	width: 24px;
+	height: 24px;
+	margin-left: -2px;
+	margin-top: 6px;
+}
+
+.module.activity .activity_pvp .pvp_admiral {
+	width: 170px;
+	height: 84px;
+	margin: 0px 0px 1px 0px;
+	white-space: nowrap;
+}
+.module.activity .activity_pvp .pvp_admiral .pvp_admiral_name {
+	width: 170px;
+	height: 14px;
+	margin: 0px 0px 1px 0px;
+	float: left;
+}
+.module.activity .activity_pvp .pvp_admiral .pvp_admiral_name .i18n {
+	width: 42px;
+	margin: 0px 1px 0px 0px;
+	float: left;
+	font-size: 11px;
+	color: #3ec0bf;
+}
+.module.activity .activity_pvp .pvp_admiral .pvp_admiral_name .value {
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.module.activity .activity_pvp .pvp_admiral .pvp_admiral_level {
+	width: 42px;
+	height: 15px;
+	margin: 0px 1px 1px 0px;
+	float: left;
+}
+.module.activity .activity_pvp .pvp_admiral .pvp_admiral_level .i18n {
+	width: 16px;
+	color: #3ec0bf;
+	float: left;
+}
+.module.activity .activity_pvp .pvp_admiral .pvp_admiral_rank {
+	width: 127px;
+	height: 15px;
+	line-height: 17px;
+	margin: 0px 0px 1px 0px;
+	float: left;
+	font-size: 11px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.module.activity .activity_pvp .pvp_admiral .pvp_admiral_comment {
+	width: 170px;
+	height: 17px;
+	line-height: 17px;
+	padding: 0px 0px 0px 3px;
+	margin: 0px 0px 1px 0px;
+	float: left;
+	color: #222;
+	font-size: 11px;
+	background-color: #eee;
+	border-radius: 5px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.module.activity .activity_pvp .pvp_admiral .pvp_admiral_label {
+	width: 110px;
+	height: 15px;
+	margin: 0px 1px 1px 0px;
+	float: left;
+	overflow: hidden;
+	font-size: 11px;
+	color: #c3b180;
+}
+.module.activity .activity_pvp .pvp_admiral .pvp_admiral_ships,
+.module.activity .activity_pvp .pvp_admiral .pvp_admiral_gears,
+.module.activity .activity_pvp .pvp_admiral .pvp_admiral_furniture {
+	width: 59px;
+	height: 15px;
+	margin: 0px 0px 1px 0px;
+	float: left;
+	font-size: 11px;
+}
+
+.module.activity .activity_pvp .pvp_fleet_name {
+	width: 170px;
+	height: 17px;
+	line-height: 17px;
+	padding: 0px 0px 0px 3px;
+	margin: 0px 0px 1px 0px;
+	color: #222;
+	font-size: 11px;
+	background-color: #eee;
+	border-radius: 5px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+.module.activity .activity_pvp .pvp_fleet_list {
+	width: 170px;
+	height: 98px;
+	margin: 0px 0px 1px 0px;
+	white-space: nowrap;
+}
+.module.activity .activity_pvp .pvpFleetShip {
+	width: 83px;
+	height: 32px;
+	margin: 0px 2px 1px 0px;
+	float: left;
+	font-size: 11px;
+	border: 1px solid #faa;
+	border-radius: 17px 5px 5px 17px;
+	background-color: #555;
+}
+.module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_icon {
+	width: 30px;
+	height: 30px;
+	margin: 0px 2px 1px 0px;
+	float: left;
+}
+.module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_icon img {
+	width: 30px;
+	height: 30px;
+}
+.module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_name {
+	width: 49px;
+	height: 15px;
+	margin: 0px 0px 1px 0px;
+	float: left;
+	overflow: hidden;
+}
+.module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_level {
+	width: 31px;
+	height: 15px;
+	margin: 0px 0px 0px 0px;
+	float: left;
+}
+.module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_level .i18n {
+	color: #3ec0bf;
+}
+.module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_star {
+	width: 18px;
+	height: 15px;
+	margin: 0px 0px 0px 0px;
+	float: left;
+}
+.module.activity .activity_pvp .pvpFleetShip .pvp_fleet_ship_star .star {
+	color: #eedab1;
+}
+.module.activity .activity_pvp .pvp_formation {
+	width: 170px;
+	float: left;
+	margin: 0px 0px 1px 0px;
+	white-space: nowrap;
+}
 
 /*------- QUESTS -------*/
 .module.quests {

--- a/src/pages/devtools/themes/natsuiro/natsuiro.html
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.html
@@ -718,7 +718,7 @@
 							<div class="clear"></div>
 						</div>
 					</div>
-					<!-- GUN FIT: Bonus / Penalty -->
+					<!-- GUN FIT: Bonus / Penalty + AACI patterns -->
 					<div class="activity_box activity_gunfit activity_dismissable">
 						<div class="fit_ship fit_profile">
 							<div class="fit_ship_pic fit_profile_pic"><img/></div>
@@ -736,6 +736,41 @@
 						<div class="aaci">
 							<div class="aaciList">
 							</div>
+							<div class="clear"></div>
+						</div>
+					</div>
+					<!-- PvP Enemy List and Fleet Info -->
+					<div class="activity_box activity_pvp activity_dismissable">
+						<div class="pvpList">
+							<div class="pvp_header">
+								<div class="pvp_title i18n">PvpListTitle</div>
+								<div class="pvp_create_kind"></div>
+								<div class="clear"></div>
+							</div>
+							<div class="pvp_list">
+							</div>
+							<div class="clear"></div>
+						</div>
+						<div class="pvpFleet">
+							<div class="pvp_admiral">
+								<div class="pvp_admiral_name"><div class="i18n">Name</div><div class="value"></div></div>
+								<div class="pvp_admiral_level"><div class="i18n">LevelShort</div><div class="value"></div></div>
+								<div class="pvp_admiral_rank">Admiral</div>
+								<div class="pvp_admiral_comment"></div>
+								<div class="pvp_admiral_label i18n">ShipGirlsOwned</div>
+								<div class="pvp_admiral_ships">300/300</div>
+								<div class="pvp_admiral_label i18n">EquipmentItemCount</div>
+								<div class="pvp_admiral_gears">9999/9999</div>
+								<div class="pvp_admiral_label i18n">FurnitureOwned</div>
+								<div class="pvp_admiral_furniture">999</div>
+							</div>
+							<div class="clear"></div>
+							<div class="pvp_fleet_name"></div>
+							<div class="pvp_fleet_list">
+							</div>
+							<div class="clear"></div>
+							<div class="pvp_formation"></div>
+							<div class="clear"></div>
 						</div>
 					</div>
 					
@@ -1017,13 +1052,32 @@
 			<!-- Ship requirement for expedition checker -->
 			<div class="expPlanner_shipReqBox requirements_textbox expPlanner_text_passed"></div>
 			
-			<!-- Gunfit / AACI patterns -->
+			<!-- Clonable: Gunfit / AACI patterns -->
 			<div class="aaciPattern">
 				<div class="apiId"></div>
 				<div class="shipIcon"><img/></div>
 				<div class="equipIcons"></div>
 				<div class="fixed"></div>
 				<div class="modifier"></div>
+			</div>
+			
+			<!-- Clonable: PvP enemy list -->
+			<div class="pvpEnemyInfo">
+				<div class="pvp_enemy_pic"><img/></div>
+				<div class="pvp_enemy_name"></div>
+				<div class="pvp_enemy_level"></div>
+				<div class="pvp_enemy_rank"></div>
+				<div class="pvp_enemy_comment"></div>
+				<div class="pvp_enemy_medals"><img src="../../../../assets/img/client/medal.png" /><span></span></div>
+				<div class="pvp_enemy_state"><img/></div>
+				<div class="clear"></div>
+			</div>
+			<!-- Clonable: PvP fleet info -->
+			<div class="pvpFleetShip">
+				<div class="pvp_fleet_ship_icon"><img/></div>
+				<div class="pvp_fleet_ship_name"></div>
+				<div class="pvp_fleet_ship_level"><span class="i18n">LevelShort</span> <span class="value"></span></div>
+				<div class="pvp_fleet_ship_star"><span class="star">&#9733;</span><span class="value"></span></div>
 			</div>
 			
 			<!-- Clonable: LBAS Base -->

--- a/src/pages/devtools/themes/natsuiro/natsuiro.html
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.html
@@ -740,7 +740,7 @@
 						</div>
 					</div>
 					<!-- PvP Enemy List and Fleet Info -->
-					<div class="activity_box activity_pvp">
+					<div class="activity_box activity_pvp activity_dismissable">
 						<div class="pvpList">
 							<div class="pvp_header">
 								<div class="pvp_title i18n">PvpListTitle</div>

--- a/src/pages/devtools/themes/natsuiro/natsuiro.html
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.html
@@ -740,7 +740,7 @@
 						</div>
 					</div>
 					<!-- PvP Enemy List and Fleet Info -->
-					<div class="activity_box activity_pvp activity_dismissable">
+					<div class="activity_box activity_pvp">
 						<div class="pvpList">
 							<div class="pvp_header">
 								<div class="pvp_title i18n">PvpListTitle</div>

--- a/src/pages/devtools/themes/natsuiro/natsuiro.html
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.html
@@ -740,7 +740,7 @@
 						</div>
 					</div>
 					<!-- PvP Enemy List and Fleet Info -->
-					<div class="activity_box activity_pvp activity_dismissable">
+					<div class="activity_box activity_pvp">
 						<div class="pvpList">
 							<div class="pvp_header">
 								<div class="pvp_title i18n">PvpListTitle</div>
@@ -756,6 +756,7 @@
 								<div class="pvp_admiral_name"><div class="i18n">Name</div><div class="value"></div></div>
 								<div class="pvp_admiral_level"><div class="i18n">LevelShort</div><div class="value"></div></div>
 								<div class="pvp_admiral_rank">Admiral</div>
+								<div class="pvp_admiral_exp">16002696</div>
 								<div class="pvp_admiral_comment"></div>
 								<div class="pvp_admiral_label i18n">ShipGirlsOwned</div>
 								<div class="pvp_admiral_ships">300/300</div>
@@ -769,8 +770,11 @@
 							<div class="pvp_fleet_list">
 							</div>
 							<div class="clear"></div>
-							<div class="pvp_formation"></div>
-							<div class="clear"></div>
+							<div class="pvp_prediction">
+								<div class="pvp_base_exp"><div class="i18n">PvpBaseExp</div><div class="value"></div></div>
+								<div class="pvp_formation"><div class="i18n">PvpFormationPred</div><img/></div>
+								<div class="clear"></div>
+							</div>
 						</div>
 					</div>
 					
@@ -1076,7 +1080,7 @@
 			<div class="pvpFleetShip">
 				<div class="pvp_fleet_ship_icon"><img/></div>
 				<div class="pvp_fleet_ship_name"></div>
-				<div class="pvp_fleet_ship_level"><span class="i18n">LevelShort</span> <span class="value"></span></div>
+				<div class="pvp_fleet_ship_level"><div class="i18n">LevelShort</div><div class="value"></div></div>
 				<div class="pvp_fleet_ship_star"><span class="star">&#9733;</span><span class="value"></span></div>
 			</div>
 			

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -2317,13 +2317,23 @@
 			console.log("PvP Enemy Fleet", data);
 			$(".activity_pvp .pvp_admiral .pvp_admiral_name .value").text(data.api_nickname);
 			$(".activity_pvp .pvp_admiral .pvp_admiral_level .value").text(data.api_level);
-			$(".activity_pvp .pvp_admiral .pvp_admiral_rank").text(KC3Meta.rank(data.api_rank));
+			// why is this rank int ID, fml
+			$(".activity_pvp .pvp_admiral .pvp_admiral_rank").text(KC3Meta.rank(data.api_rank))
+				.attr("title", KC3Meta.rank(data.api_rank));
+			// guess nobody is interest in api_experience[1]?
+			$(".activity_pvp .pvp_admiral .pvp_admiral_exp").text(data.api_experience[0]);
 			$(".activity_pvp .pvp_admiral .pvp_admiral_comment").text(data.api_cmt);
 			$(".activity_pvp .pvp_admiral .pvp_admiral_ships").text("{0} /{1}".format(data.api_ship));
-			$(".activity_pvp .pvp_admiral .pvp_admiral_gears").text("{0} /{1}".format(data.api_slotitem));
+			$(".activity_pvp .pvp_admiral .pvp_admiral_gears").text("{0} /{1}".format(
+				data.api_slotitem[0],
+				// 3 fixed item space for everyone? fml
+				3 + data.api_slotitem[1]
+			));
 			$(".activity_pvp .pvp_admiral .pvp_admiral_furniture").text(data.api_furniture);
+			// This is not shown in game
 			$(".activity_pvp .pvp_fleet_name").text(data.api_deckname);
 			$(".activity_pvp .pvp_fleet_list").empty();
+			var levelFlagship = 0, level2ndShip = 0;
 			$.each(data.api_deck.api_ships, function(idx, ship){
 				if(ship.api_id > 0){
 					var shipBox = $("#factory .pvpFleetShip").clone();
@@ -2333,10 +2343,32 @@
 					var shipName = KC3Meta.shipName(shipMaster.api_name);
 					$(".pvp_fleet_ship_name", shipBox).text(shipName).attr("title", shipName);
 					$(".pvp_fleet_ship_level .value", shipBox).text(ship.api_level);
-					$(".pvp_fleet_ship_star .value", shipBox).text(1+ship.api_star);
+					if(idx === 0) levelFlagship = ship.api_level;
+					if(idx === 1) level2ndShip = ship.api_level;
+					$(".pvp_fleet_ship_star .value", shipBox).text(1 + ship.api_star);
 					shipBox.appendTo(".activity_pvp .pvp_fleet_list");
 				}
 			});
+			
+			var baseExp = 3 + Math.floor(KC3Meta.expShip(levelFlagship)[1] / 100 + KC3Meta.expShip(level2ndShip)[1] / 300);
+			if(baseExp > 500){
+				baseExp = Math.floor(500 + Math.sqrt(baseExp - 500));
+			}
+			$(".activity_pvp .pvp_base_exp .value").text(baseExp);
+			// TODO scan current selected fleet to detect position of CT and their levels
+			var baseExpS = Math.floor(baseExp * 1.2),
+				baseExpC = Math.floor(baseExp * 0.64),
+				baseExpD = Math.floor(baseExp * 0.56);
+			$(".activity_pvp .pvp_base_exp").attr("title",
+				"x1.2(S+): {0}\nx1 (A/B): {1}\nx0.64(C): {2}\nx0.56(D): {3}"
+				.format(baseExpS, baseExp, baseExpC, baseExpD)
+			);
+			// TODO predicts opponent's formation
+			var predictedFormation = 1;
+			$(".activity_pvp .pvp_formation img")
+				.attr("src", KC3Meta.formationIcon(predictedFormation))
+				.attr("title", KC3Meta.formationText(predictedFormation));
+			
 			$(".module.activity .activity_tab").removeClass("active");
 			$("#atab_activity").addClass("active");
 			$(".module.activity .activity_box").hide();

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -2364,9 +2364,10 @@
 				baseExpD  = Math.floor(baseExp * 0.56 * 0.8 * ctBonus);
 			$(".activity_pvp .pvp_base_exp .value").text(baseExpS);
 			$(".activity_pvp .pvp_base_exp").attr("title",
-				KC3Meta.term("PvpBaseExp") + ": {0}\n"
-				+ "x1.2(S+): {1}\nx1 (A/B): {2}\nx0.64(C): {3}\nx0.56(D): {4}"
-				.format(baseExp, baseExpS, baseExpAB, baseExpC, baseExpD)
+				("{0}: {1}\nx1.2(S+): {2}\nx1 (A/B): {3}\nx0.64(C): {4}\nx0.56(D): {5}"
+				 + ctBonus > 1 ? "\n(CT x{6})" : "")
+					.format(KC3Meta.term("PvpBaseExp"),
+						baseExp, baseExpS, baseExpAB, baseExpC, baseExpD, ctBonus)
 			);
 			var predictedFormation = playerFleet.predictOpponentFormation(
 				// Normalize opponent's fleet: convert Object to Array, remove -1 elements

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -2358,16 +2358,18 @@
 			var playerFleet = PlayerManager.fleets[selectedFleet > 4 ? 0 : selectedFleet - 1];
 			var ctBonus = playerFleet.lookupKatoriClassBonus();
 			// Variant of battle rank
-			var baseExpS  = Math.floor(baseExp * 1.2 * ctBonus),
-				baseExpAB = Math.floor(baseExp * 1.0 * ctBonus),
-				baseExpC  = Math.floor(baseExp * 0.64 * ctBonus),
-				baseExpD  = Math.floor(baseExp * 0.56 * 0.8 * ctBonus);
+			var baseExpWoCT = Math.floor(baseExp * 1.2),
+				baseExpS  = Math.floor(Math.floor(baseExp * 1.2) * ctBonus),
+				baseExpAB = Math.floor(Math.floor(baseExp * 1.0) * ctBonus),
+				baseExpC  = Math.floor(Math.floor(baseExp * 0.64) * ctBonus),
+				baseExpD  = Math.floor(Math.floor(Math.floor(baseExp * 0.56) * 0.8) * ctBonus);
 			$(".activity_pvp .pvp_base_exp .value").text(baseExpS);
 			$(".activity_pvp .pvp_base_exp").attr("title",
-				("{0}: {1}\nx1.2(S+): {2}\nx1 (A/B): {3}\nx0.64(C): {4}\nx0.56(D): {5}"
-				 + ctBonus > 1 ? "\n(CT x{6})" : "")
+				("{0}: {1}\nSS/S: {2}\nA/B: {3}\nC: {4}\nD: {5}"
+				 + (ctBonus > 1 ? "\n{6}: {7}" : ""))
 					.format(KC3Meta.term("PvpBaseExp"),
-						baseExp, baseExpS, baseExpAB, baseExpC, baseExpD, ctBonus)
+						baseExp, baseExpS, baseExpAB, baseExpC, baseExpD,
+						KC3Meta.term("PvpDispBaseExpWoCT").format(ctBonus), baseExpWoCT)
 			);
 			var predictedFormation = playerFleet.predictOpponentFormation(
 				// Normalize opponent's fleet: convert Object to Array, remove -1 elements

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -2267,6 +2267,84 @@
 
 		ClearedMap: function(data){},
 
+		PvPList: function(data){
+			if(!ConfigManager.info_pvp_info)
+				return;
+			console.log("PvP Enemy List", data);
+			var jpRankArr = ["","\u5143\u5e25","\u5927\u5c06","\u4e2d\u5c06","\u5c11\u5c06","\u5927\u4f50","\u4e2d\u4f50","\u65b0\u7c73\u4e2d\u4f50","\u5c11\u4f50","\u4e2d\u5805\u5c11\u4f50","\u65b0\u7c73\u5c11\u4f50"];
+			$(".activity_pvp .pvp_header .pvp_create_kind").text(
+				KC3Meta.term("PvpListCreateType{0}".format(data.api_create_kind))
+			);
+			$(".activity_pvp .pvp_list").empty();
+			$.each(data.api_list, function(idx, enemy){
+				var enemyBox = $("#factory .pvpEnemyInfo").clone();
+				$(".pvp_enemy_pic img", enemyBox).attr("src", KC3Meta.shipIcon(enemy.api_enemy_flag_ship));
+				$(".pvp_enemy_pic", enemyBox).attr("title", KC3Meta.shipName(KC3Master.ship(enemy.api_enemy_flag_ship).api_name));
+				$(".pvp_enemy_name", enemyBox).text(enemy.api_enemy_name);
+				$(".pvp_enemy_name", enemyBox).attr("title", enemy.api_enemy_name);
+				$(".pvp_enemy_level", enemyBox).text(enemy.api_enemy_level);
+				// api_enemy_rank is not int ID of rank, fml
+				var rankId = jpRankArr.indexOf(enemy.api_enemy_rank);
+				$(".pvp_enemy_rank", enemyBox).text(KC3Meta.rank(rankId));
+				$(".pvp_enemy_rank", enemyBox).attr("title", KC3Meta.rank(rankId));
+				$(".pvp_enemy_comment", enemyBox).text(enemy.api_enemy_comment);
+				$(".pvp_enemy_comment", enemyBox).attr("title", enemy.api_enemy_comment);
+				if(enemy.api_medals > 0){
+					$(".pvp_enemy_medals span", enemyBox).text(enemy.api_medals);
+				} else {
+					$(".pvp_enemy_medals", enemyBox).hide();
+				}
+				if(enemy.api_state > 0){
+					$(".pvp_enemy_state img", enemyBox).attr("src",
+						"../../../../assets/img/client/ratings/{0}.png".format(["","E","D","C","B","A","S"][enemy.api_state])
+					);
+				} else {
+					$(".pvp_enemy_state", enemyBox).hide();
+				}
+				enemyBox.appendTo(".activity_pvp .pvp_list");
+			});
+			$(".module.activity .activity_tab").removeClass("active");
+			$("#atab_activity").addClass("active");
+			$(".module.activity .activity_box").hide();
+			$(".module.activity .activity_pvp .pvpList").show();
+			$(".module.activity .activity_pvp .pvpFleet").hide();
+			$(".module.activity .activity_pvp").fadeIn(500);
+		},
+
+		PvPFleet: function(data){
+			if(!ConfigManager.info_pvp_info)
+				return;
+			console.log("PvP Enemy Fleet", data);
+			$(".activity_pvp .pvp_admiral .pvp_admiral_name .value").text(data.api_nickname);
+			$(".activity_pvp .pvp_admiral .pvp_admiral_level .value").text(data.api_level);
+			$(".activity_pvp .pvp_admiral .pvp_admiral_rank").text(KC3Meta.rank(data.api_rank));
+			$(".activity_pvp .pvp_admiral .pvp_admiral_comment").text(data.api_cmt);
+			$(".activity_pvp .pvp_admiral .pvp_admiral_ships").text("{0} /{1}".format(data.api_ship));
+			$(".activity_pvp .pvp_admiral .pvp_admiral_gears").text("{0} /{1}".format(data.api_slotitem));
+			$(".activity_pvp .pvp_admiral .pvp_admiral_furniture").text(data.api_furniture);
+			$(".activity_pvp .pvp_fleet_name").text(data.api_deckname);
+			$(".activity_pvp .pvp_fleet_list").empty();
+			$.each(data.api_deck.api_ships, function(idx, ship){
+				if(ship.api_id > 0){
+					var shipBox = $("#factory .pvpFleetShip").clone();
+					var shipMaster = KC3Master.ship(ship.api_ship_id);
+					$(".pvp_fleet_ship_icon img", shipBox).attr("src", KC3Meta.shipIcon(ship.api_ship_id))
+						.attr("title", KC3Meta.stype(shipMaster.api_stype));
+					var shipName = KC3Meta.shipName(shipMaster.api_name);
+					$(".pvp_fleet_ship_name", shipBox).text(shipName).attr("title", shipName);
+					$(".pvp_fleet_ship_level .value", shipBox).text(ship.api_level);
+					$(".pvp_fleet_ship_star .value", shipBox).text(1+ship.api_star);
+					shipBox.appendTo(".activity_pvp .pvp_fleet_list");
+				}
+			});
+			$(".module.activity .activity_tab").removeClass("active");
+			$("#atab_activity").addClass("active");
+			$(".module.activity .activity_box").hide();
+			$(".module.activity .activity_pvp .pvpList").hide();
+			$(".module.activity .activity_pvp .pvpFleet").show();
+			$(".module.activity .activity_pvp").fadeIn(500);
+		},
+
 		PvPStart: function(data){
 			// Clear battle details box just to make sure
 			clearBattleData();


### PR DESCRIPTION
Natsuiro theme only, close #1454

* Add new setting to toggle activity
* Add new API handling
* Add two activities for PvP opponents list and fleet details
* Also show PvP create type
* Also show opponent's fleet name which is hidden in game
* Not show some values useless I think: friend count? exp of next level?
* [x] Show base EXP of S Rank (with other ranks and Katori-Class modifier on tooltip)
* [x] Show predicted formation based on current selected fleet (if Combined/LBAS selected, use fleet 1. Will not be refreshed in time if fleet changed, just reopen the opponent in game.)

SS, styles are still being adjusted:
![image](https://cloud.githubusercontent.com/assets/160240/22397773/13649804-e5b4-11e6-9e5d-412a23c468e7.png)
![image](https://cloud.githubusercontent.com/assets/160240/22397774/173d2e96-e5b4-11e6-88b6-e8cce7fac82e.png)

new SS with xp and formation:
![image](https://cloud.githubusercontent.com/assets/160240/22402035/87146f9e-e623-11e6-911f-5b6c2026d4ae.png)
![image](https://cloud.githubusercontent.com/assets/160240/22402018/f118dbc4-e622-11e6-85bf-2188d4a1517c.png)

Base EXP with rank & CT bonus:
![image](https://cloud.githubusercontent.com/assets/160240/22410280/2dca03c8-e6d1-11e6-911d-34e15a6bd5e1.png)
