### PR TITLE
Settings to disable Taiha alert

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -480,7 +480,7 @@
 			},
 			{
 				"id" : "alert_taiha_damecon",
-				"name" : "SettingsDisableHasDameon",
+				"name" : "SettingsDisableHasDamecon",
 				"type" : "check",
 				"options" : {}
 			},

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -473,6 +473,18 @@
 				"options" : {}
 			},
 			{
+				"id" : "alert_taiha_homeport",
+				"name" : "SettingsDisableHomePort",
+				"type" : "check",
+				"options" : {}
+			},
+			{
+				"id" : "alert_taiha_damecon",
+				"name" : "SettingsDisableHasDameon",
+				"type" : "check",
+				"options" : {}
+			},
+			{
 				"id" : "alert_taiha_blur",
 				"name" : "SettingsScreenBlur",
 				"type" : "check",

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -144,8 +144,9 @@ Retreives when needed to apply on components
 				alert_taiha_blood	: true,
 				alert_taiha_ss		: false,
 				alert_taiha_sound	: false,
-				alert_taiha_pvp		: false,
 				alert_taiha_panel	: true,
+				alert_taiha_homeport: false,
+				alert_taiha_damecon	: false,
 				
 				api_translation		: true,
 				api_tracking 		: true,


### PR DESCRIPTION
Close #1480 this time.

Two new settings added:

 * Disabled at Home Port, default: false. Enable it at player's own risk. Because it's one of two situations which should alert player NOT to go ahead with Taiha ship.
 * Ignore Damecon Ship (in other world: Disabled if Damecon equipped), default: false

can not find any reason to show Taiha alert on PvP battle... so removed the unused term of TL.
I guess it was supposed to alert at Home Port to stop player sortieing for PvP if there is Taiha non-flagship.
(i'm wondering what is the English term to describe 'non-flagship ship' which referred to `僚艦` or `随伴艦` 🤔 )
