### PR TITLE
new ship\equip export tool on showcase page

### DIFF
--- a/src/library/managers/ShipManager.js
+++ b/src/library/managers/ShipManager.js
@@ -221,7 +221,7 @@ Saves and loads list to and from localStorage
 		// Look for ships by specified conditions
 		find :function( cond ){
 			var result = [];
-			var s;
+			var x;
 			for(var i in this.list) {
 				x = this.list[i];
 				if(cond.call(x, x)) {

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -1,0 +1,875 @@
+"use strict";
+
+var enableShelfTimer = false;
+
+function ShowcaseExporter() {
+    this.canvas = {};
+    this.ctx = {};
+    this.allShipGroups = {};
+    this.loading = 0;
+    this.shipCount = 0;
+    this.rowParams = {
+        width: 330,
+        height: 35
+    };
+    this.colors = {
+        odd: "#e0e0e0",
+        even: "#f2f2f2"
+    };
+    this.columnCount = 5;
+    this.addName = false;
+    this.loadingCount = 0;
+    this.callback = function () {
+    };
+    this.aircraftTypes = [];
+    this._statsImages = {
+        fp: null,
+        tp: null,
+        aa: null,
+        ar: null,
+        as: null,
+        ev: null,
+        ls: null,
+        dv: null,
+        ht: null,
+        rn: null,
+        or: null
+    };
+    this._equipTypeImages = {};
+    this._shipImages = {};
+    this._otherImages = {};
+    this._equipCanvases = {};
+    this._equipGroupCanvases = {}
+    this._paramToApi = {
+        fp: "api_houg",
+        tp: "api_raig",
+        aa: "api_tyku",
+        ar: "api_souk",
+        as: "api_tais",
+        ev: "api_houk",
+        ls: "api_saku",
+        dv: "api_baku",
+        ht: "api_houm",
+        rn: "api_leng",
+        or: "api_distance"
+    };
+}
+
+ShowcaseExporter.prototype._init = function () {
+    this.canvas = document.createElement("CANVAS");
+    this.ctx = this.canvas.getContext("2d");
+    this.allShipGroups = {};
+    this.aircraftTypes = $.unique($.merge(KC3GearManager.carrierBasedAircraftType3Ids, KC3GearManager.landBasedAircraftType3Ids));
+    for (var i in KC3Meta._stype) {
+        if (KC3Meta._stype != "")
+            this.allShipGroups[i] = [];
+    }
+};
+
+ShowcaseExporter.prototype.complete = function () {
+    (this.callback || function () {
+    })();
+};
+
+ShowcaseExporter.prototype._drawBorders = function (canvas, ctx, rowWidth) {
+    if (!canvas)
+        canvas = this.canvas;
+    if (!ctx)
+        ctx = this.ctx;
+    if (!rowWidth)
+        rowWidth = this.rowParams.width;
+    for (var x = rowWidth; x < canvas.width; x += rowWidth) {
+        ctx.fillStyle = "#FFF";
+        for (var y = 0; y < canvas.height; y += 20) {
+            ctx.fillRect(x - 1, y, 2, 10);
+        }
+    }
+};
+
+ShowcaseExporter.prototype._addCredits = function (canvasData, topLine) {
+    if (!canvasData)
+        canvasData = this.canvas;
+    if (!topLine)
+        topLine = "Ship List";
+
+
+    var canvas = document.createElement("CANVAS");
+    var ctx = canvas.getContext("2d");
+
+    canvas.height = canvasData.height + this.rowParams.height * 2 + 18;
+    canvas.width = canvasData.width;
+
+    ctx.fillStyle = "#FFF";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.drawImage(canvasData, 0, this.rowParams.height * 2, canvasData.width, canvasData.height);
+
+    var d = new Date();
+
+    var monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "June",
+        "July", "Aug", "Sep", "Oct", "Nov", "Dec"
+    ];
+
+    var created = "Made in KC3 on " + d.getDate() + " " + monthNames[d.getMonth()] + " " + d.getFullYear();
+    ctx.font = "400 14pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+    ctx.fillStyle = "#000";
+
+    ctx.fillText(
+        created,
+        canvas.width - this.rowParams.height * 0.5 - ctx.measureText(created).width,
+        canvas.height - 1
+    );
+    var x = 20;
+    if (topLine.indexOf("Ship") != -1) {
+        x = this._addConsumableImage(ctx, canvas, x, "medals") + 50;
+        this._addConsumableImage(ctx, canvas, x, "blueprints");
+    } else {
+        x = this._addConsumableImage(ctx, canvas, x, "devmats") + 50;
+        this._addConsumableImage(ctx, canvas, x, "screws");
+    }
+
+    var header = this.addName ? JSON.parse(localStorage.player).name + " " + topLine : topLine;
+
+    var fontsize = 30;
+    ctx.font = "600 " + fontsize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+    ctx.fillText(header, (canvas.width - ctx.measureText(header).width) / 2, this.rowParams.height + fontsize / 2);
+
+    var img = new Image();
+    img.exporter = this;
+    img.onload = function () {
+        ctx.drawImage(
+            img,
+            0, 0, img.width, img.height,
+            canvas.width - this.exporter.rowParams.height * 2, 0,
+            this.exporter.rowParams.height * 2, this.exporter.rowParams.height * 2
+        );
+
+        ctx.drawImage(
+            img,
+            0, 0, img.width, img.height,
+            0, 0,
+            this.exporter.rowParams.height * 2, this.exporter.rowParams.height * 2
+        );
+        var date = d.getFullYear() + "_" + d.getMonth() + "_" + d.getDate();
+        if (enableShelfTimer) {
+            clearTimeout(enableShelfTimer);
+        }
+        var self = this;
+        chrome.downloads.setShelfEnabled(false);
+        chrome.downloads.download({
+            url: canvas.toDataURL("PNG"),
+            filename: ConfigManager.ss_directory + '/' + date + '_' + topLine.replace(" ", "") + ".PNG",
+            conflictAction: "uniquify"
+        }, function (downloadId) {
+            enableShelfTimer = setTimeout(function () {
+                chrome.downloads.setShelfEnabled(true);
+                enableShelfTimer = false;
+                self.exporter.complete();
+            }, 100);
+        });
+    };
+    img.src = "/assets/img/logo/128.png";
+
+};
+
+ShowcaseExporter.prototype._addConsumableImage = function (ctx, canvas, x, type) {
+    ctx.fillText(JSON.parse(localStorage.consumables)[type], x, canvas.height - 1);
+    x += ctx.measureText(JSON.parse(localStorage.consumables)[type]).width + 5;
+    ctx.drawImage(this._otherImages[type], x, canvas.height - 18, 18, 18);
+    return x + 18;
+};
+
+ShowcaseExporter.prototype._loadImage = function (imageName, imageGroup, url, callback) {
+    var img = new Image();
+    var self = this;
+    img.imageName = imageName;
+    this.loadingCount++;
+
+    img.onload = function () {
+        self[imageGroup][this.imageName] = this;
+        self.loadingCount--;
+
+        if (self.loadingCount == 0)
+            callback();
+    };
+    img.src = url;
+};
+
+ShowcaseExporter.prototype._loadImages = function (callback) {
+    for (var i in this._statsImages) {
+        if (!this._statsImages.hasOwnProperty(i))
+            continue;
+        this._loadImage(i, "_statsImages", "/assets/img/stats/" + i + ".png", callback)
+    }
+
+    for (var i in this._equipTypeImages) {
+        if (!this._equipTypeImages.hasOwnProperty(i))
+            continue;
+        this._loadImage(i, "_equipTypeImages", "/assets/img/items/" + i + ".png", callback);
+    }
+
+    for (var i in this._shipImages) {
+        if (!this._shipImages.hasOwnProperty(i))
+            continue;
+        this._loadImage(i, "_shipImages", "/assets/img/ships/" + i + ".png", callback);
+    }
+
+    this._loadImage("medals", "_otherImages", "/assets/img/useitems/57.png", callback);
+    this._loadImage("blueprints", "_otherImages", "/assets/img/useitems/58.png", callback);
+    this._loadImage("screws", "_otherImages", "/assets/img/useitems/4.png", callback);
+    this._loadImage("devmats", "_otherImages", "/assets/img/useitems/3.png", callback);
+
+};
+
+/* SHIP EXPORT
+ ------------------------- */
+ShowcaseExporter.prototype.exportShips = function () {
+    this._init();
+    this._getShips();
+    var self = this;
+    this._loadImages(function () {
+        self._resizeCanvas();
+        var x = 0;
+        var y = 0;
+        var color = self.colors.odd;
+        for (var type in self.allShipGroups) {
+            if (self.allShipGroups[type].length > 0) {
+                if (y >= self.canvas.height - self.rowParams.height) {
+                    x += self.rowParams.width;
+                    y = 0;
+                }
+
+                self._drawShipTypeName(x, y, type, color);
+                y += self.rowParams.height;
+
+                for (var j = 0; j < self.allShipGroups[type].length; j++) {
+                    self._drawShip(x, y, self.allShipGroups[type][j], color);
+                    y += self.rowParams.height;
+                    if (y >= self.canvas.height) {
+                        x += self.rowParams.width;
+                        y = 0;
+                    }
+                }
+                if (color == self.colors.even)
+                    color = self.colors.odd;
+                else
+                    color = self.colors.even;
+            }
+        }
+
+        self._finalize();
+    });
+};
+
+ShowcaseExporter.prototype._drawShipTypeName = function (x, y, type, background) {
+    this.ctx.fillStyle = background;
+    this.ctx.fillRect(x, y, this.rowParams.width, this.rowParams.height);
+
+    this.ctx.font = "600 20pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+    this.ctx.fillStyle = "#0066CC";
+    this.ctx.fillText(KC3Meta.stype(type), x + this.rowParams.height / 2, y + this.rowParams.height - (this.rowParams.height - 18) / 2);
+};
+
+ShowcaseExporter.prototype._finalize = function () {
+    if (this.loading != 0)
+        return;
+    this._drawBorders();
+    this._addCredits();
+};
+
+ShowcaseExporter.prototype._resizeCanvas = function () {
+    var types = 0;
+    for (var type in this.allShipGroups) {
+        if (this.allShipGroups[type].length > 0)
+            types++;
+    }
+    this.canvas.height = Math.ceil((this.shipCount + types) / this.columnCount) * this.rowParams.height;
+    this.canvas.width = this.columnCount * this.rowParams.width;
+
+    if (!this._checkFit()) {
+        this.canvas.height = Math.ceil((this.shipCount + types) / this.columnCount + 1) * this.rowParams.height;
+        this.canvas.width = this.columnCount * this.rowParams.width;
+    }
+
+    this._fill();
+};
+
+ShowcaseExporter.prototype._checkFit = function () {
+    // i don't know how to make this check better
+    // math....
+    var x = 0;
+    var y = 0;
+    for (var type in this.allShipGroups) {
+        if (this.allShipGroups[type].length > 0) {
+            if (y >= this.canvas.height - this.rowParams.height) {
+                x += this.rowParams.width;
+                y = 0;
+            }
+            // drawing title
+            y += this.rowParams.height;
+
+            for (var j = 0; j < this.allShipGroups[type].length; j++) {
+                // drawing ship
+                y += this.rowParams.height;
+                if (y >= this.canvas.height) {
+                    x += this.rowParams.width;
+                    y = 0;
+                }
+            }
+        }
+    }
+
+    return !(x >= this.canvas.width && y != 0);
+};
+
+ShowcaseExporter.prototype._getShips = function () {
+    var ships = JSON.parse(localStorage.ships);
+    for (var i in ships) {
+        if (ships[i].lock == 0)
+            continue;
+
+        var ship = KC3ShipManager.get(ships[i].rosterId);
+        this.allShipGroups[ship.master().api_stype].push(ship);
+        this._shipImages[ship.masterId] = null;
+        this.shipCount++;
+    }
+
+    for (var i in this.allShipGroups) {
+        if (this.allShipGroups[i].length > 0) {
+            this.allShipGroups[i].sort(function (shipA, shipB) {
+                if (shipB.level != shipA.level)
+                    return shipB.level - shipA.level;
+                else
+                    return shipB.masterId - shipA.masterId;
+            });
+        }
+    }
+};
+
+ShowcaseExporter.prototype._drawShip = function (x, y, ship, background) {
+    this.ctx.fillStyle = background;
+    this.ctx.fillRect(x, y, this.rowParams.width, this.rowParams.height);
+    var xOffset = this.rowParams.height / 7;
+
+    this._drawStat(ship.fp, x + xOffset, y, this.rowParams.height / 2, this.rowParams.height / 2, "#ff8888", background);
+    this._drawStat(ship.tp, x + xOffset + this.rowParams.height / 2, y, this.rowParams.height / 2, this.rowParams.height / 2, "#00CCFF", background);
+    this._drawStat(ship.aa, x + xOffset + this.rowParams.height / 2, y + this.rowParams.height / 2, this.rowParams.height / 2, this.rowParams.height / 2, "#ff9900", background);
+    this._drawStat(ship.ar, x + xOffset, y + this.rowParams.height / 2, this.rowParams.height / 2, this.rowParams.height / 2, "#ffcc00", background);
+    this._drawStat(ship.lk, x + xOffset + this.rowParams.height, y, this.rowParams.height / 5, this.rowParams.height / 2, "#66FF66", background);
+
+    this._drawIcon(x + xOffset, y, ship.masterId);
+
+    var fontSize = 19;
+    this.ctx.font = "400 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+    while (this.ctx.measureText(ship.name()).width > this.rowParams.width - this.rowParams.height * 3.5) {
+        fontSize--;
+        this.ctx.font = "400 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+    }
+    this.ctx.fillStyle = "#000";
+    this.ctx.fillText(ship.name(), x + this.rowParams.height * 2, y + this.rowParams.height - (this.rowParams.height - fontSize) / 2);
+
+    this.ctx.font = "400 19pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+    this.ctx.fillText(
+        ship.level,
+        x + this.rowParams.width - this.rowParams.height * 0.5 - this.ctx.measureText(ship.level).width,
+        y + this.rowParams.height - (this.rowParams.height - fontSize) / 2
+    );
+
+};
+
+ShowcaseExporter.prototype._drawIcon = function (x, y, shipId) {
+    this.ctx.drawImage(
+        this._shipImages[shipId],
+        0, 0, this._shipImages[shipId].width, this._shipImages[shipId].height,
+        x, y, this.rowParams.height, this.rowParams.height
+    );
+};
+
+ShowcaseExporter.prototype._drawStat = function (stat, x, y, w, h, color, background) {
+    if (stat[0] >= stat[1]) {
+        this.ctx.fillStyle = color;
+        this.ctx.fillRect(x, y, w, h);
+    } else {
+        this.ctx.fillStyle = background;
+        this.ctx.fillRect(x, y, w, h);
+    }
+};
+
+ShowcaseExporter.prototype._fill = function () {
+    this.ctx.fillStyle = "#efefef";
+    this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+};
+
+/* EQUIP EXPORT
+ ------------------------- */
+
+ShowcaseExporter.prototype.exportEquip = function () {
+    var gears = this._getGears();
+    var self = this;
+
+    this._loadImages(function () {
+        self._processGears(gears);
+    });
+};
+
+ShowcaseExporter.prototype._getGears = function () {
+    var allGears = JSON.parse(localStorage.gears);
+    var sorted = {};
+    for (var i in allGears) {
+        if (allGears[i].lock == 0)
+            continue;
+
+        var equip = allGears[i];
+        var equipMaster = KC3Master.slotitem(equip.masterId);
+
+        var masterId = "m" + equip.masterId;
+        var typeId = "t" + equipMaster.api_type[3];
+        var groupId = "g" + equipMaster.api_type[0];
+        if (!sorted[groupId]) {
+            sorted[groupId] = {
+                name: KC3Meta.gearTypeName(0, equipMaster.api_type[0]),
+                types: {}
+            };
+        }
+
+        if (!sorted[groupId]["types"][typeId]) {
+            sorted[groupId]["types"][typeId] = {
+                typeId: KC3Master.slotitem(equip.masterId).api_type[3],
+                name: KC3Meta.gearTypeName(2, equipMaster.api_type[2]),
+                gears: {}
+            };
+            this._equipTypeImages[KC3Master.slotitem(equip.masterId).api_type[3]] = null;
+        }
+
+        if (!sorted[groupId]["types"][typeId]["gears"][masterId]) {
+            sorted[groupId]["types"][typeId]["gears"][masterId] = {
+                masterId: equip.masterId,
+                name: KC3Meta.gearName(equipMaster.api_name),
+                fp: equipMaster.api_houg,
+                tp: equipMaster.api_raig,
+                aa: equipMaster.api_tyku,
+                ar: equipMaster.api_souk,
+                as: equipMaster.api_tais,
+                ev: equipMaster.api_houk,
+                ls: equipMaster.api_saku,
+                dv: equipMaster.api_baku,
+                ht: equipMaster.api_houm,
+                rn: equipMaster.api_leng,
+                or: equipMaster.api_distance,
+                "s0": 0,
+                "s1": 0, "s2": 0, "s3": 0, "s4": 0, "s5": 0,
+                "s6": 0, "s7": 0, "s8": 0, "s9": 0, "s10": 0
+            };
+        }
+        sorted[groupId]["types"][typeId]["gears"][masterId]["s" + equip.stars]++;
+    }
+
+    return sorted;
+};
+
+ShowcaseExporter.prototype._processGears = function (gears) {
+    var canvas = document.createElement("CANVAS");
+    var ctx = canvas.getContext("2d");
+
+    var columnsCount = 5;
+    var rowHeight = 30;
+    var rowWidth = 350;
+
+    this._drawEquipGroups(gears, rowWidth, rowHeight);
+    var columns = this._splitEquipByColumns(columnsCount);
+    canvas.height = this._getBiggestColumn(columns);
+    canvas.width = rowWidth * columnsCount;
+    ctx.fillStyle = this.colors.odd;
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    this._fillEquipCanvas(canvas, ctx, columns, rowWidth);
+    this._drawBorders(canvas, ctx, rowWidth);
+    this._addCredits(canvas, "Equipment List");
+};
+
+ShowcaseExporter.prototype._fillEquipCanvas = function (canvas, ctx, columns, rowWidth) {
+    for (var i = 0; i < columns.length; i++) {
+        var column = columns[i];
+        var y = 0, x = i * rowWidth;
+        for (var j = 0; j < column.length; j++) {
+            var canvasData = this._equipGroupCanvases[column[j]];
+            ctx.drawImage(canvasData, x, y, canvasData.width, canvasData.height);
+            y += canvasData.height;
+        }
+    }
+};
+
+ShowcaseExporter.prototype._getBiggestColumn = function (columns) {
+    var maxSize = 0;
+    for (var i = 0; i < columns.length; i++) {
+        if (typeof columns[i] != "object")
+            continue;
+
+        var size = 0;
+        for (var j = 0; j < columns[i].length; j++) {
+            size += this._equipGroupCanvases[columns[i][j]].height;
+        }
+        if (maxSize < size)
+            maxSize = size;
+    }
+    return maxSize;
+};
+
+ShowcaseExporter.prototype._splitEquipByColumns = function (maxColumns) {
+    var maxHeight = this._getMaxHeight(), totalHeight = this._getTotalHeight();
+    var aproxSize = Math.max(Math.ceil(totalHeight / maxColumns), maxHeight);
+    var paging = this._fillEquipColumns(aproxSize);
+
+    if (paging.length > maxColumns) {
+        paging = this._fixEquipPaging(aproxSize, paging, maxColumns);
+    }
+    return paging;
+};
+
+ShowcaseExporter.prototype._fixEquipPaging = function (aproxSize, paging, maxColumns) {
+    while (paging.length > maxColumns) {
+        paging = this._fillEquipColumns(aproxSize++);
+    }
+    return paging;
+};
+
+ShowcaseExporter.prototype._fillEquipColumns = function (aproxSize) {
+    var groupIds = [];
+    for (var groupId in this._equipGroupCanvases) {
+        if (groupId.startsWith("g"))
+            groupIds.push(parseInt(groupId.slice("1")));
+    }
+    groupIds.sort(function (a, b) {
+        return a - b;
+    });
+
+
+    var newPaging = [[]];
+    var size = 0;
+    var column = 0;
+    for (var i = 0; i < groupIds.length; i++) {
+        if (size + this._equipGroupCanvases["g" + groupIds[i]].height > aproxSize) {
+            column++;
+            newPaging.push([]);
+            size = 0;
+        }
+        newPaging[column].push("g" + groupIds[i]);
+        size += this._equipGroupCanvases["g" + groupIds[i]].height;
+    }
+    return newPaging;
+};
+
+ShowcaseExporter.prototype._getMaxHeight = function () {
+    var maxHeight = 0;
+
+    for (var groupId in this._equipGroupCanvases) {
+        if (!this._equipGroupCanvases.hasOwnProperty(groupId))
+            continue;
+        if (this._equipGroupCanvases[groupId].height > maxHeight)
+            maxHeight = this._equipGroupCanvases[groupId].height;
+    }
+    return maxHeight;
+};
+
+ShowcaseExporter.prototype._getTotalHeight = function () {
+    var totalHeight = 0;
+
+    for (var groupId in this._equipGroupCanvases) {
+        if (!this._equipGroupCanvases.hasOwnProperty(groupId))
+            continue;
+        totalHeight += this._equipGroupCanvases[groupId].height;
+    }
+    return totalHeight;
+};
+
+ShowcaseExporter.prototype._drawEquipGroups = function (gears, rowWidth, rowHeight) {
+    var groupIds = [];
+    for (var groupId in gears) {
+        if (groupId.startsWith("g"))
+            groupIds.push(parseInt(groupId.slice("1")));
+    }
+    groupIds.sort(function (a, b) {
+        return a - b;
+    });
+
+    var bool = true;
+    for (var i = 0; i < groupIds.length; i++) {
+        var canvas = document.createElement("CANVAS"), ctx = canvas.getContext("2d");
+        canvas.height = this._drawEquipGroup(gears["g" + groupIds[i]], rowWidth, rowHeight);
+        canvas.width = rowWidth;
+        ctx.fillStyle = bool ? this.colors.odd : this.colors.even;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        bool = !bool;
+        this._addEquipGroupsToCanvas(gears["g" + groupIds[i]], canvas, ctx, rowHeight);
+        this._equipGroupCanvases["g" + groupIds[i]] = canvas;
+    }
+};
+
+ShowcaseExporter.prototype._addEquipGroupsToCanvas = function (group, canvas, ctx, rowHeight) {
+    var typeCount = 0;
+    for (var typeId in group.types) {//each type
+        typeCount++;
+    }
+
+    var y = 0;
+    var fontSize = 16;
+    ctx.font = "600 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+    ctx.fillStyle = "#000";
+    ctx.fillText(group.name, (canvas.width - ctx.measureText(group.name).width) / 2, ( rowHeight + fontSize) / 2);
+    y += rowHeight;
+
+    for (var typeId in group.types) {
+        if (typeId.startsWith("t")) {
+            var type = group.types[typeId];
+            if (typeCount > 1) {
+                y += rowHeight / 2;
+                fontSize = 16;
+                ctx.font = "500 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+                ctx.fillStyle = "#000";
+                ctx.fillText(type.name, (canvas.width - ctx.measureText(type.name).width) / 2, y + (rowHeight + fontSize) / 2);
+                y += rowHeight * 1.5;
+            }
+
+            var masterIds = [];
+            for (var masterId in type.gears) {
+                if (!type.hasOwnProperty(masterId) && masterId.startsWith("m")) {
+                    masterIds.push(masterId);
+                }
+            }
+
+            var sortingParam = this._paramToApi[KC3StrategyTabs.gears.definition._defaultCompareMethod[typeId]];
+            if (!!sortingParam) {
+                masterIds.sort(function (a, b) {
+                    var shipA = KC3Master.slotitem(a.slice(1)), shipB = KC3Master.slotitem(b.slice(1));
+                    return shipB[sortingParam] - shipA[sortingParam];
+                });
+            }
+
+            for (var i = 0; i < masterIds.length; i++) {
+                masterId = masterIds[i];
+                var canvasData = this._equipCanvases[masterId];
+                ctx.drawImage(canvasData, 0, y, canvasData.width, canvasData.height);
+                y += canvasData.height;
+
+            }
+            y += rowHeight * 0.5;
+
+            ctx.fillStyle = "#FFF";
+            for (var xPos = 0; xPos < 0 + canvas.width; xPos += 20) {
+                ctx.fillRect(xPos, y - 2, 10, 2);
+            }
+        }
+    }
+};
+
+ShowcaseExporter.prototype._drawEquipGroup = function (group, rowWidth, rowHeight) {
+    var typeCount = 0;
+    for (var typeId in group.types) {
+        typeCount++;
+    }
+
+    var height = 0;
+    for (var i in group.types) {
+        if (i.startsWith("t")) {
+            height += this._drawEquipTypes(group.types[i], rowWidth, rowHeight);
+        }
+    }
+    if (typeCount > 1)
+        height += rowHeight * typeCount * 2;// + typename each
+    return height + rowHeight;// + groupName
+};
+
+ShowcaseExporter.prototype._drawEquipTypes = function (types, rowWidth, rowHeight) {
+    var height = 0;
+
+    for (var masterId in types.gears) {
+        if (!types.hasOwnProperty(masterId) && masterId.startsWith("m")) {
+            height += this._drawEquip(types.gears[masterId], rowWidth, rowHeight, false);
+        }
+    }
+    return height + 0.5 * rowHeight;
+};
+
+ShowcaseExporter.prototype._drawEquip = function (equip, rowWidth, rowHeight, fake) {
+    var height;
+    if (!fake) {
+        height = this._drawEquip(equip, rowWidth, rowHeight, true);
+    }
+
+    var img = this._equipTypeImages[KC3Master.slotitem(equip.masterId).api_type[3]];
+    var canvas = document.createElement("CANVAS"), ctx = canvas.getContext("2d");
+    var x = 0, y = 0;
+
+    if (fake == false) {
+        canvas.width = rowWidth;
+        canvas.height = height;
+        ctx.drawImage(img, 0, 0, img.width, img.height, x, y, rowHeight, rowHeight);
+    }
+
+    var equipMaxY = this._drawEquipInfo(equip, ctx, x, y, rowWidth, rowHeight, fake);
+
+    ctx.fillStyle = "#000";
+    var fontSize;
+    for (var i = 0; i <= 10; i++) {
+        if (i == 0)
+            fontSize = 14;
+        else
+            fontSize = 10;
+        if (equip["s" + i] == 0)
+            continue;
+
+        var text = "";
+        if (i == 0) {
+            text = " x";
+        } else if (i == 10) {
+            text = "+10★ x"
+        } else {
+            text = "+" + i + "★ x"
+        }
+        text += equip["s" + i];
+        ctx.font = fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        if (!fake)
+            ctx.fillText(text, x + rowWidth - rowHeight * 0.5 - ctx.measureText(text).width, y + (rowHeight + fontSize) / 2);
+        y += fontSize + 4;
+    }
+    if (equipMaxY > y)
+        y = equipMaxY;
+
+    this._equipCanvases["m" + equip.masterId] = canvas;
+    return y + 5;
+};
+
+ShowcaseExporter.prototype._drawEquipInfo = function (equip, ctx, x, y, rowWidth, rowHeight, fake) {
+    var startY = y;
+    var fontSize = 10;
+    ctx.font = fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+    ctx.fillStyle = "#000";
+
+    var available = rowWidth - rowHeight * 3.5;
+
+    var name = this._splitText(equip.name, ctx, available);
+    y = this._drawEquipName(name, ctx, x + 30, y, rowHeight, fontSize, fake);
+
+    if (equip.name != KC3Master.slotitem(equip.masterId).api_name) {
+        name = this._splitText(KC3Master.slotitem(equip.masterId).api_name, ctx, available, "");
+        y = this._drawEquipName(name, ctx, x + 30, y, fontSize, fontSize, fake);
+    }
+    y = y < startY + 30 ? startY + 30 : y;
+
+    var available = rowWidth - rowHeight * 3.5;
+
+    y += 5;
+    var statsY = this._drawEquipStats(equip, ctx, x + rowHeight, y, available, fake);
+    y = Math.max(statsY, y);
+    if (statsY > 0)
+        y += 10;
+    return y;
+};
+
+ShowcaseExporter.prototype._drawEquipName = function (nameLines, ctx, x, y, rowHeight, fontSize, fake) {
+    if (nameLines.length == 1) {
+        if (!fake)
+            ctx.fillText(nameLines[0], x, y + fontSize);
+        y += fontSize + 5;
+    } else {
+        for (var i = 0; i < nameLines.length; i++) {
+            if (!fake)
+                ctx.fillText(nameLines[i], x, y + fontSize);
+            y += fontSize + 5;
+        }
+    }
+    return y;
+};
+
+ShowcaseExporter.prototype._splitText = function (text, ctx, maxWidth, splitter) {
+    if (typeof splitter == "undefined")
+        splitter = " ";
+
+    if(text.indexOf(splitter)==-1)
+        splitter="";
+
+    var rows = [];
+    var words = text.split(splitter);
+
+    //@TODO what if single word will be so long so it goes outside maxWidth?
+    while (words.length > 0) {
+        var line = [];
+        var next = words.shift();
+        while (ctx.measureText((line.join(splitter) + splitter + next).trim()).width < maxWidth && next != "") {
+            line.push(next);
+            if (words.length > 0)
+                next = words.shift();
+            else
+                next = "";
+        }
+        rows.push(line.join(splitter));
+        if (next != "") {
+            words.unshift(next);
+        }
+    }
+
+    return rows;
+};
+
+ShowcaseExporter.prototype._drawEquipStats = function (equip, ctx, x, y, available, fake) {
+    var fontSize = 10;
+    ctx.font = fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+    ctx.fillStyle = "#000";
+
+    var startX = x;
+    var img;
+    var noStats = true;
+
+    function drawStat() {
+        img = this._statsImages[i];
+        if (typeof equip[i] != "undefined" && equip[i] > 0) {
+            noStats = false;
+            if (x + img.width + 3 + ctx.measureText(equip[i]).width > startX + available) {
+                y += img.height + 5;
+                x = startX;
+            }
+
+            if (!fake)
+                ctx.drawImage(img, 0, 0, img.width, img.height, x, y, img.width, img.height);
+            x += img.width + 3;
+            if (!fake)
+                ctx.fillText(equip[i], x, y + (img.height + fontSize) / 2);
+            x += ctx.measureText(equip[i]).width;
+            x += 10;
+        }
+    }
+    var sortingParam = KC3StrategyTabs.gears.definition._defaultCompareMethod["t"+KC3Master.slotitem(equip.masterId).api_type[3]];
+    if(!!sortingParam && sortingParam!="overall"){
+        var i = sortingParam;
+        drawStat.call(this);
+    }
+
+
+    for (var i in this._statsImages) {
+        if (!this._statsImages.hasOwnProperty(i))
+            continue;
+
+        if (i == "or" && this.aircraftTypes.indexOf(KC3Master.slotitem(equip.masterId).api_type[3]) == -1)
+            continue;
+
+        if(sortingParam==i)
+            continue;
+
+        drawStat.call(this);
+    }
+    if (noStats)
+        return 0;
+
+    y += img.height + 5;
+    return y;
+};
+
+ShowcaseExporter.prototype._cloneArray = function (a) {
+    var b = [];
+    var i = a.length;
+    while (i--) {
+        if (typeof a[i] == "object")
+            b[i] = this._cloneArray(a[i]);
+        else
+            b[i] = a[i];
+    }
+    return b;
+};

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -3,6 +3,10 @@
 
     var enableShelfTimer = false;
 
+    function generateFontString(weight, px){
+      return weight+" "+px+"px \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+    }
+
     window.ShowcaseExporter = function () {
         this.canvas = {};
         this.ctx = {};
@@ -22,7 +26,6 @@
         this.loadingCount = 0;
         this.callback = function () {
         };
-        this.aircraftTypes = [];
         this._statsImages = {
             fp: null,
             tp: null,
@@ -60,7 +63,6 @@
         this.canvas = document.createElement("CANVAS");
         this.ctx = this.canvas.getContext("2d");
         this.allShipGroups = {};
-        this.aircraftTypes = $.unique($.merge(KC3GearManager.carrierBasedAircraftType3Ids, KC3GearManager.landBasedAircraftType3Ids));
         for (var i in KC3Meta._stype) {
             if (KC3Meta._stype !== "")
                 this.allShipGroups[i] = [];
@@ -105,7 +107,7 @@
         ctx.drawImage(canvasData, 0, this.rowParams.height * 2, canvasData.width, canvasData.height);
 
         var created = "Made in KC3 on " + dateFormat("dd mmm yyyy");
-        ctx.font = "400 14pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        ctx.font = generateFontString(400,14);
         ctx.fillStyle = "#000";
 
         ctx.fillText(
@@ -125,7 +127,7 @@
         var header = this.addName ? JSON.parse(localStorage.player).name + " " + topLine : topLine;
 
         var fontsize = 30;
-        ctx.font = "600 " + fontsize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        ctx.font = generateFontString(600,fontsize);
         ctx.fillText(header, (canvas.width - ctx.measureText(header).width) / 2, this.rowParams.height + fontsize / 2);
 
         var img = new Image();
@@ -148,17 +150,18 @@
                 clearTimeout(enableShelfTimer);
             }
             var self = this;
+            var filename = ConfigManager.ss_directory + '/' + dateFormat("yyyy-mm-dd") + '_' + topLine.replace(" ", "") + ".png";
             chrome.downloads.setShelfEnabled(false);
             chrome.downloads.download({
-                url: canvas.toDataURL("PNG"),
-                filename: ConfigManager.ss_directory + '/' + dateFormat("yyyy-mm-dd") + '_' + topLine.replace(" ", "") + ".PNG",
+                url: canvas.toDataURL("image/png"),
+                filename: filename,
                 conflictAction: "uniquify"
             }, function (downloadId) {
                 enableShelfTimer = setTimeout(function () {
                     chrome.downloads.setShelfEnabled(true);
                     enableShelfTimer = false;
                     self.exporter.cleanUp();
-                    self.exporter.complete();
+                    self.exporter.complete({downloadId:downloadId,filename:filename});
                 }, 100);
             });
         };
@@ -219,7 +222,6 @@
         this.canvas = {};
         this.ctx = {};
         this.allShipGroups = {};
-        this.aircraftTypes = [];
         this._statsImages = {};
         this._equipTypeImages = {};
         this._shipImages = {};
@@ -272,7 +274,7 @@
         this.ctx.fillStyle = background;
         this.ctx.fillRect(x, y, this.rowParams.width, this.rowParams.height);
 
-        this.ctx.font = "600 20pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        this.ctx.font = generateFontString(600,20);
         this.ctx.fillStyle = "#0066CC";
         this.ctx.fillText(KC3Meta.stype(type), x + this.rowParams.height / 2, y + this.rowParams.height - (this.rowParams.height - 18) / 2);
     };
@@ -365,15 +367,15 @@
         this._drawIcon(x + xOffset, y, ship.masterId);
 
         var fontSize = 19;
-        this.ctx.font = "400 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        this.ctx.font = generateFontString(400,fontSize);
         while (this.ctx.measureText(ship.name()).width > this.rowParams.width - this.rowParams.height * 3.5) {
             fontSize--;
-            this.ctx.font = "400 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+            this.ctx.font = generateFontString(400,fontSize);
         }
         this.ctx.fillStyle = "#000";
         this.ctx.fillText(ship.name(), x + this.rowParams.height * 2, y + this.rowParams.height - (this.rowParams.height - fontSize) / 2);
 
-        this.ctx.font = "400 19pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        this.ctx.font = generateFontString(400,19);
         this.ctx.fillText(
             ship.level,
             x + this.rowParams.width - this.rowParams.height * 0.5 - this.ctx.measureText(ship.level).width,
@@ -622,7 +624,7 @@
 
         var y = 0;
         var fontSize = 16;
-        ctx.font = "600 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        ctx.font = generateFontString(600,fontSize);
         ctx.fillStyle = "#000";
         ctx.fillText(group.name, (canvas.width - ctx.measureText(group.name).width) / 2, ( rowHeight + fontSize) / 2);
         y += rowHeight;
@@ -633,7 +635,7 @@
                 if (typeCount > 1) {
                     y += rowHeight / 2;
                     fontSize = 16;
-                    ctx.font = "500 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+                    ctx.font = generateFontString(500,fontSize);
                     ctx.fillStyle = "#000";
                     ctx.fillText(type.name, (canvas.width - ctx.measureText(type.name).width) / 2, y + (rowHeight + fontSize) / 2);
                     y += rowHeight * 1.5;
@@ -731,7 +733,7 @@
                 text = "+" + i + "★ x";
             }
             text += equip["s" + i];
-            ctx.font = fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+            ctx.font = generateFontString(400,fontSize);
             if (!fake)
                 ctx.fillText(text, x + rowWidth - rowHeight * 0.5 - ctx.measureText(text).width, y + (rowHeight + fontSize) / 2);
             y += fontSize + 4;
@@ -746,7 +748,7 @@
     ShowcaseExporter.prototype._drawEquipInfo = function (equip, ctx, x, y, rowWidth, rowHeight, fake) {
         var startY = y;
         var fontSize = 10;
-        ctx.font = fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        ctx.font = generateFontString(400,fontSize);
         ctx.fillStyle = "#000";
 
         var available = rowWidth - rowHeight * 3.5;
@@ -773,16 +775,16 @@
     ShowcaseExporter.prototype._drawEquipName = function (nameLines, ctx, x, y, rowHeight, fontSize, fake) {
         if (nameLines.length === 1) {
             if (!fake)
-                ctx.fillText(nameLines[0], x, y + fontSize);
+                ctx.fillText(nameLines[0], x, y + fontSize + 2);
             y += fontSize + 5;
         } else {
             for (var i = 0; i < nameLines.length; i++) {
                 if (!fake)
-                    ctx.fillText(nameLines[i], x, y + fontSize);
+                    ctx.fillText(nameLines[i], x, y + fontSize + 2);
                 y += fontSize + 5;
             }
         }
-        return y;
+        return y + 2;
     };
 
     ShowcaseExporter.prototype._splitText = function (text, ctx, maxWidth, splitter) {
@@ -817,7 +819,7 @@
 
     ShowcaseExporter.prototype._drawEquipStats = function (equip, ctx, x, y, available, fake) {
         var fontSize = 10;
-        ctx.font = fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        ctx.font = generateFontString(400,fontSize);
         ctx.fillStyle = "#000";
 
         var startX = x;
@@ -825,7 +827,7 @@
         var noStats = true;
 
         function drawStat(img) {
-            if (typeof equip[i] !== "undefined" && equip[i] > 0) {
+            if (typeof equip[i] !== "undefined" && equip[i] !== 0) {
                 noStats = false;
                 if (x + img.width + 3 + ctx.measureText(equip[i]).width > startX + available) {
                     y += img.height + 5;
@@ -855,7 +857,7 @@
             if (!this._statsImages.hasOwnProperty(i))
                 continue;
 
-            if (i === "or" && this.aircraftTypes.indexOf(KC3Master.slotitem(equip.masterId).api_type[3]) === -1)
+            if (i === "or" && KC3GearManager.landBasedAircraftType3Ids.indexOf(KC3Master.slotitem(equip.masterId).api_type[3]) === -1)
                 continue;
 
             if (sortingParam === i)

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -104,13 +104,7 @@
         ctx.fillRect(0, 0, canvas.width, canvas.height);
         ctx.drawImage(canvasData, 0, this.rowParams.height * 2, canvasData.width, canvasData.height);
 
-        var d = new Date();
-
-        var monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "June",
-            "July", "Aug", "Sep", "Oct", "Nov", "Dec"
-        ];
-
-        var created = "Made in KC3 on " + d.getDate() + " " + monthNames[d.getMonth()] + " " + d.getFullYear();
+        var created = "Made in KC3 on " + dateFormat("dd mmm yyyy");
         ctx.font = "400 14pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
         ctx.fillStyle = "#000";
 
@@ -150,7 +144,6 @@
                 0, 0,
                 this.exporter.rowParams.height * 2, this.exporter.rowParams.height * 2
             );
-            var date = d.getFullYear() + "_" + d.getMonth() + "_" + d.getDate();
             if (enableShelfTimer) {
                 clearTimeout(enableShelfTimer);
             }
@@ -158,7 +151,7 @@
             chrome.downloads.setShelfEnabled(false);
             chrome.downloads.download({
                 url: canvas.toDataURL("PNG"),
-                filename: ConfigManager.ss_directory + '/' + date + '_' + topLine.replace(" ", "") + ".PNG",
+                filename: ConfigManager.ss_directory + '/' + dateFormat("yyyy-mm-dd") + '_' + topLine.replace(" ", "") + ".PNG",
                 conflictAction: "uniquify"
             }, function (downloadId) {
                 enableShelfTimer = setTimeout(function () {
@@ -337,14 +330,12 @@
     };
 
     ShowcaseExporter.prototype._getShips = function () {
-        var ships = JSON.parse(localStorage.ships);
-        for (var i in ships) {
-            if (ships[i].lock === 0)
-                continue;
+        KC3ShipManager.load();
+        var ships = KC3ShipManager.find(function(s){return s.lock !==0;});
 
-            var ship = KC3ShipManager.get(ships[i].rosterId);
-            this.allShipGroups[ship.master().api_stype].push(ship);
-            this._shipImages[ship.masterId] = null;
+        for (var i in ships) {
+            this.allShipGroups[ships[i].master().api_stype].push(ships[i]);
+            this._shipImages[ships[i].masterId] = null;
             this.shipCount++;
         }
 
@@ -736,8 +727,6 @@
             var text = "";
             if (i === 0) {
                 text = " x";
-            } else if (i === 10) {
-                text = "+10★ x";
             } else {
                 text = "+" + i + "★ x";
             }
@@ -881,15 +870,4 @@
         return y;
     };
 
-    ShowcaseExporter.prototype._cloneArray = function (a) {
-        var b = [];
-        var i = a.length;
-        while (i--) {
-            if (typeof a[i] === "object")
-                b[i] = this._cloneArray(a[i]);
-            else
-                b[i] = a[i];
-        }
-        return b;
-    };
 })();

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -564,16 +564,17 @@
 
         this._drawEquipGroups(gears, rowWidth, rowHeight);
         var columns = this._splitEquipByColumns(columnsCount);
-        canvas.height = this._getBiggestColumn(columns);
-        canvas.width = rowWidth * columnsCount;
-        ctx.fillStyle = this.colors.odd;
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
         this._fillEquipCanvas(canvas, ctx, columns, rowWidth);
         this._drawBorders(canvas, ctx, rowWidth);
         this._addCredits(canvas, "Equipment List");
     };
 
     ShowcaseExporter.prototype._fillEquipCanvas = function (canvas, ctx, columns, rowWidth) {
+        canvas.height = this._getBiggestColumn(columns);
+        canvas.width = rowWidth * columns.length;
+        ctx.fillStyle = this.colors.odd;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
         for (var i = 0; i < columns.length; i++) {
             var column = columns[i];
             var y = 0, x = i * rowWidth;

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -100,7 +100,7 @@
         var ctx = canvas.getContext("2d");
 
         var fontsize = 18;
-        canvas.height = canvasData.height + this.rowParams.height * 2 + fontsize+4;
+        canvas.height = canvasData.height + this.rowParams.height * 2 + fontsize + 4;
         canvas.width = canvasData.width;
 
         ctx.fillStyle = "#FFF";
@@ -125,7 +125,7 @@
             this._addConsumableImage(ctx, canvas, x, "screws");
         }
 
-        var fontsize = 30;
+        fontsize = 30;
         ctx.font = generateFontString(600, fontsize);
         ctx.fillText(topLine, (canvas.width - ctx.measureText(topLine).width) / 2, this.rowParams.height + fontsize / 2);
 
@@ -347,7 +347,7 @@
         this.ctx.textBaseline = "middle";
         this.ctx.font = generateFontString(600, fontsize);
         this.ctx.fillStyle = "#0066CC";
-        this.ctx.fillText(KC3Meta.stype(type), x + this.rowParams.height / 2, y + (this.rowParams.height)/2 );
+        this.ctx.fillText(KC3Meta.stype(type), x + this.rowParams.height / 2, y + (this.rowParams.height) / 2);
     };
 
     ShowcaseExporter.prototype._finalize = function () {
@@ -796,7 +796,7 @@
         var fontSize;
         for (var i = 0; i <= 10; i++) {
             var text = "";
-            if (i === 0){
+            if (i === 0) {
                 fontSize = 18;
                 text = "x" + equip.total;
                 ctx.font = generateFontString(400, fontSize);
@@ -816,7 +816,7 @@
 
 
                 text = "★" + i;
-                ctx.fillStyle="#42837f";
+                ctx.fillStyle = "#42837f";
                 ctx.font = generateFontString(600, fontSize);
                 if (!fake)
                     ctx.fillText(text, x + rowWidth - rowHeight * 0.5 - xOffset - ctx.measureText(text).width, y + (rowHeight + fontSize) / 2);

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -3,7 +3,7 @@
 
     var enableShelfTimer = false;
 
-    window.ShowcaseExporter = function() {
+    window.ShowcaseExporter = function () {
         this.canvas = {};
         this.ctx = {};
         this.allShipGroups = {};
@@ -62,7 +62,7 @@
         this.allShipGroups = {};
         this.aircraftTypes = $.unique($.merge(KC3GearManager.carrierBasedAircraftType3Ids, KC3GearManager.landBasedAircraftType3Ids));
         for (var i in KC3Meta._stype) {
-            if (KC3Meta._stype != "")
+            if (KC3Meta._stype !== "")
                 this.allShipGroups[i] = [];
         }
     };
@@ -271,7 +271,7 @@
     };
 
     ShowcaseExporter.prototype._finalize = function () {
-        if (this.loading != 0)
+        if (this.loading !== 0)
             return;
         this._drawBorders();
         this._addCredits();
@@ -432,8 +432,8 @@
                 };
             }
 
-            if (!sorted[groupId]['types'][typeId]) {
-                sorted[groupId]['types'][typeId] = {
+            if (!sorted[groupId].types[typeId]) {
+                sorted[groupId].types[typeId] = {
                     typeId: KC3Master.slotitem(equip.masterId).api_type[3],
                     name: KC3Meta.gearTypeName(2, equipMaster.api_type[2]),
                     gears: {}
@@ -441,8 +441,8 @@
                 this._equipTypeImages[KC3Master.slotitem(equip.masterId).api_type[3]] = null;
             }
 
-            if (!sorted[groupId]['types'][typeId]['gears'][masterId]) {
-                sorted[groupId]['types'][typeId]['gears'][masterId] = {
+            if (!sorted[groupId].types[typeId].gears[masterId]) {
+                sorted[groupId].types[typeId].gears[masterId] = {
                     masterId: equip.masterId,
                     name: KC3Meta.gearName(equipMaster.api_name),
                     fp: equipMaster.api_houg,
@@ -461,7 +461,7 @@
                     "s6": 0, "s7": 0, "s8": 0, "s9": 0, "s10": 0
                 };
             }
-            sorted[groupId]['types'][typeId]['gears'][masterId]["s" + equip.stars]++;
+            sorted[groupId].types[typeId].gears[masterId]["s" + equip.stars]++;
         }
 
         return sorted;
@@ -796,7 +796,7 @@
         while (words.length > 0) {
             var line = [];
             var next = words.shift();
-            while (ctx.measureText((line.join(splitter) + splitter + next).trim()).width < maxWidth && next != "") {
+            while (ctx.measureText((line.join(splitter) + splitter + next).trim()).width < maxWidth && next !== "") {
                 line.push(next);
                 if (words.length > 0)
                     next = words.shift();
@@ -804,7 +804,7 @@
                     next = "";
             }
             rows.push(line.join(splitter));
-            if (next != "") {
+            if (next !== "") {
                 words.unshift(next);
             }
         }
@@ -844,7 +844,7 @@
         if (!!sortingParam && sortingParam != "overall") {
             i = sortingParam;
             img = this._statsImages[i];
-            drawStat.call(this,img);
+            drawStat.call(this, img);
         }
 
 
@@ -858,7 +858,7 @@
             if (sortingParam == i)
                 continue;
             img = this._statsImages[i];
-            drawStat.call(this,img);
+            drawStat.call(this, img);
         }
         if (noStats)
             return 0;

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -99,7 +99,8 @@
         var canvas = document.createElement("CANVAS");
         var ctx = canvas.getContext("2d");
 
-        canvas.height = canvasData.height + this.rowParams.height * 2 + 18;
+        var fontsize = 18;
+        canvas.height = canvasData.height + this.rowParams.height * 2 + fontsize+4;
         canvas.width = canvasData.width;
 
         ctx.fillStyle = "#FFF";
@@ -107,7 +108,7 @@
         ctx.drawImage(canvasData, 0, this.rowParams.height * 2, canvasData.width, canvasData.height);
 
         var created = "Made in KC3 on " + dateFormat("dd mmm yyyy");
-        ctx.font = generateFontString(400, 14);
+        ctx.font = generateFontString(400, fontsize);
         ctx.fillStyle = "#000";
 
         ctx.fillText(
@@ -342,9 +343,11 @@
         this.ctx.fillStyle = background;
         this.ctx.fillRect(x, y, this.rowParams.width, this.rowParams.height);
 
-        this.ctx.font = generateFontString(600, 20);
+        var fontsize = 25;
+        this.ctx.textBaseline = "middle";
+        this.ctx.font = generateFontString(600, fontsize);
         this.ctx.fillStyle = "#0066CC";
-        this.ctx.fillText(KC3Meta.stype(type), x + this.rowParams.height / 2, y + this.rowParams.height - (this.rowParams.height - 18) / 2);
+        this.ctx.fillText(KC3Meta.stype(type), x + this.rowParams.height / 2, y + (this.rowParams.height)/2 );
     };
 
     ShowcaseExporter.prototype._finalize = function () {
@@ -436,20 +439,22 @@
 
         this._drawIcon(x + xOffset, y, ship.masterId);
 
-        var fontSize = 19;
+        var fontSize = 24;
         this.ctx.font = generateFontString(400, fontSize);
         while (this.ctx.measureText(ship.name()).width > this.rowParams.width - this.rowParams.height * 3.5) {
             fontSize--;
             this.ctx.font = generateFontString(400, fontSize);
         }
         this.ctx.fillStyle = "#000";
-        this.ctx.fillText(ship.name(), x + this.rowParams.height * 2, y + this.rowParams.height - (this.rowParams.height - fontSize) / 2);
+        this.ctx.textBaseline = "middle";
+        this.ctx.fillText(ship.name(), x + this.rowParams.height * 2, y + this.rowParams.height / 2);
 
-        this.ctx.font = generateFontString(400, 19);
+        this.ctx.font = generateFontString(400, 24);
+        this.ctx.textBaseline = "middle";
         this.ctx.fillText(
             ship.level,
             x + this.rowParams.width - this.rowParams.height * 0.5 - this.ctx.measureText(ship.level).width,
-            y + this.rowParams.height - (this.rowParams.height - fontSize) / 2
+            y + this.rowParams.height / 2
         );
 
     };
@@ -694,7 +699,7 @@
         }
 
         var y = 0;
-        var fontSize = 16;
+        var fontSize = 20;
         ctx.font = generateFontString(600, fontSize);
         ctx.fillStyle = "#000";
         ctx.fillText(group.name, (canvas.width - ctx.measureText(group.name).width) / 2, ( rowHeight + fontSize) / 2);
@@ -705,7 +710,7 @@
                 var type = group.types[typeId];
                 if (typeCount > 1) {
                     y += rowHeight / 2;
-                    fontSize = 16;
+                    fontSize = 20;
                     ctx.font = generateFontString(500, fontSize);
                     ctx.fillStyle = "#000";
                     ctx.fillText(type.name, (canvas.width - ctx.measureText(type.name).width) / 2, y + (rowHeight + fontSize) / 2);
@@ -792,14 +797,14 @@
         for (var i = 0; i <= 10; i++) {
             var text = "";
             if (i === 0){
-                fontSize = 14;
+                fontSize = 18;
                 text = "x" + equip.total;
                 ctx.font = generateFontString(400, fontSize);
                 ctx.fillStyle = "#000";
                 if (!fake)
                     ctx.fillText(text, x + rowWidth - rowHeight * 0.5 - ctx.measureText(text).width, y + (rowHeight + fontSize) / 2);
             } else {
-                fontSize = 10;
+                fontSize = 13;
                 if (equip["s" + i] === 0)
                     continue;
                 ctx.fillStyle = "#000";
@@ -827,7 +832,7 @@
 
     ShowcaseExporter.prototype._drawEquipInfo = function (equip, ctx, x, y, rowWidth, rowHeight, fake) {
         var startY = y;
-        var fontSize = 10;
+        var fontSize = 13;
         ctx.font = generateFontString(400, fontSize);
         ctx.fillStyle = "#000";
 
@@ -898,7 +903,7 @@
     };
 
     ShowcaseExporter.prototype._drawEquipStats = function (equip, ctx, x, y, available, fake) {
-        var fontSize = 10;
+        var fontSize = 16;
         ctx.font = generateFontString(400, fontSize);
         ctx.fillStyle = "#000";
 

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -294,9 +294,13 @@
         });
     };
 
-    ShowcaseExporter.prototype._openInNewTab = function (dataURL) {
-        window.open(dataURL, "_blank");
-        this.complete({});
+    ShowcaseExporter.prototype._openInNewTab = function (dataURL,topLine) {
+        if(dataURL.length>=2*1024*1024){
+            this._download(dataURL,topLine);
+        } else {
+            window.open(dataURL, "_blank");
+            this.complete({});
+        }
     };
 
     /* SHIP EXPORT

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -273,7 +273,7 @@
                             Accept: 'application/json'
                         },
                         data: {
-                            image: dataURL.substring(23),
+                            image: dataURL.substring(22),
                             type: 'base64'
                         },
                         success: function (response) {

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -120,7 +120,7 @@
             canvas.height - 1
         );
         var x = 20;
-        if (topLine.indexOf("Ship") != -1) {
+        if (topLine.indexOf("Ship") !== -1) {
             x = this._addConsumableImage(ctx, canvas, x, "medals") + 50;
             this._addConsumableImage(ctx, canvas, x, "blueprints");
         } else {
@@ -319,7 +319,7 @@
             }
         }
 
-        return !(x >= this.canvas.width && y != 0);
+        return !(x >= this.canvas.width && y !== 0);
     };
 
     ShowcaseExporter.prototype._getShips = function () {
@@ -337,7 +337,7 @@
         for (i in this.allShipGroups) {
             if (this.allShipGroups[i].length > 0) {
                 this.allShipGroups[i].sort(function (shipA, shipB) {
-                    if (shipB.level != shipA.level)
+                    if (shipB.level !== shipA.level)
                         return shipB.level - shipA.level;
                     else
                         return shipB.masterId - shipA.masterId;
@@ -501,7 +501,7 @@
     ShowcaseExporter.prototype._getBiggestColumn = function (columns) {
         var maxSize = 0;
         for (var i = 0; i < columns.length; i++) {
-            if (typeof columns[i] != "object")
+            if (typeof columns[i] !== "object")
                 continue;
 
             var size = 0;
@@ -751,7 +751,7 @@
         var name = this._splitText(equip.name, ctx, available);
         y = this._drawEquipName(name, ctx, x + 30, y, rowHeight, fontSize, fake);
 
-        if (equip.name != KC3Master.slotitem(equip.masterId).api_name) {
+        if (equip.name !== KC3Master.slotitem(equip.masterId).api_name) {
             name = this._splitText(KC3Master.slotitem(equip.masterId).api_name, ctx, available, "");
             y = this._drawEquipName(name, ctx, x + 30, y, fontSize, fontSize, fake);
         }
@@ -786,7 +786,7 @@
         if (typeof splitter === "undefined")
             splitter = " ";
 
-        if (text.indexOf(splitter) == -1)
+        if (text.indexOf(splitter) === -1)
             splitter = "";
 
         var rows = [];
@@ -822,7 +822,7 @@
         var noStats = true;
 
         function drawStat(img) {
-            if (typeof equip[i] != "undefined" && equip[i] > 0) {
+            if (typeof equip[i] !== "undefined" && equip[i] > 0) {
                 noStats = false;
                 if (x + img.width + 3 + ctx.measureText(equip[i]).width > startX + available) {
                     y += img.height + 5;
@@ -841,7 +841,7 @@
 
         var sortingParam = KC3StrategyTabs.gears.definition._defaultCompareMethod["t" + KC3Master.slotitem(equip.masterId).api_type[3]];
         var i;
-        if (!!sortingParam && sortingParam != "overall") {
+        if (!!sortingParam && sortingParam !== "overall") {
             i = sortingParam;
             img = this._statsImages[i];
             drawStat.call(this, img);
@@ -855,7 +855,7 @@
             if (i === "or" && this.aircraftTypes.indexOf(KC3Master.slotitem(equip.masterId).api_type[3]) === -1)
                 continue;
 
-            if (sortingParam == i)
+            if (sortingParam === i)
                 continue;
             img = this._statsImages[i];
             drawStat.call(this, img);

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -164,6 +164,7 @@
                 enableShelfTimer = setTimeout(function () {
                     chrome.downloads.setShelfEnabled(true);
                     enableShelfTimer = false;
+                    self.exporter.cleanUp();
                     self.exporter.complete();
                 }, 100);
             });
@@ -219,6 +220,19 @@
         this._loadImage("screws", "_otherImages", "/assets/img/useitems/4.png", callback);
         this._loadImage("devmats", "_otherImages", "/assets/img/useitems/3.png", callback);
 
+    };
+
+    ShowcaseExporter.prototype.cleanUp = function () {
+        this.canvas = {};
+        this.ctx = {};
+        this.allShipGroups = {};
+        this.aircraftTypes = [];
+        this._statsImages = {};
+        this._equipTypeImages = {};
+        this._shipImages = {};
+        this._otherImages = {};
+        this._equipCanvases = {};
+        this._equipGroupCanvases = {};
     };
 
     /* SHIP EXPORT

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -1,875 +1,881 @@
-"use strict";
+(function () {
+    "use strict";
 
-var enableShelfTimer = false;
+    var enableShelfTimer = false;
 
-function ShowcaseExporter() {
-    this.canvas = {};
-    this.ctx = {};
-    this.allShipGroups = {};
-    this.loading = 0;
-    this.shipCount = 0;
-    this.rowParams = {
-        width: 330,
-        height: 35
+    window.ShowcaseExporter = function() {
+        this.canvas = {};
+        this.ctx = {};
+        this.allShipGroups = {};
+        this.loading = 0;
+        this.shipCount = 0;
+        this.rowParams = {
+            width: 330,
+            height: 35
+        };
+        this.colors = {
+            odd: "#e0e0e0",
+            even: "#f2f2f2"
+        };
+        this.columnCount = 5;
+        this.addName = false;
+        this.loadingCount = 0;
+        this.callback = function () {
+        };
+        this.aircraftTypes = [];
+        this._statsImages = {
+            fp: null,
+            tp: null,
+            aa: null,
+            ar: null,
+            as: null,
+            ev: null,
+            ls: null,
+            dv: null,
+            ht: null,
+            rn: null,
+            or: null
+        };
+        this._equipTypeImages = {};
+        this._shipImages = {};
+        this._otherImages = {};
+        this._equipCanvases = {};
+        this._equipGroupCanvases = {};
+        this._paramToApi = {
+            fp: "api_houg",
+            tp: "api_raig",
+            aa: "api_tyku",
+            ar: "api_souk",
+            as: "api_tais",
+            ev: "api_houk",
+            ls: "api_saku",
+            dv: "api_baku",
+            ht: "api_houm",
+            rn: "api_leng",
+            or: "api_distance"
+        };
     };
-    this.colors = {
-        odd: "#e0e0e0",
-        even: "#f2f2f2"
-    };
-    this.columnCount = 5;
-    this.addName = false;
-    this.loadingCount = 0;
-    this.callback = function () {
-    };
-    this.aircraftTypes = [];
-    this._statsImages = {
-        fp: null,
-        tp: null,
-        aa: null,
-        ar: null,
-        as: null,
-        ev: null,
-        ls: null,
-        dv: null,
-        ht: null,
-        rn: null,
-        or: null
-    };
-    this._equipTypeImages = {};
-    this._shipImages = {};
-    this._otherImages = {};
-    this._equipCanvases = {};
-    this._equipGroupCanvases = {}
-    this._paramToApi = {
-        fp: "api_houg",
-        tp: "api_raig",
-        aa: "api_tyku",
-        ar: "api_souk",
-        as: "api_tais",
-        ev: "api_houk",
-        ls: "api_saku",
-        dv: "api_baku",
-        ht: "api_houm",
-        rn: "api_leng",
-        or: "api_distance"
-    };
-}
 
-ShowcaseExporter.prototype._init = function () {
-    this.canvas = document.createElement("CANVAS");
-    this.ctx = this.canvas.getContext("2d");
-    this.allShipGroups = {};
-    this.aircraftTypes = $.unique($.merge(KC3GearManager.carrierBasedAircraftType3Ids, KC3GearManager.landBasedAircraftType3Ids));
-    for (var i in KC3Meta._stype) {
-        if (KC3Meta._stype != "")
-            this.allShipGroups[i] = [];
-    }
-};
+    ShowcaseExporter.prototype._init = function () {
+        this.canvas = document.createElement("CANVAS");
+        this.ctx = this.canvas.getContext("2d");
+        this.allShipGroups = {};
+        this.aircraftTypes = $.unique($.merge(KC3GearManager.carrierBasedAircraftType3Ids, KC3GearManager.landBasedAircraftType3Ids));
+        for (var i in KC3Meta._stype) {
+            if (KC3Meta._stype != "")
+                this.allShipGroups[i] = [];
+        }
+    };
 
-ShowcaseExporter.prototype.complete = function () {
-    (this.callback || function () {
-    })();
-};
+    ShowcaseExporter.prototype.complete = function () {
+        (this.callback || function () {
+        })();
+    };
 
-ShowcaseExporter.prototype._drawBorders = function (canvas, ctx, rowWidth) {
-    if (!canvas)
-        canvas = this.canvas;
-    if (!ctx)
-        ctx = this.ctx;
-    if (!rowWidth)
-        rowWidth = this.rowParams.width;
-    for (var x = rowWidth; x < canvas.width; x += rowWidth) {
+    ShowcaseExporter.prototype._drawBorders = function (canvas, ctx, rowWidth) {
+        if (!canvas)
+            canvas = this.canvas;
+        if (!ctx)
+            ctx = this.ctx;
+        if (!rowWidth)
+            rowWidth = this.rowParams.width;
+        for (var x = rowWidth; x < canvas.width; x += rowWidth) {
+            ctx.fillStyle = "#FFF";
+            for (var y = 0; y < canvas.height; y += 20) {
+                ctx.fillRect(x - 1, y, 2, 10);
+            }
+        }
+    };
+
+    ShowcaseExporter.prototype._addCredits = function (canvasData, topLine) {
+        if (!canvasData)
+            canvasData = this.canvas;
+        if (!topLine)
+            topLine = "Ship List";
+
+
+        var canvas = document.createElement("CANVAS");
+        var ctx = canvas.getContext("2d");
+
+        canvas.height = canvasData.height + this.rowParams.height * 2 + 18;
+        canvas.width = canvasData.width;
+
         ctx.fillStyle = "#FFF";
-        for (var y = 0; y < canvas.height; y += 20) {
-            ctx.fillRect(x - 1, y, 2, 10);
-        }
-    }
-};
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.drawImage(canvasData, 0, this.rowParams.height * 2, canvasData.width, canvasData.height);
 
-ShowcaseExporter.prototype._addCredits = function (canvasData, topLine) {
-    if (!canvasData)
-        canvasData = this.canvas;
-    if (!topLine)
-        topLine = "Ship List";
+        var d = new Date();
 
+        var monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "June",
+            "July", "Aug", "Sep", "Oct", "Nov", "Dec"
+        ];
 
-    var canvas = document.createElement("CANVAS");
-    var ctx = canvas.getContext("2d");
+        var created = "Made in KC3 on " + d.getDate() + " " + monthNames[d.getMonth()] + " " + d.getFullYear();
+        ctx.font = "400 14pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        ctx.fillStyle = "#000";
 
-    canvas.height = canvasData.height + this.rowParams.height * 2 + 18;
-    canvas.width = canvasData.width;
-
-    ctx.fillStyle = "#FFF";
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    ctx.drawImage(canvasData, 0, this.rowParams.height * 2, canvasData.width, canvasData.height);
-
-    var d = new Date();
-
-    var monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "June",
-        "July", "Aug", "Sep", "Oct", "Nov", "Dec"
-    ];
-
-    var created = "Made in KC3 on " + d.getDate() + " " + monthNames[d.getMonth()] + " " + d.getFullYear();
-    ctx.font = "400 14pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
-    ctx.fillStyle = "#000";
-
-    ctx.fillText(
-        created,
-        canvas.width - this.rowParams.height * 0.5 - ctx.measureText(created).width,
-        canvas.height - 1
-    );
-    var x = 20;
-    if (topLine.indexOf("Ship") != -1) {
-        x = this._addConsumableImage(ctx, canvas, x, "medals") + 50;
-        this._addConsumableImage(ctx, canvas, x, "blueprints");
-    } else {
-        x = this._addConsumableImage(ctx, canvas, x, "devmats") + 50;
-        this._addConsumableImage(ctx, canvas, x, "screws");
-    }
-
-    var header = this.addName ? JSON.parse(localStorage.player).name + " " + topLine : topLine;
-
-    var fontsize = 30;
-    ctx.font = "600 " + fontsize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
-    ctx.fillText(header, (canvas.width - ctx.measureText(header).width) / 2, this.rowParams.height + fontsize / 2);
-
-    var img = new Image();
-    img.exporter = this;
-    img.onload = function () {
-        ctx.drawImage(
-            img,
-            0, 0, img.width, img.height,
-            canvas.width - this.exporter.rowParams.height * 2, 0,
-            this.exporter.rowParams.height * 2, this.exporter.rowParams.height * 2
+        ctx.fillText(
+            created,
+            canvas.width - this.rowParams.height * 0.5 - ctx.measureText(created).width,
+            canvas.height - 1
         );
-
-        ctx.drawImage(
-            img,
-            0, 0, img.width, img.height,
-            0, 0,
-            this.exporter.rowParams.height * 2, this.exporter.rowParams.height * 2
-        );
-        var date = d.getFullYear() + "_" + d.getMonth() + "_" + d.getDate();
-        if (enableShelfTimer) {
-            clearTimeout(enableShelfTimer);
+        var x = 20;
+        if (topLine.indexOf("Ship") != -1) {
+            x = this._addConsumableImage(ctx, canvas, x, "medals") + 50;
+            this._addConsumableImage(ctx, canvas, x, "blueprints");
+        } else {
+            x = this._addConsumableImage(ctx, canvas, x, "devmats") + 50;
+            this._addConsumableImage(ctx, canvas, x, "screws");
         }
+
+        var header = this.addName ? JSON.parse(localStorage.player).name + " " + topLine : topLine;
+
+        var fontsize = 30;
+        ctx.font = "600 " + fontsize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        ctx.fillText(header, (canvas.width - ctx.measureText(header).width) / 2, this.rowParams.height + fontsize / 2);
+
+        var img = new Image();
+        img.exporter = this;
+        img.onload = function () {
+            ctx.drawImage(
+                img,
+                0, 0, img.width, img.height,
+                canvas.width - this.exporter.rowParams.height * 2, 0,
+                this.exporter.rowParams.height * 2, this.exporter.rowParams.height * 2
+            );
+
+            ctx.drawImage(
+                img,
+                0, 0, img.width, img.height,
+                0, 0,
+                this.exporter.rowParams.height * 2, this.exporter.rowParams.height * 2
+            );
+            var date = d.getFullYear() + "_" + d.getMonth() + "_" + d.getDate();
+            if (enableShelfTimer) {
+                clearTimeout(enableShelfTimer);
+            }
+            var self = this;
+            chrome.downloads.setShelfEnabled(false);
+            chrome.downloads.download({
+                url: canvas.toDataURL("PNG"),
+                filename: ConfigManager.ss_directory + '/' + date + '_' + topLine.replace(" ", "") + ".PNG",
+                conflictAction: "uniquify"
+            }, function (downloadId) {
+                enableShelfTimer = setTimeout(function () {
+                    chrome.downloads.setShelfEnabled(true);
+                    enableShelfTimer = false;
+                    self.exporter.complete();
+                }, 100);
+            });
+        };
+        img.src = "/assets/img/logo/128.png";
+
+    };
+
+    ShowcaseExporter.prototype._addConsumableImage = function (ctx, canvas, x, type) {
+        ctx.fillText(JSON.parse(localStorage.consumables)[type], x, canvas.height - 1);
+        x += ctx.measureText(JSON.parse(localStorage.consumables)[type]).width + 5;
+        ctx.drawImage(this._otherImages[type], x, canvas.height - 18, 18, 18);
+        return x + 18;
+    };
+
+    ShowcaseExporter.prototype._loadImage = function (imageName, imageGroup, url, callback) {
+        var img = new Image();
         var self = this;
-        chrome.downloads.setShelfEnabled(false);
-        chrome.downloads.download({
-            url: canvas.toDataURL("PNG"),
-            filename: ConfigManager.ss_directory + '/' + date + '_' + topLine.replace(" ", "") + ".PNG",
-            conflictAction: "uniquify"
-        }, function (downloadId) {
-            enableShelfTimer = setTimeout(function () {
-                chrome.downloads.setShelfEnabled(true);
-                enableShelfTimer = false;
-                self.exporter.complete();
-            }, 100);
-        });
+        img.imageName = imageName;
+        this.loadingCount++;
+
+        img.onload = function () {
+            self[imageGroup][this.imageName] = this;
+            self.loadingCount--;
+
+            if (self.loadingCount === 0)
+                callback();
+        };
+        img.src = url;
     };
-    img.src = "/assets/img/logo/128.png";
 
-};
+    ShowcaseExporter.prototype._loadImages = function (callback) {
+        for (var i in this._statsImages) {
+            if (!this._statsImages.hasOwnProperty(i))
+                continue;
+            this._loadImage(i, "_statsImages", "/assets/img/stats/" + i + ".png", callback);
+        }
 
-ShowcaseExporter.prototype._addConsumableImage = function (ctx, canvas, x, type) {
-    ctx.fillText(JSON.parse(localStorage.consumables)[type], x, canvas.height - 1);
-    x += ctx.measureText(JSON.parse(localStorage.consumables)[type]).width + 5;
-    ctx.drawImage(this._otherImages[type], x, canvas.height - 18, 18, 18);
-    return x + 18;
-};
+        for (i in this._equipTypeImages) {
+            if (!this._equipTypeImages.hasOwnProperty(i))
+                continue;
+            this._loadImage(i, "_equipTypeImages", "/assets/img/items/" + i + ".png", callback);
+        }
 
-ShowcaseExporter.prototype._loadImage = function (imageName, imageGroup, url, callback) {
-    var img = new Image();
-    var self = this;
-    img.imageName = imageName;
-    this.loadingCount++;
+        for (i in this._shipImages) {
+            if (!this._shipImages.hasOwnProperty(i))
+                continue;
+            this._loadImage(i, "_shipImages", "/assets/img/ships/" + i + ".png", callback);
+        }
 
-    img.onload = function () {
-        self[imageGroup][this.imageName] = this;
-        self.loadingCount--;
+        this._loadImage("medals", "_otherImages", "/assets/img/useitems/57.png", callback);
+        this._loadImage("blueprints", "_otherImages", "/assets/img/useitems/58.png", callback);
+        this._loadImage("screws", "_otherImages", "/assets/img/useitems/4.png", callback);
+        this._loadImage("devmats", "_otherImages", "/assets/img/useitems/3.png", callback);
 
-        if (self.loadingCount == 0)
-            callback();
     };
-    img.src = url;
-};
 
-ShowcaseExporter.prototype._loadImages = function (callback) {
-    for (var i in this._statsImages) {
-        if (!this._statsImages.hasOwnProperty(i))
-            continue;
-        this._loadImage(i, "_statsImages", "/assets/img/stats/" + i + ".png", callback)
-    }
-
-    for (var i in this._equipTypeImages) {
-        if (!this._equipTypeImages.hasOwnProperty(i))
-            continue;
-        this._loadImage(i, "_equipTypeImages", "/assets/img/items/" + i + ".png", callback);
-    }
-
-    for (var i in this._shipImages) {
-        if (!this._shipImages.hasOwnProperty(i))
-            continue;
-        this._loadImage(i, "_shipImages", "/assets/img/ships/" + i + ".png", callback);
-    }
-
-    this._loadImage("medals", "_otherImages", "/assets/img/useitems/57.png", callback);
-    this._loadImage("blueprints", "_otherImages", "/assets/img/useitems/58.png", callback);
-    this._loadImage("screws", "_otherImages", "/assets/img/useitems/4.png", callback);
-    this._loadImage("devmats", "_otherImages", "/assets/img/useitems/3.png", callback);
-
-};
-
-/* SHIP EXPORT
- ------------------------- */
-ShowcaseExporter.prototype.exportShips = function () {
-    this._init();
-    this._getShips();
-    var self = this;
-    this._loadImages(function () {
-        self._resizeCanvas();
-        var x = 0;
-        var y = 0;
-        var color = self.colors.odd;
-        for (var type in self.allShipGroups) {
-            if (self.allShipGroups[type].length > 0) {
-                if (y >= self.canvas.height - self.rowParams.height) {
-                    x += self.rowParams.width;
-                    y = 0;
-                }
-
-                self._drawShipTypeName(x, y, type, color);
-                y += self.rowParams.height;
-
-                for (var j = 0; j < self.allShipGroups[type].length; j++) {
-                    self._drawShip(x, y, self.allShipGroups[type][j], color);
-                    y += self.rowParams.height;
-                    if (y >= self.canvas.height) {
+    /* SHIP EXPORT
+     ------------------------- */
+    ShowcaseExporter.prototype.exportShips = function () {
+        this._init();
+        this._getShips();
+        var self = this;
+        this._loadImages(function () {
+            self._resizeCanvas();
+            var x = 0;
+            var y = 0;
+            var color = self.colors.odd;
+            for (var type in self.allShipGroups) {
+                if (self.allShipGroups[type].length > 0) {
+                    if (y >= self.canvas.height - self.rowParams.height) {
                         x += self.rowParams.width;
                         y = 0;
                     }
+
+                    self._drawShipTypeName(x, y, type, color);
+                    y += self.rowParams.height;
+
+                    for (var j = 0; j < self.allShipGroups[type].length; j++) {
+                        self._drawShip(x, y, self.allShipGroups[type][j], color);
+                        y += self.rowParams.height;
+                        if (y >= self.canvas.height) {
+                            x += self.rowParams.width;
+                            y = 0;
+                        }
+                    }
+                    if (color === self.colors.even)
+                        color = self.colors.odd;
+                    else
+                        color = self.colors.even;
                 }
-                if (color == self.colors.even)
-                    color = self.colors.odd;
-                else
-                    color = self.colors.even;
             }
+
+            self._finalize();
+        });
+    };
+
+    ShowcaseExporter.prototype._drawShipTypeName = function (x, y, type, background) {
+        this.ctx.fillStyle = background;
+        this.ctx.fillRect(x, y, this.rowParams.width, this.rowParams.height);
+
+        this.ctx.font = "600 20pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        this.ctx.fillStyle = "#0066CC";
+        this.ctx.fillText(KC3Meta.stype(type), x + this.rowParams.height / 2, y + this.rowParams.height - (this.rowParams.height - 18) / 2);
+    };
+
+    ShowcaseExporter.prototype._finalize = function () {
+        if (this.loading != 0)
+            return;
+        this._drawBorders();
+        this._addCredits();
+    };
+
+    ShowcaseExporter.prototype._resizeCanvas = function () {
+        var types = 0;
+        for (var type in this.allShipGroups) {
+            if (this.allShipGroups[type].length > 0)
+                types++;
+        }
+        this.canvas.height = Math.ceil((this.shipCount + types) / this.columnCount) * this.rowParams.height;
+        this.canvas.width = this.columnCount * this.rowParams.width;
+
+        if (!this._checkFit()) {
+            this.canvas.height = Math.ceil((this.shipCount + types) / this.columnCount + 1) * this.rowParams.height;
+            this.canvas.width = this.columnCount * this.rowParams.width;
         }
 
-        self._finalize();
-    });
-};
+        this._fill();
+    };
 
-ShowcaseExporter.prototype._drawShipTypeName = function (x, y, type, background) {
-    this.ctx.fillStyle = background;
-    this.ctx.fillRect(x, y, this.rowParams.width, this.rowParams.height);
-
-    this.ctx.font = "600 20pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
-    this.ctx.fillStyle = "#0066CC";
-    this.ctx.fillText(KC3Meta.stype(type), x + this.rowParams.height / 2, y + this.rowParams.height - (this.rowParams.height - 18) / 2);
-};
-
-ShowcaseExporter.prototype._finalize = function () {
-    if (this.loading != 0)
-        return;
-    this._drawBorders();
-    this._addCredits();
-};
-
-ShowcaseExporter.prototype._resizeCanvas = function () {
-    var types = 0;
-    for (var type in this.allShipGroups) {
-        if (this.allShipGroups[type].length > 0)
-            types++;
-    }
-    this.canvas.height = Math.ceil((this.shipCount + types) / this.columnCount) * this.rowParams.height;
-    this.canvas.width = this.columnCount * this.rowParams.width;
-
-    if (!this._checkFit()) {
-        this.canvas.height = Math.ceil((this.shipCount + types) / this.columnCount + 1) * this.rowParams.height;
-        this.canvas.width = this.columnCount * this.rowParams.width;
-    }
-
-    this._fill();
-};
-
-ShowcaseExporter.prototype._checkFit = function () {
-    // i don't know how to make this check better
-    // math....
-    var x = 0;
-    var y = 0;
-    for (var type in this.allShipGroups) {
-        if (this.allShipGroups[type].length > 0) {
-            if (y >= this.canvas.height - this.rowParams.height) {
-                x += this.rowParams.width;
-                y = 0;
-            }
-            // drawing title
-            y += this.rowParams.height;
-
-            for (var j = 0; j < this.allShipGroups[type].length; j++) {
-                // drawing ship
-                y += this.rowParams.height;
-                if (y >= this.canvas.height) {
+    ShowcaseExporter.prototype._checkFit = function () {
+        // i don't know how to make this check better
+        // math....
+        var x = 0;
+        var y = 0;
+        for (var type in this.allShipGroups) {
+            if (this.allShipGroups[type].length > 0) {
+                if (y >= this.canvas.height - this.rowParams.height) {
                     x += this.rowParams.width;
                     y = 0;
                 }
-            }
-        }
-    }
+                // drawing title
+                y += this.rowParams.height;
 
-    return !(x >= this.canvas.width && y != 0);
-};
-
-ShowcaseExporter.prototype._getShips = function () {
-    var ships = JSON.parse(localStorage.ships);
-    for (var i in ships) {
-        if (ships[i].lock == 0)
-            continue;
-
-        var ship = KC3ShipManager.get(ships[i].rosterId);
-        this.allShipGroups[ship.master().api_stype].push(ship);
-        this._shipImages[ship.masterId] = null;
-        this.shipCount++;
-    }
-
-    for (var i in this.allShipGroups) {
-        if (this.allShipGroups[i].length > 0) {
-            this.allShipGroups[i].sort(function (shipA, shipB) {
-                if (shipB.level != shipA.level)
-                    return shipB.level - shipA.level;
-                else
-                    return shipB.masterId - shipA.masterId;
-            });
-        }
-    }
-};
-
-ShowcaseExporter.prototype._drawShip = function (x, y, ship, background) {
-    this.ctx.fillStyle = background;
-    this.ctx.fillRect(x, y, this.rowParams.width, this.rowParams.height);
-    var xOffset = this.rowParams.height / 7;
-
-    this._drawStat(ship.fp, x + xOffset, y, this.rowParams.height / 2, this.rowParams.height / 2, "#ff8888", background);
-    this._drawStat(ship.tp, x + xOffset + this.rowParams.height / 2, y, this.rowParams.height / 2, this.rowParams.height / 2, "#00CCFF", background);
-    this._drawStat(ship.aa, x + xOffset + this.rowParams.height / 2, y + this.rowParams.height / 2, this.rowParams.height / 2, this.rowParams.height / 2, "#ff9900", background);
-    this._drawStat(ship.ar, x + xOffset, y + this.rowParams.height / 2, this.rowParams.height / 2, this.rowParams.height / 2, "#ffcc00", background);
-    this._drawStat(ship.lk, x + xOffset + this.rowParams.height, y, this.rowParams.height / 5, this.rowParams.height / 2, "#66FF66", background);
-
-    this._drawIcon(x + xOffset, y, ship.masterId);
-
-    var fontSize = 19;
-    this.ctx.font = "400 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
-    while (this.ctx.measureText(ship.name()).width > this.rowParams.width - this.rowParams.height * 3.5) {
-        fontSize--;
-        this.ctx.font = "400 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
-    }
-    this.ctx.fillStyle = "#000";
-    this.ctx.fillText(ship.name(), x + this.rowParams.height * 2, y + this.rowParams.height - (this.rowParams.height - fontSize) / 2);
-
-    this.ctx.font = "400 19pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
-    this.ctx.fillText(
-        ship.level,
-        x + this.rowParams.width - this.rowParams.height * 0.5 - this.ctx.measureText(ship.level).width,
-        y + this.rowParams.height - (this.rowParams.height - fontSize) / 2
-    );
-
-};
-
-ShowcaseExporter.prototype._drawIcon = function (x, y, shipId) {
-    this.ctx.drawImage(
-        this._shipImages[shipId],
-        0, 0, this._shipImages[shipId].width, this._shipImages[shipId].height,
-        x, y, this.rowParams.height, this.rowParams.height
-    );
-};
-
-ShowcaseExporter.prototype._drawStat = function (stat, x, y, w, h, color, background) {
-    if (stat[0] >= stat[1]) {
-        this.ctx.fillStyle = color;
-        this.ctx.fillRect(x, y, w, h);
-    } else {
-        this.ctx.fillStyle = background;
-        this.ctx.fillRect(x, y, w, h);
-    }
-};
-
-ShowcaseExporter.prototype._fill = function () {
-    this.ctx.fillStyle = "#efefef";
-    this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
-};
-
-/* EQUIP EXPORT
- ------------------------- */
-
-ShowcaseExporter.prototype.exportEquip = function () {
-    var gears = this._getGears();
-    var self = this;
-
-    this._loadImages(function () {
-        self._processGears(gears);
-    });
-};
-
-ShowcaseExporter.prototype._getGears = function () {
-    var allGears = JSON.parse(localStorage.gears);
-    var sorted = {};
-    for (var i in allGears) {
-        if (allGears[i].lock == 0)
-            continue;
-
-        var equip = allGears[i];
-        var equipMaster = KC3Master.slotitem(equip.masterId);
-
-        var masterId = "m" + equip.masterId;
-        var typeId = "t" + equipMaster.api_type[3];
-        var groupId = "g" + equipMaster.api_type[0];
-        if (!sorted[groupId]) {
-            sorted[groupId] = {
-                name: KC3Meta.gearTypeName(0, equipMaster.api_type[0]),
-                types: {}
-            };
-        }
-
-        if (!sorted[groupId]["types"][typeId]) {
-            sorted[groupId]["types"][typeId] = {
-                typeId: KC3Master.slotitem(equip.masterId).api_type[3],
-                name: KC3Meta.gearTypeName(2, equipMaster.api_type[2]),
-                gears: {}
-            };
-            this._equipTypeImages[KC3Master.slotitem(equip.masterId).api_type[3]] = null;
-        }
-
-        if (!sorted[groupId]["types"][typeId]["gears"][masterId]) {
-            sorted[groupId]["types"][typeId]["gears"][masterId] = {
-                masterId: equip.masterId,
-                name: KC3Meta.gearName(equipMaster.api_name),
-                fp: equipMaster.api_houg,
-                tp: equipMaster.api_raig,
-                aa: equipMaster.api_tyku,
-                ar: equipMaster.api_souk,
-                as: equipMaster.api_tais,
-                ev: equipMaster.api_houk,
-                ls: equipMaster.api_saku,
-                dv: equipMaster.api_baku,
-                ht: equipMaster.api_houm,
-                rn: equipMaster.api_leng,
-                or: equipMaster.api_distance,
-                "s0": 0,
-                "s1": 0, "s2": 0, "s3": 0, "s4": 0, "s5": 0,
-                "s6": 0, "s7": 0, "s8": 0, "s9": 0, "s10": 0
-            };
-        }
-        sorted[groupId]["types"][typeId]["gears"][masterId]["s" + equip.stars]++;
-    }
-
-    return sorted;
-};
-
-ShowcaseExporter.prototype._processGears = function (gears) {
-    var canvas = document.createElement("CANVAS");
-    var ctx = canvas.getContext("2d");
-
-    var columnsCount = 5;
-    var rowHeight = 30;
-    var rowWidth = 350;
-
-    this._drawEquipGroups(gears, rowWidth, rowHeight);
-    var columns = this._splitEquipByColumns(columnsCount);
-    canvas.height = this._getBiggestColumn(columns);
-    canvas.width = rowWidth * columnsCount;
-    ctx.fillStyle = this.colors.odd;
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    this._fillEquipCanvas(canvas, ctx, columns, rowWidth);
-    this._drawBorders(canvas, ctx, rowWidth);
-    this._addCredits(canvas, "Equipment List");
-};
-
-ShowcaseExporter.prototype._fillEquipCanvas = function (canvas, ctx, columns, rowWidth) {
-    for (var i = 0; i < columns.length; i++) {
-        var column = columns[i];
-        var y = 0, x = i * rowWidth;
-        for (var j = 0; j < column.length; j++) {
-            var canvasData = this._equipGroupCanvases[column[j]];
-            ctx.drawImage(canvasData, x, y, canvasData.width, canvasData.height);
-            y += canvasData.height;
-        }
-    }
-};
-
-ShowcaseExporter.prototype._getBiggestColumn = function (columns) {
-    var maxSize = 0;
-    for (var i = 0; i < columns.length; i++) {
-        if (typeof columns[i] != "object")
-            continue;
-
-        var size = 0;
-        for (var j = 0; j < columns[i].length; j++) {
-            size += this._equipGroupCanvases[columns[i][j]].height;
-        }
-        if (maxSize < size)
-            maxSize = size;
-    }
-    return maxSize;
-};
-
-ShowcaseExporter.prototype._splitEquipByColumns = function (maxColumns) {
-    var maxHeight = this._getMaxHeight(), totalHeight = this._getTotalHeight();
-    var aproxSize = Math.max(Math.ceil(totalHeight / maxColumns), maxHeight);
-    var paging = this._fillEquipColumns(aproxSize);
-
-    if (paging.length > maxColumns) {
-        paging = this._fixEquipPaging(aproxSize, paging, maxColumns);
-    }
-    return paging;
-};
-
-ShowcaseExporter.prototype._fixEquipPaging = function (aproxSize, paging, maxColumns) {
-    while (paging.length > maxColumns) {
-        paging = this._fillEquipColumns(aproxSize++);
-    }
-    return paging;
-};
-
-ShowcaseExporter.prototype._fillEquipColumns = function (aproxSize) {
-    var groupIds = [];
-    for (var groupId in this._equipGroupCanvases) {
-        if (groupId.startsWith("g"))
-            groupIds.push(parseInt(groupId.slice("1")));
-    }
-    groupIds.sort(function (a, b) {
-        return a - b;
-    });
-
-
-    var newPaging = [[]];
-    var size = 0;
-    var column = 0;
-    for (var i = 0; i < groupIds.length; i++) {
-        if (size + this._equipGroupCanvases["g" + groupIds[i]].height > aproxSize) {
-            column++;
-            newPaging.push([]);
-            size = 0;
-        }
-        newPaging[column].push("g" + groupIds[i]);
-        size += this._equipGroupCanvases["g" + groupIds[i]].height;
-    }
-    return newPaging;
-};
-
-ShowcaseExporter.prototype._getMaxHeight = function () {
-    var maxHeight = 0;
-
-    for (var groupId in this._equipGroupCanvases) {
-        if (!this._equipGroupCanvases.hasOwnProperty(groupId))
-            continue;
-        if (this._equipGroupCanvases[groupId].height > maxHeight)
-            maxHeight = this._equipGroupCanvases[groupId].height;
-    }
-    return maxHeight;
-};
-
-ShowcaseExporter.prototype._getTotalHeight = function () {
-    var totalHeight = 0;
-
-    for (var groupId in this._equipGroupCanvases) {
-        if (!this._equipGroupCanvases.hasOwnProperty(groupId))
-            continue;
-        totalHeight += this._equipGroupCanvases[groupId].height;
-    }
-    return totalHeight;
-};
-
-ShowcaseExporter.prototype._drawEquipGroups = function (gears, rowWidth, rowHeight) {
-    var groupIds = [];
-    for (var groupId in gears) {
-        if (groupId.startsWith("g"))
-            groupIds.push(parseInt(groupId.slice("1")));
-    }
-    groupIds.sort(function (a, b) {
-        return a - b;
-    });
-
-    var bool = true;
-    for (var i = 0; i < groupIds.length; i++) {
-        var canvas = document.createElement("CANVAS"), ctx = canvas.getContext("2d");
-        canvas.height = this._drawEquipGroup(gears["g" + groupIds[i]], rowWidth, rowHeight);
-        canvas.width = rowWidth;
-        ctx.fillStyle = bool ? this.colors.odd : this.colors.even;
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
-        bool = !bool;
-        this._addEquipGroupsToCanvas(gears["g" + groupIds[i]], canvas, ctx, rowHeight);
-        this._equipGroupCanvases["g" + groupIds[i]] = canvas;
-    }
-};
-
-ShowcaseExporter.prototype._addEquipGroupsToCanvas = function (group, canvas, ctx, rowHeight) {
-    var typeCount = 0;
-    for (var typeId in group.types) {//each type
-        typeCount++;
-    }
-
-    var y = 0;
-    var fontSize = 16;
-    ctx.font = "600 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
-    ctx.fillStyle = "#000";
-    ctx.fillText(group.name, (canvas.width - ctx.measureText(group.name).width) / 2, ( rowHeight + fontSize) / 2);
-    y += rowHeight;
-
-    for (var typeId in group.types) {
-        if (typeId.startsWith("t")) {
-            var type = group.types[typeId];
-            if (typeCount > 1) {
-                y += rowHeight / 2;
-                fontSize = 16;
-                ctx.font = "500 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
-                ctx.fillStyle = "#000";
-                ctx.fillText(type.name, (canvas.width - ctx.measureText(type.name).width) / 2, y + (rowHeight + fontSize) / 2);
-                y += rowHeight * 1.5;
-            }
-
-            var masterIds = [];
-            for (var masterId in type.gears) {
-                if (!type.hasOwnProperty(masterId) && masterId.startsWith("m")) {
-                    masterIds.push(masterId);
+                for (var j = 0; j < this.allShipGroups[type].length; j++) {
+                    // drawing ship
+                    y += this.rowParams.height;
+                    if (y >= this.canvas.height) {
+                        x += this.rowParams.width;
+                        y = 0;
+                    }
                 }
             }
+        }
 
-            var sortingParam = this._paramToApi[KC3StrategyTabs.gears.definition._defaultCompareMethod[typeId]];
-            if (!!sortingParam) {
-                masterIds.sort(function (a, b) {
-                    var shipA = KC3Master.slotitem(a.slice(1)), shipB = KC3Master.slotitem(b.slice(1));
-                    return shipB[sortingParam] - shipA[sortingParam];
+        return !(x >= this.canvas.width && y != 0);
+    };
+
+    ShowcaseExporter.prototype._getShips = function () {
+        var ships = JSON.parse(localStorage.ships);
+        for (var i in ships) {
+            if (ships[i].lock === 0)
+                continue;
+
+            var ship = KC3ShipManager.get(ships[i].rosterId);
+            this.allShipGroups[ship.master().api_stype].push(ship);
+            this._shipImages[ship.masterId] = null;
+            this.shipCount++;
+        }
+
+        for (i in this.allShipGroups) {
+            if (this.allShipGroups[i].length > 0) {
+                this.allShipGroups[i].sort(function (shipA, shipB) {
+                    if (shipB.level != shipA.level)
+                        return shipB.level - shipA.level;
+                    else
+                        return shipB.masterId - shipA.masterId;
                 });
             }
-
-            for (var i = 0; i < masterIds.length; i++) {
-                masterId = masterIds[i];
-                var canvasData = this._equipCanvases[masterId];
-                ctx.drawImage(canvasData, 0, y, canvasData.width, canvasData.height);
-                y += canvasData.height;
-
-            }
-            y += rowHeight * 0.5;
-
-            ctx.fillStyle = "#FFF";
-            for (var xPos = 0; xPos < 0 + canvas.width; xPos += 20) {
-                ctx.fillRect(xPos, y - 2, 10, 2);
-            }
         }
-    }
-};
+    };
 
-ShowcaseExporter.prototype._drawEquipGroup = function (group, rowWidth, rowHeight) {
-    var typeCount = 0;
-    for (var typeId in group.types) {
-        typeCount++;
-    }
+    ShowcaseExporter.prototype._drawShip = function (x, y, ship, background) {
+        this.ctx.fillStyle = background;
+        this.ctx.fillRect(x, y, this.rowParams.width, this.rowParams.height);
+        var xOffset = this.rowParams.height / 7;
 
-    var height = 0;
-    for (var i in group.types) {
-        if (i.startsWith("t")) {
-            height += this._drawEquipTypes(group.types[i], rowWidth, rowHeight);
+        this._drawStat(ship.fp, x + xOffset, y, this.rowParams.height / 2, this.rowParams.height / 2, "#ff8888", background);
+        this._drawStat(ship.tp, x + xOffset + this.rowParams.height / 2, y, this.rowParams.height / 2, this.rowParams.height / 2, "#00CCFF", background);
+        this._drawStat(ship.aa, x + xOffset + this.rowParams.height / 2, y + this.rowParams.height / 2, this.rowParams.height / 2, this.rowParams.height / 2, "#ff9900", background);
+        this._drawStat(ship.ar, x + xOffset, y + this.rowParams.height / 2, this.rowParams.height / 2, this.rowParams.height / 2, "#ffcc00", background);
+        this._drawStat(ship.lk, x + xOffset + this.rowParams.height, y, this.rowParams.height / 5, this.rowParams.height / 2, "#66FF66", background);
+
+        this._drawIcon(x + xOffset, y, ship.masterId);
+
+        var fontSize = 19;
+        this.ctx.font = "400 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        while (this.ctx.measureText(ship.name()).width > this.rowParams.width - this.rowParams.height * 3.5) {
+            fontSize--;
+            this.ctx.font = "400 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
         }
-    }
-    if (typeCount > 1)
-        height += rowHeight * typeCount * 2;// + typename each
-    return height + rowHeight;// + groupName
-};
+        this.ctx.fillStyle = "#000";
+        this.ctx.fillText(ship.name(), x + this.rowParams.height * 2, y + this.rowParams.height - (this.rowParams.height - fontSize) / 2);
 
-ShowcaseExporter.prototype._drawEquipTypes = function (types, rowWidth, rowHeight) {
-    var height = 0;
+        this.ctx.font = "400 19pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        this.ctx.fillText(
+            ship.level,
+            x + this.rowParams.width - this.rowParams.height * 0.5 - this.ctx.measureText(ship.level).width,
+            y + this.rowParams.height - (this.rowParams.height - fontSize) / 2
+        );
 
-    for (var masterId in types.gears) {
-        if (!types.hasOwnProperty(masterId) && masterId.startsWith("m")) {
-            height += this._drawEquip(types.gears[masterId], rowWidth, rowHeight, false);
-        }
-    }
-    return height + 0.5 * rowHeight;
-};
+    };
 
-ShowcaseExporter.prototype._drawEquip = function (equip, rowWidth, rowHeight, fake) {
-    var height;
-    if (!fake) {
-        height = this._drawEquip(equip, rowWidth, rowHeight, true);
-    }
+    ShowcaseExporter.prototype._drawIcon = function (x, y, shipId) {
+        this.ctx.drawImage(
+            this._shipImages[shipId],
+            0, 0, this._shipImages[shipId].width, this._shipImages[shipId].height,
+            x, y, this.rowParams.height, this.rowParams.height
+        );
+    };
 
-    var img = this._equipTypeImages[KC3Master.slotitem(equip.masterId).api_type[3]];
-    var canvas = document.createElement("CANVAS"), ctx = canvas.getContext("2d");
-    var x = 0, y = 0;
-
-    if (fake == false) {
-        canvas.width = rowWidth;
-        canvas.height = height;
-        ctx.drawImage(img, 0, 0, img.width, img.height, x, y, rowHeight, rowHeight);
-    }
-
-    var equipMaxY = this._drawEquipInfo(equip, ctx, x, y, rowWidth, rowHeight, fake);
-
-    ctx.fillStyle = "#000";
-    var fontSize;
-    for (var i = 0; i <= 10; i++) {
-        if (i == 0)
-            fontSize = 14;
-        else
-            fontSize = 10;
-        if (equip["s" + i] == 0)
-            continue;
-
-        var text = "";
-        if (i == 0) {
-            text = " x";
-        } else if (i == 10) {
-            text = "+10★ x"
+    ShowcaseExporter.prototype._drawStat = function (stat, x, y, w, h, color, background) {
+        if (stat[0] >= stat[1]) {
+            this.ctx.fillStyle = color;
+            this.ctx.fillRect(x, y, w, h);
         } else {
-            text = "+" + i + "★ x"
+            this.ctx.fillStyle = background;
+            this.ctx.fillRect(x, y, w, h);
         }
-        text += equip["s" + i];
-        ctx.font = fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
-        if (!fake)
-            ctx.fillText(text, x + rowWidth - rowHeight * 0.5 - ctx.measureText(text).width, y + (rowHeight + fontSize) / 2);
-        y += fontSize + 4;
-    }
-    if (equipMaxY > y)
-        y = equipMaxY;
+    };
 
-    this._equipCanvases["m" + equip.masterId] = canvas;
-    return y + 5;
-};
+    ShowcaseExporter.prototype._fill = function () {
+        this.ctx.fillStyle = "#efefef";
+        this.ctx.fillRect(0, 0, this.canvas.width, this.canvas.height);
+    };
 
-ShowcaseExporter.prototype._drawEquipInfo = function (equip, ctx, x, y, rowWidth, rowHeight, fake) {
-    var startY = y;
-    var fontSize = 10;
-    ctx.font = fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
-    ctx.fillStyle = "#000";
+    /* EQUIP EXPORT
+     ------------------------- */
 
-    var available = rowWidth - rowHeight * 3.5;
+    ShowcaseExporter.prototype.exportEquip = function () {
+        var gears = this._getGears();
+        var self = this;
 
-    var name = this._splitText(equip.name, ctx, available);
-    y = this._drawEquipName(name, ctx, x + 30, y, rowHeight, fontSize, fake);
+        this._loadImages(function () {
+            self._processGears(gears);
+        });
+    };
 
-    if (equip.name != KC3Master.slotitem(equip.masterId).api_name) {
-        name = this._splitText(KC3Master.slotitem(equip.masterId).api_name, ctx, available, "");
-        y = this._drawEquipName(name, ctx, x + 30, y, fontSize, fontSize, fake);
-    }
-    y = y < startY + 30 ? startY + 30 : y;
+    ShowcaseExporter.prototype._getGears = function () {
+        var allGears = JSON.parse(localStorage.gears);
+        var sorted = {};
+        for (var i in allGears) {
+            if (allGears[i].lock === 0)
+                continue;
 
-    var available = rowWidth - rowHeight * 3.5;
+            var equip = allGears[i];
+            var equipMaster = KC3Master.slotitem(equip.masterId);
 
-    y += 5;
-    var statsY = this._drawEquipStats(equip, ctx, x + rowHeight, y, available, fake);
-    y = Math.max(statsY, y);
-    if (statsY > 0)
-        y += 10;
-    return y;
-};
-
-ShowcaseExporter.prototype._drawEquipName = function (nameLines, ctx, x, y, rowHeight, fontSize, fake) {
-    if (nameLines.length == 1) {
-        if (!fake)
-            ctx.fillText(nameLines[0], x, y + fontSize);
-        y += fontSize + 5;
-    } else {
-        for (var i = 0; i < nameLines.length; i++) {
-            if (!fake)
-                ctx.fillText(nameLines[i], x, y + fontSize);
-            y += fontSize + 5;
-        }
-    }
-    return y;
-};
-
-ShowcaseExporter.prototype._splitText = function (text, ctx, maxWidth, splitter) {
-    if (typeof splitter == "undefined")
-        splitter = " ";
-
-    if(text.indexOf(splitter)==-1)
-        splitter="";
-
-    var rows = [];
-    var words = text.split(splitter);
-
-    //@TODO what if single word will be so long so it goes outside maxWidth?
-    while (words.length > 0) {
-        var line = [];
-        var next = words.shift();
-        while (ctx.measureText((line.join(splitter) + splitter + next).trim()).width < maxWidth && next != "") {
-            line.push(next);
-            if (words.length > 0)
-                next = words.shift();
-            else
-                next = "";
-        }
-        rows.push(line.join(splitter));
-        if (next != "") {
-            words.unshift(next);
-        }
-    }
-
-    return rows;
-};
-
-ShowcaseExporter.prototype._drawEquipStats = function (equip, ctx, x, y, available, fake) {
-    var fontSize = 10;
-    ctx.font = fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
-    ctx.fillStyle = "#000";
-
-    var startX = x;
-    var img;
-    var noStats = true;
-
-    function drawStat() {
-        img = this._statsImages[i];
-        if (typeof equip[i] != "undefined" && equip[i] > 0) {
-            noStats = false;
-            if (x + img.width + 3 + ctx.measureText(equip[i]).width > startX + available) {
-                y += img.height + 5;
-                x = startX;
+            var masterId = "m" + equip.masterId;
+            var typeId = "t" + equipMaster.api_type[3];
+            var groupId = "g" + equipMaster.api_type[0];
+            if (!sorted[groupId]) {
+                sorted[groupId] = {
+                    name: KC3Meta.gearTypeName(0, equipMaster.api_type[0]),
+                    types: {}
+                };
             }
 
-            if (!fake)
-                ctx.drawImage(img, 0, 0, img.width, img.height, x, y, img.width, img.height);
-            x += img.width + 3;
-            if (!fake)
-                ctx.fillText(equip[i], x, y + (img.height + fontSize) / 2);
-            x += ctx.measureText(equip[i]).width;
-            x += 10;
+            if (!sorted[groupId]['types'][typeId]) {
+                sorted[groupId]['types'][typeId] = {
+                    typeId: KC3Master.slotitem(equip.masterId).api_type[3],
+                    name: KC3Meta.gearTypeName(2, equipMaster.api_type[2]),
+                    gears: {}
+                };
+                this._equipTypeImages[KC3Master.slotitem(equip.masterId).api_type[3]] = null;
+            }
+
+            if (!sorted[groupId]['types'][typeId]['gears'][masterId]) {
+                sorted[groupId]['types'][typeId]['gears'][masterId] = {
+                    masterId: equip.masterId,
+                    name: KC3Meta.gearName(equipMaster.api_name),
+                    fp: equipMaster.api_houg,
+                    tp: equipMaster.api_raig,
+                    aa: equipMaster.api_tyku,
+                    ar: equipMaster.api_souk,
+                    as: equipMaster.api_tais,
+                    ev: equipMaster.api_houk,
+                    ls: equipMaster.api_saku,
+                    dv: equipMaster.api_baku,
+                    ht: equipMaster.api_houm,
+                    rn: equipMaster.api_leng,
+                    or: equipMaster.api_distance,
+                    "s0": 0,
+                    "s1": 0, "s2": 0, "s3": 0, "s4": 0, "s5": 0,
+                    "s6": 0, "s7": 0, "s8": 0, "s9": 0, "s10": 0
+                };
+            }
+            sorted[groupId]['types'][typeId]['gears'][masterId]["s" + equip.stars]++;
         }
-    }
-    var sortingParam = KC3StrategyTabs.gears.definition._defaultCompareMethod["t"+KC3Master.slotitem(equip.masterId).api_type[3]];
-    if(!!sortingParam && sortingParam!="overall"){
-        var i = sortingParam;
-        drawStat.call(this);
-    }
+
+        return sorted;
+    };
+
+    ShowcaseExporter.prototype._processGears = function (gears) {
+        var canvas = document.createElement("CANVAS");
+        var ctx = canvas.getContext("2d");
+
+        var columnsCount = 5;
+        var rowHeight = 30;
+        var rowWidth = 350;
+
+        this._drawEquipGroups(gears, rowWidth, rowHeight);
+        var columns = this._splitEquipByColumns(columnsCount);
+        canvas.height = this._getBiggestColumn(columns);
+        canvas.width = rowWidth * columnsCount;
+        ctx.fillStyle = this.colors.odd;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        this._fillEquipCanvas(canvas, ctx, columns, rowWidth);
+        this._drawBorders(canvas, ctx, rowWidth);
+        this._addCredits(canvas, "Equipment List");
+    };
+
+    ShowcaseExporter.prototype._fillEquipCanvas = function (canvas, ctx, columns, rowWidth) {
+        for (var i = 0; i < columns.length; i++) {
+            var column = columns[i];
+            var y = 0, x = i * rowWidth;
+            for (var j = 0; j < column.length; j++) {
+                var canvasData = this._equipGroupCanvases[column[j]];
+                ctx.drawImage(canvasData, x, y, canvasData.width, canvasData.height);
+                y += canvasData.height;
+            }
+        }
+    };
+
+    ShowcaseExporter.prototype._getBiggestColumn = function (columns) {
+        var maxSize = 0;
+        for (var i = 0; i < columns.length; i++) {
+            if (typeof columns[i] != "object")
+                continue;
+
+            var size = 0;
+            for (var j = 0; j < columns[i].length; j++) {
+                size += this._equipGroupCanvases[columns[i][j]].height;
+            }
+            if (maxSize < size)
+                maxSize = size;
+        }
+        return maxSize;
+    };
+
+    ShowcaseExporter.prototype._splitEquipByColumns = function (maxColumns) {
+        var maxHeight = this._getMaxHeight(), totalHeight = this._getTotalHeight();
+        var aproxSize = Math.max(Math.ceil(totalHeight / maxColumns), maxHeight);
+        var paging = this._fillEquipColumns(aproxSize);
+
+        if (paging.length > maxColumns) {
+            paging = this._fixEquipPaging(aproxSize, paging, maxColumns);
+        }
+        return paging;
+    };
+
+    ShowcaseExporter.prototype._fixEquipPaging = function (aproxSize, paging, maxColumns) {
+        while (paging.length > maxColumns) {
+            paging = this._fillEquipColumns(aproxSize++);
+        }
+        return paging;
+    };
+
+    ShowcaseExporter.prototype._fillEquipColumns = function (aproxSize) {
+        var groupIds = [];
+        for (var groupId in this._equipGroupCanvases) {
+            if (groupId.startsWith("g"))
+                groupIds.push(parseInt(groupId.slice("1")));
+        }
+        groupIds.sort(function (a, b) {
+            return a - b;
+        });
 
 
-    for (var i in this._statsImages) {
-        if (!this._statsImages.hasOwnProperty(i))
-            continue;
+        var newPaging = [[]];
+        var size = 0;
+        var column = 0;
+        for (var i = 0; i < groupIds.length; i++) {
+            if (size + this._equipGroupCanvases["g" + groupIds[i]].height > aproxSize) {
+                column++;
+                newPaging.push([]);
+                size = 0;
+            }
+            newPaging[column].push("g" + groupIds[i]);
+            size += this._equipGroupCanvases["g" + groupIds[i]].height;
+        }
+        return newPaging;
+    };
 
-        if (i == "or" && this.aircraftTypes.indexOf(KC3Master.slotitem(equip.masterId).api_type[3]) == -1)
-            continue;
+    ShowcaseExporter.prototype._getMaxHeight = function () {
+        var maxHeight = 0;
 
-        if(sortingParam==i)
-            continue;
+        for (var groupId in this._equipGroupCanvases) {
+            if (!this._equipGroupCanvases.hasOwnProperty(groupId))
+                continue;
+            if (this._equipGroupCanvases[groupId].height > maxHeight)
+                maxHeight = this._equipGroupCanvases[groupId].height;
+        }
+        return maxHeight;
+    };
 
-        drawStat.call(this);
-    }
-    if (noStats)
-        return 0;
+    ShowcaseExporter.prototype._getTotalHeight = function () {
+        var totalHeight = 0;
 
-    y += img.height + 5;
-    return y;
-};
+        for (var groupId in this._equipGroupCanvases) {
+            if (!this._equipGroupCanvases.hasOwnProperty(groupId))
+                continue;
+            totalHeight += this._equipGroupCanvases[groupId].height;
+        }
+        return totalHeight;
+    };
 
-ShowcaseExporter.prototype._cloneArray = function (a) {
-    var b = [];
-    var i = a.length;
-    while (i--) {
-        if (typeof a[i] == "object")
-            b[i] = this._cloneArray(a[i]);
-        else
-            b[i] = a[i];
-    }
-    return b;
-};
+    ShowcaseExporter.prototype._drawEquipGroups = function (gears, rowWidth, rowHeight) {
+        var groupIds = [];
+        for (var groupId in gears) {
+            if (groupId.startsWith("g"))
+                groupIds.push(parseInt(groupId.slice("1")));
+        }
+        groupIds.sort(function (a, b) {
+            return a - b;
+        });
+
+        var bool = true;
+        for (var i = 0; i < groupIds.length; i++) {
+            var canvas = document.createElement("CANVAS"), ctx = canvas.getContext("2d");
+            canvas.height = this._drawEquipGroup(gears["g" + groupIds[i]], rowWidth, rowHeight);
+            canvas.width = rowWidth;
+            ctx.fillStyle = bool ? this.colors.odd : this.colors.even;
+            ctx.fillRect(0, 0, canvas.width, canvas.height);
+            bool = !bool;
+            this._addEquipGroupsToCanvas(gears["g" + groupIds[i]], canvas, ctx, rowHeight);
+            this._equipGroupCanvases["g" + groupIds[i]] = canvas;
+        }
+    };
+
+    ShowcaseExporter.prototype._addEquipGroupsToCanvas = function (group, canvas, ctx, rowHeight) {
+        function compareEquip(a, b) {
+            var equipA = KC3Master.slotitem(a.slice(1)), equipB = KC3Master.slotitem(b.slice(1));
+            return equipB[sortingParam] - equipA[sortingParam];
+        }
+
+        var typeCount = 0;
+        for (var typeId in group.types) {
+            typeCount++;
+        }
+
+        var y = 0;
+        var fontSize = 16;
+        ctx.font = "600 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        ctx.fillStyle = "#000";
+        ctx.fillText(group.name, (canvas.width - ctx.measureText(group.name).width) / 2, ( rowHeight + fontSize) / 2);
+        y += rowHeight;
+
+        for (typeId in group.types) {
+            if (typeId.startsWith("t")) {
+                var type = group.types[typeId];
+                if (typeCount > 1) {
+                    y += rowHeight / 2;
+                    fontSize = 16;
+                    ctx.font = "500 " + fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+                    ctx.fillStyle = "#000";
+                    ctx.fillText(type.name, (canvas.width - ctx.measureText(type.name).width) / 2, y + (rowHeight + fontSize) / 2);
+                    y += rowHeight * 1.5;
+                }
+
+                var masterIds = [];
+                for (var masterId in type.gears) {
+                    if (!type.hasOwnProperty(masterId) && masterId.startsWith("m")) {
+                        masterIds.push(masterId);
+                    }
+                }
+
+                var sortingParam = this._paramToApi[KC3StrategyTabs.gears.definition._defaultCompareMethod[typeId]];
+                if (!!sortingParam) {
+                    masterIds.sort(compareEquip);
+                }
+
+                for (var i = 0; i < masterIds.length; i++) {
+                    masterId = masterIds[i];
+                    var canvasData = this._equipCanvases[masterId];
+                    ctx.drawImage(canvasData, 0, y, canvasData.width, canvasData.height);
+                    y += canvasData.height;
+
+                }
+                y += rowHeight * 0.5;
+
+                ctx.fillStyle = "#FFF";
+                for (var xPos = 0; xPos < 0 + canvas.width; xPos += 20) {
+                    ctx.fillRect(xPos, y - 2, 10, 2);
+                }
+            }
+        }
+    };
+
+    ShowcaseExporter.prototype._drawEquipGroup = function (group, rowWidth, rowHeight) {
+        var typeCount = 0;
+        for (var typeId in group.types) {
+            typeCount++;
+        }
+
+        var height = 0;
+        for (var i in group.types) {
+            if (i.startsWith("t")) {
+                height += this._drawEquipTypes(group.types[i], rowWidth, rowHeight);
+            }
+        }
+        if (typeCount > 1)
+            height += rowHeight * typeCount * 2;// + typename each
+        return height + rowHeight;// + groupName
+    };
+
+    ShowcaseExporter.prototype._drawEquipTypes = function (types, rowWidth, rowHeight) {
+        var height = 0;
+
+        for (var masterId in types.gears) {
+            if (!types.hasOwnProperty(masterId) && masterId.startsWith("m")) {
+                height += this._drawEquip(types.gears[masterId], rowWidth, rowHeight, false);
+            }
+        }
+        return height + 0.5 * rowHeight;
+    };
+
+    ShowcaseExporter.prototype._drawEquip = function (equip, rowWidth, rowHeight, fake) {
+        var height;
+        if (!fake) {
+            height = this._drawEquip(equip, rowWidth, rowHeight, true);
+        }
+
+        var img = this._equipTypeImages[KC3Master.slotitem(equip.masterId).api_type[3]];
+        var canvas = document.createElement("CANVAS"), ctx = canvas.getContext("2d");
+        var x = 0, y = 0;
+
+        if (fake === false) {
+            canvas.width = rowWidth;
+            canvas.height = height;
+            ctx.drawImage(img, 0, 0, img.width, img.height, x, y, rowHeight, rowHeight);
+        }
+
+        var equipMaxY = this._drawEquipInfo(equip, ctx, x, y, rowWidth, rowHeight, fake);
+
+        ctx.fillStyle = "#000";
+        var fontSize;
+        for (var i = 0; i <= 10; i++) {
+            if (i === 0)
+                fontSize = 14;
+            else
+                fontSize = 10;
+            if (equip["s" + i] === 0)
+                continue;
+
+            var text = "";
+            if (i === 0) {
+                text = " x";
+            } else if (i === 10) {
+                text = "+10★ x";
+            } else {
+                text = "+" + i + "★ x";
+            }
+            text += equip["s" + i];
+            ctx.font = fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+            if (!fake)
+                ctx.fillText(text, x + rowWidth - rowHeight * 0.5 - ctx.measureText(text).width, y + (rowHeight + fontSize) / 2);
+            y += fontSize + 4;
+        }
+        if (equipMaxY > y)
+            y = equipMaxY;
+
+        this._equipCanvases["m" + equip.masterId] = canvas;
+        return y + 5;
+    };
+
+    ShowcaseExporter.prototype._drawEquipInfo = function (equip, ctx, x, y, rowWidth, rowHeight, fake) {
+        var startY = y;
+        var fontSize = 10;
+        ctx.font = fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        ctx.fillStyle = "#000";
+
+        var available = rowWidth - rowHeight * 3.5;
+
+        var name = this._splitText(equip.name, ctx, available);
+        y = this._drawEquipName(name, ctx, x + 30, y, rowHeight, fontSize, fake);
+
+        if (equip.name != KC3Master.slotitem(equip.masterId).api_name) {
+            name = this._splitText(KC3Master.slotitem(equip.masterId).api_name, ctx, available, "");
+            y = this._drawEquipName(name, ctx, x + 30, y, fontSize, fontSize, fake);
+        }
+        y = y < startY + 30 ? startY + 30 : y;
+
+        available = rowWidth - rowHeight * 3.5;
+
+        y += 5;
+        var statsY = this._drawEquipStats(equip, ctx, x + rowHeight, y, available, fake);
+        y = Math.max(statsY, y);
+        if (statsY > 0)
+            y += 10;
+        return y;
+    };
+
+    ShowcaseExporter.prototype._drawEquipName = function (nameLines, ctx, x, y, rowHeight, fontSize, fake) {
+        if (nameLines.length === 1) {
+            if (!fake)
+                ctx.fillText(nameLines[0], x, y + fontSize);
+            y += fontSize + 5;
+        } else {
+            for (var i = 0; i < nameLines.length; i++) {
+                if (!fake)
+                    ctx.fillText(nameLines[i], x, y + fontSize);
+                y += fontSize + 5;
+            }
+        }
+        return y;
+    };
+
+    ShowcaseExporter.prototype._splitText = function (text, ctx, maxWidth, splitter) {
+        if (typeof splitter === "undefined")
+            splitter = " ";
+
+        if (text.indexOf(splitter) == -1)
+            splitter = "";
+
+        var rows = [];
+        var words = text.split(splitter);
+
+        //@TODO what if single word will be so long so it goes outside maxWidth?
+        while (words.length > 0) {
+            var line = [];
+            var next = words.shift();
+            while (ctx.measureText((line.join(splitter) + splitter + next).trim()).width < maxWidth && next != "") {
+                line.push(next);
+                if (words.length > 0)
+                    next = words.shift();
+                else
+                    next = "";
+            }
+            rows.push(line.join(splitter));
+            if (next != "") {
+                words.unshift(next);
+            }
+        }
+
+        return rows;
+    };
+
+    ShowcaseExporter.prototype._drawEquipStats = function (equip, ctx, x, y, available, fake) {
+        var fontSize = 10;
+        ctx.font = fontSize + "pt \"Helvetica Neue\", Helvetica, Arial, sans-serif";
+        ctx.fillStyle = "#000";
+
+        var startX = x;
+        var img;
+        var noStats = true;
+
+        function drawStat(img) {
+            if (typeof equip[i] != "undefined" && equip[i] > 0) {
+                noStats = false;
+                if (x + img.width + 3 + ctx.measureText(equip[i]).width > startX + available) {
+                    y += img.height + 5;
+                    x = startX;
+                }
+
+                if (!fake)
+                    ctx.drawImage(img, 0, 0, img.width, img.height, x, y, img.width, img.height);
+                x += img.width + 3;
+                if (!fake)
+                    ctx.fillText(equip[i], x, y + (img.height + fontSize) / 2);
+                x += ctx.measureText(equip[i]).width;
+                x += 10;
+            }
+        }
+
+        var sortingParam = KC3StrategyTabs.gears.definition._defaultCompareMethod["t" + KC3Master.slotitem(equip.masterId).api_type[3]];
+        var i;
+        if (!!sortingParam && sortingParam != "overall") {
+            i = sortingParam;
+            img = this._statsImages[i];
+            drawStat.call(this,img);
+        }
+
+
+        for (i in this._statsImages) {
+            if (!this._statsImages.hasOwnProperty(i))
+                continue;
+
+            if (i === "or" && this.aircraftTypes.indexOf(KC3Master.slotitem(equip.masterId).api_type[3]) === -1)
+                continue;
+
+            if (sortingParam == i)
+                continue;
+            img = this._statsImages[i];
+            drawStat.call(this,img);
+        }
+        if (noStats)
+            return 0;
+
+        y += img.height + 5;
+        return y;
+    };
+
+    ShowcaseExporter.prototype._cloneArray = function (a) {
+        var b = [];
+        var i = a.length;
+        while (i--) {
+            if (typeof a[i] === "object")
+                b[i] = this._cloneArray(a[i]);
+            else
+                b[i] = a[i];
+        }
+        return b;
+    };
+})();

--- a/src/pages/strategy/strategy.html
+++ b/src/pages/strategy/strategy.html
@@ -143,6 +143,7 @@
 		<script type="text/javascript" src="../../library/objects/Ship.js"></script>
 		<script type="text/javascript" src="../../library/objects/Sortie.js"></script>
 		<script type="text/javascript" src="../../library/objects/LandBase.js"></script>
+		<script type="text/javascript" src="../../library/objects/ShowcaseExporter.js"></script>
 		<script type="text/javascript" src="../../library/managers/ConfigManager.js"></script>
 		<script type="text/javascript" src="../../library/managers/GearManager.js"></script>
 		<script type="text/javascript" src="../../library/managers/PlayerManager.js"></script>

--- a/src/pages/strategy/tabs/showcase/showcase.css
+++ b/src/pages/strategy/tabs/showcase/showcase.css
@@ -1,7 +1,40 @@
 .tab_showcase .factory {
 	display:none;
 }
-
+/* BUTTONS
+-----------------------------*/
+.tab_showcase  .controls .control {
+	width: 140px;
+	height: 20px;
+	line-height: 20px;
+	margin: 0px 5px 0px 0px;
+	font-weight: bold;
+	font-size: 12px;
+	text-align: center;
+	float: left;
+	border-radius: 7px;
+}
+.tab_showcase  .control {
+	background:#369;
+	color:#fff;
+}
+.tab_showcase  .control:hover {
+	background-color: #0066CC;
+}
+.tab_showcase .controls {
+	background:#f0f5ff;
+	border-bottom:1px solid #369;
+	width: 700px;
+	margin: 0px 0px 0px 0px;
+	padding: 5px 10px;
+}
+.tab_showcase  .control.disabled {
+	background-color:#eee;
+}
+.tab_showcase  .control.disabled:hover {
+	background-color: #eee;
+	cursor:default;
+}
 /* SHIPS
 -----------------------------*/
 .tab_showcase .stype_box {

--- a/src/pages/strategy/tabs/showcase/showcase.css
+++ b/src/pages/strategy/tabs/showcase/showcase.css
@@ -35,6 +35,12 @@
 	background-color: #eee;
 	cursor:default;
 }
+.tab_showcase .exportResults div:first-child{
+	margin-top:10px;
+}
+.tab_showcase .exportResults a{
+	cursor: pointer;
+}
 /* SHIPS
 -----------------------------*/
 .tab_showcase .stype_box {

--- a/src/pages/strategy/tabs/showcase/showcase.html
+++ b/src/pages/strategy/tabs/showcase/showcase.html
@@ -29,8 +29,8 @@
 	<div class="help_q">Why some of my equipment\ships are not shown on export image?</div>
 	<div class="help_a">Image are showing only locked ships and items. If you acquired and locked item in current game session, you might need to go to home port once.</div>
 
-	<div class="help_q">How can i change export destination?</div>
-	<div class="help_a">By default exporter is using screenshot "Output Mode". But in case of Imgur error or image is being too big for new tab picture will be downloaded.</div>
+	<div class="help_q">Exporter is downloading image instead of opening it in new tab or Imgur!</div>
+	<div class="help_a">In case of Imgur error or image data string is being too big for new tab to handle it will be downloaded.</div>
 
 	<div class="help_more">
 		<a href="https://github.com/KC3Kai/KC3Kai/wiki/Strategy-Room%3A-Showcase">Learn more</a>
@@ -38,6 +38,20 @@
 </div>
 
 <div class="controls">
+	<div class="options">
+		<div>
+			<label for="exportOutputMode">Output to </label>
+			<select id="exportOutputMode">
+				<option value="2">New Tab</option>
+				<option value="1">Imgur</option>
+				<option value="0">Download</option>
+			</select>
+		</div>
+		<div>
+			<input type="checkbox" id="exportAddName">
+			<label for="exportAddName">Show my name and level on image</label>
+		</div>
+	</div>
 	<div class="control hover" id="exportShips">Export Ships</div>
     <div class="control hover" id="exportEquipment">Export Equipment</div>
 	<div class="clear"></div>

--- a/src/pages/strategy/tabs/showcase/showcase.html
+++ b/src/pages/strategy/tabs/showcase/showcase.html
@@ -31,6 +31,11 @@
 	</div>
 </div>
 
+<div class="controls">
+	<div class="control hover" id="exportShips">Export Ships</div>
+    <div class="control hover" id="exportEquipment">Export Equipment</div>
+	<div class="clear"></div>
+</div>
 
 <div class="page_padding">
 	<div class="page_section">Ships</div>

--- a/src/pages/strategy/tabs/showcase/showcase.html
+++ b/src/pages/strategy/tabs/showcase/showcase.html
@@ -30,7 +30,7 @@
 	<div class="help_a">Image are showing only locked ships and items. If you acquired and locked item in current game session, you might need to go to home port once.</div>
 
 	<div class="help_q">How can i change export destination?</div>
-	<div class="help_a">Exporter is using screenshot "Output Mode". In case of Imgur error it will fallback to download.</div>
+	<div class="help_a">By default exporter is using screenshot "Output Mode". But in case of Imgur error or image is being too big for new tab picture will be downloaded.</div>
 
 	<div class="help_more">
 		<a href="https://github.com/KC3Kai/KC3Kai/wiki/Strategy-Room%3A-Showcase">Learn more</a>

--- a/src/pages/strategy/tabs/showcase/showcase.html
+++ b/src/pages/strategy/tabs/showcase/showcase.html
@@ -35,6 +35,7 @@
 	<div class="control hover" id="exportShips">Export Ships</div>
     <div class="control hover" id="exportEquipment">Export Equipment</div>
 	<div class="clear"></div>
+	<div class="exportResults"></div>
 </div>
 
 <div class="page_padding">

--- a/src/pages/strategy/tabs/showcase/showcase.html
+++ b/src/pages/strategy/tabs/showcase/showcase.html
@@ -27,7 +27,7 @@
 	<div class="help_a">Unfortunately, in game data it is still categorized under sea planes. I am sorry but we will not go for the extra effort of making an exception for this equipment.</div>
 
 	<div class="help_q">Why some of my equipment\ships are not shown on export image?</div>
-	<div class="help_a">Image are showing only locked ships and items. If you acquired and locked item in current game session, you might need to relogin. This is a know bug.</div>
+	<div class="help_a">Image are showing only locked ships and items. If you acquired and locked item in current game session, you might need to go to home port once.</div>
 
 	<div class="help_q">How can i change export destination?</div>
 	<div class="help_a">Exporter is using screenshot "Output Mode". In case of Imgur error it will fallback to download.</div>

--- a/src/pages/strategy/tabs/showcase/showcase.html
+++ b/src/pages/strategy/tabs/showcase/showcase.html
@@ -26,6 +26,12 @@
 	<div class="help_q">Night scout seaplane should be on the Night gear box!</div>
 	<div class="help_a">Unfortunately, in game data it is still categorized under sea planes. I am sorry but we will not go for the extra effort of making an exception for this equipment.</div>
 
+	<div class="help_q">Why some of my equipment\ships are not shown on export image?</div>
+	<div class="help_a">Image are showing only locked ships and items. If you acquired and locked item in current game session, you might need to relogin. This is a know bug.</div>
+
+	<div class="help_q">How can i change export destination?</div>
+	<div class="help_a">Exporter is using screenshot "Output Mode". In case of Imgur error it will fallback to download.</div>
+
 	<div class="help_more">
 		<a href="https://github.com/KC3Kai/KC3Kai/wiki/Strategy-Room%3A-Showcase">Learn more</a>
 	</div>

--- a/src/pages/strategy/tabs/showcase/showcase.js
+++ b/src/pages/strategy/tabs/showcase/showcase.js
@@ -199,6 +199,7 @@
                     $("<div></div>").html("Saved to ").append(
                         $("<a></a>")
                             .html(result.filename)
+                            .attr("title","Show in folder")
                             .click(function () {
                                 chrome.downloads.show(result.downloadId);
                                 return false;

--- a/src/pages/strategy/tabs/showcase/showcase.js
+++ b/src/pages/strategy/tabs/showcase/showcase.js
@@ -221,6 +221,8 @@
                     return;
                 $(this).addClass("disabled");
                 var exporter = new ShowcaseExporter();
+                exporter._outputMode = $("#exportOutputMode").val();
+                exporter._addNameAndLevel = $("#exportAddName")[0].checked;
                 exporter.complete = function (data) {
                 	self.displayExportResult(data);
                     $("#exportShips").removeClass("disabled");
@@ -233,12 +235,16 @@
                     return;
                 $(this).addClass("disabled");
                 var exporter = new ShowcaseExporter();
+                exporter._outputMode = $("#exportOutputMode").val();
+                exporter._addNameAndLevel = $("#exportAddName")[0].checked;
                 exporter.complete = function (data) {
                     self.displayExportResult(data);
                     $("#exportEquipment").removeClass("disabled");
                 };
+                $("#exportOutputMode").val();
                 exporter.exportEquip();
             });
+            $("#exportOutputMode").val(parseInt(ConfigManager.ss_mode,10));
 
 			// SHIPS
 			$.each(this.shipCache, function(stype, stypeList){

--- a/src/pages/strategy/tabs/showcase/showcase.js
+++ b/src/pages/strategy/tabs/showcase/showcase.js
@@ -1,11 +1,11 @@
 (function(){
 	"use strict";
-	
+
 	KC3StrategyTabs.showcase = new KC3StrategyTab("showcase");
-	
+
 	KC3StrategyTabs.showcase.definition = {
 		tabSelf: KC3StrategyTabs.showcase,
-		
+
 		shipCache: {},
 		gearCache: {},
 		equipTypes: {
@@ -83,13 +83,13 @@
 				types: [ 20, 21, 22, 33 ]
 			}
 		},
-		
+
 		/* INIT
 		Prepares static data needed
 		---------------------------------*/
 		init :function(){
 		},
-		
+
 		/* RELOAD
 		Prepares latest fleets data
 		---------------------------------*/
@@ -101,17 +101,17 @@
 			// Clean cache data
 			this.shipCache = { bb:[], fbb:[], bbv:[], cv:[], cvl:[], ca:[], cav:[], cl:[], dd:[], ss:[], clt:[], ax:[], ao:[] };
 			this.gearCache = {};
-			
+
 			// Convert ship list object into array
 			TempShipList = $.map(KC3ShipManager.list, function(value, index) {
 				return [value];
 			});
-			
+
 			// Order by level
 			TempShipList.sort(function(a,b){
 				return b.level  - a.level;
 			});
-			
+
 			// Add leveled list to ship cache, max 6 per type
 			for(ctr in TempShipList){
 				ThisShip = TempShipList[ctr];
@@ -138,7 +138,7 @@
 					default: break;
 				}
 			}
-			
+
 			// Organize all owned equipment by slotitem_id
 			var GearRecords = {};
 			$.each(KC3GearManager.list, function(index, element){
@@ -149,12 +149,12 @@
 				// Increment this gear to the slotitem_id
 				GearRecords["g"+element.masterId]++;
 			});
-			
+
 			// Organize slotitem_ids into their types
 			var GearMaster, GearType;
 			$.each(GearRecords, function(index, element){
 				GearMaster = KC3Master.slotitem( index.substr(1) );
-				
+
 				GearType = GearMaster.api_type[3];
 				// If gear type does not exist yet
 				if(typeof self.gearCache["t"+GearType] == "undefined"){
@@ -177,25 +177,50 @@
 				});
 			});
 		},
-		
+
 		addToStypeList :function(stype, shipObj){
 			if(this.shipCache[stype].length < 6){
 				this.shipCache[stype].push(shipObj);
 			}
 		},
-		
+
 		/* EXECUTE
 		Places data onto the interface
 		---------------------------------*/
 		execute :function(){
 			var shipBox, self=this;
-			
+
+			// BUTTONS
+            $("#exportShips").on("click", function(){
+                if ($(this).hasClass("disabled"))
+                    return;
+                $(this).addClass("disabled");
+                var exporter = new ShowcaseExporter();
+                var self = this;
+                exporter.complete = function () {
+                    $(self).removeClass("disabled");
+                };
+                exporter.exportShips();
+            });
+
+            $("#exportEquipment").on("click", function(){
+                if ($(this).hasClass("disabled"))
+                    return;
+                $(this).addClass("disabled");
+                var exporter = new ShowcaseExporter();
+                var self = this;
+                exporter.complete = function () {
+                    $(self).removeClass("disabled");
+                };
+                exporter.exportEquip();
+            });
+
 			// SHIPS
 			$.each(this.shipCache, function(stype, stypeList){
-				
+
 				$.each(stypeList, function(index, shipObj){
 					if (shipObj.level == 1) return true;
-					
+
 					shipBox = $(".tab_showcase .factory .show_ship").clone();
 					$(".ship_pic img", shipBox).attr("src", KC3Meta.shipIcon( shipObj.masterId ) );
 					$(".ship_name", shipBox).html( shipObj.name() );
@@ -205,15 +230,15 @@
 					self.checkModStat(shipBox, "api_tyku", "aa", 2, shipObj);
 					self.checkModStat(shipBox, "api_souk", "ar", 3, shipObj);
 					// self.checkModStat(shipBox, "api_luck", "lk", 4, shipObj);
-					
+
 					$(".ship_mod_lk", shipBox).html( shipObj.lk[0] );
 					$(".ship_mod_lk", shipBox).addClass("max");
-					
+
 					$(".tab_showcase .stype_"+stype).append(shipBox);
 				});
-				
+
 			});
-			
+
 			// GEARS
 			var GearTypeBox, GearBox, TopGears, MergedList, GearTypeIcon;
 			$.each(this.equipTypes, function(index, element){
@@ -221,11 +246,11 @@
 				if(typeof self.gearCache[index] != "undefined"){
 					MergedList = self.gearCache[index];
 					GearTypeIcon = index.substr(1);
-					
+
 				// Check if he does have any of this gear type
 				}else if(typeof element.types == "undefined"){
 					return true;
-					
+
 				// IS TYPE-COLLECTION
 				}else{
 					// Merge each type on this list
@@ -235,22 +260,22 @@
 					});
 					GearTypeIcon = 0;
 				}
-				
+
 				// If has order-by parameter
 				if(typeof element.order != "undefined"){
 					MergedList.sort(function(a,b){
 						return b[ element.order ]  - a[ element.order ];
 					});
 				}
-				
+
 				// Get 4 most powerful gear on this type
 				TopGears = MergedList.slice(0,4);
 				// console.log("TopGears for", element.name, TopGears);
-				
+
 				// Create gear-type box
 				GearTypeBox = $(".tab_showcase .factory .gtype_box").clone();
 				$(".gtype_title", GearTypeBox).html(element.name);
-				
+
 				// Add gears on this gear-type
 				$.each(TopGears, function(gearIndex, ThisTopGear){
 					if(typeof ThisTopGear !== "undefined"){
@@ -260,7 +285,7 @@
 						GearTypeIcon = 0;
 						$(".gear_name", GearBox).html( ThisTopGear.name );
 						$(".gear_name", GearBox).attr("title", ThisTopGear.name );
-						
+
 						if(typeof element.order !== "undefined"){
 							$(".gear_stat_icon img", GearBox).attr("src", "../../assets/img/stats/"+element.order+".png");
 							$(".gear_stat_val", GearBox).html( ThisTopGear[element.order] );
@@ -269,18 +294,18 @@
 							$(".gear_stat_icon", GearBox).hide();
 							$(".gear_stat_val", GearBox).hide();
 						}
-						
+
 						$(".gear_count", GearBox).html( ThisTopGear.count );
-						
+
 						$(".gtype_contents", GearTypeBox).append(GearBox);
 					}
 				});
-				
+
 				$(".tab_showcase .gtype_boxes").append(GearTypeBox);
 			});
 			$(".tab_showcase .gtype_boxes").append( $("<div/>").addClass("clear") );
 		},
-		
+
 		checkModStat :function(shipBox, apiStat, statCode, modIndex, shipObj){
 			var minStat = shipObj.master()[ apiStat ][0];
 			var maxStat = shipObj.master()[ apiStat ][1];
@@ -292,7 +317,7 @@
 				$(".ship_mod_"+statCode, shipBox).html( maxStat - (minStat+modStat) );
 			}
 		}
-		
+
 	};
-	
+
 })();

--- a/src/pages/strategy/tabs/showcase/showcase.js
+++ b/src/pages/strategy/tabs/showcase/showcase.js
@@ -184,6 +184,30 @@
 			}
 		},
 
+        displayExportResult: function (result) {
+            if (!!result.url) {
+                $(".exportResults").append(
+                    $("<div></div>").html("Uploaded to ").append(
+                        $("<a></a>")
+                            .html("Imgur")
+                            .attr("target", "_blank")
+                            .attr("href", result.url)
+                    )
+                );
+            } else if (!!result.downloadId) {
+                $(".exportResults").append(
+                    $("<div></div>").html("Saved to ").append(
+                        $("<a></a>")
+                            .html(result.filename)
+                            .click(function () {
+                                chrome.downloads.show(result.downloadId);
+                                return false;
+                            })
+                    )
+                );
+            }
+        },
+
 		/* EXECUTE
 		Places data onto the interface
 		---------------------------------*/
@@ -196,9 +220,9 @@
                     return;
                 $(this).addClass("disabled");
                 var exporter = new ShowcaseExporter();
-                var self = this;
-                exporter.complete = function () {
-                    $(self).removeClass("disabled");
+                exporter.complete = function (data) {
+                	self.displayExportResult(data);
+                    $("#exportShips").removeClass("disabled");
                 };
                 exporter.exportShips();
             });
@@ -208,9 +232,9 @@
                     return;
                 $(this).addClass("disabled");
                 var exporter = new ShowcaseExporter();
-                var self = this;
-                exporter.complete = function () {
-                    $(self).removeClass("disabled");
+                exporter.complete = function (data) {
+                    self.displayExportResult(data);
+                    $("#exportEquipment").removeClass("disabled");
                 };
                 exporter.exportEquip();
             });


### PR DESCRIPTION
Two new buttons inside showcase tab. http://imgur.com/a/67gxg

Export are made in "download only" mode, because i am not sure that chrome will be ok about long data url. Though forcing it to use screenshot setting (imgur\download\new tab) or adding new one into options shouldn't be a big problem.

Would be really glad if someone could:
1. review code and point places that i should change (i am more like php developer and scopes in js makes me crasy)
2. test equip export. i am not even 1yo teitoku so i don't have a lot of rare stuff.