### PR TITLE
Provide an option of disabling special quest adjustment

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -72,6 +72,11 @@
 				"type": "check"
 			},
 			{
+				"id": "spCounterAdjust",
+				"name": "SettingsSpecialCounterAdjust",
+				"type": "check"
+			},
+			{
 				"id": "updateNotification",
 				"name": "SettingsUpdateNotification",
 				"type": "radio",

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -27,6 +27,7 @@ Retreives when needed to apply on components
 				devOnlyPages		: false,
 				forceDMMLogin		: false,
 				apiRecorder			: false,
+				spCounterAdjust     : true,
 				updateNotification	: 2,
 
 				showCatBombs		: true,

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -1191,21 +1191,25 @@ Used by SortieManager
 								break;
 							case 15:	// 15 = AP
 								console.log("You sunk a AP");
-								sunkApCnt += 1;
+								if (! ConfigManager.spCounterAdjust ) {
+									KC3QuestManager.get(218).increment();
+									KC3QuestManager.get(212).increment();
+								} else {
+									sunkApCnt += 1;
+								}
 								KC3QuestManager.get(213).increment();
 								KC3QuestManager.get(221).increment();
 								break;
 						}
 					}
-					
+
 				}
 			}
-			if(sunkApCnt > 0){
+			if(ConfigManager.spCounterAdjust && sunkApCnt > 0){
 				// Bd6 must inc first than Bd5 as its id smaller :)
 				KC3QuestManager.get(212).increment(0, sunkApCnt);
 				KC3QuestManager.get(218).increment(0, sunkApCnt);
 			}
-			
 			// Save enemy deck name for encounter
 			var name = resultData.api_enemy_info.api_deck_name;
 			if(KC3SortieManager.onSortie > 0 && !!name){

--- a/src/library/objects/Quest.js
+++ b/src/library/objects/Quest.js
@@ -14,7 +14,7 @@ Quest Type:
 */
 (function(){
 	"use strict";
-	
+
 	window.KC3Quest = function(){
 		this.id = 0;
 		this.type = 0;
@@ -22,7 +22,7 @@ Quest Type:
 		this.progress = 0;
 		this.tracking = false;
 	};
-	
+
 	/* DEFINE
 	Fill object with already-formatted quest data
 	------------------------------------------*/
@@ -33,14 +33,14 @@ Quest Type:
 		if (data.progress) {
 			this.progress = data.progress;
 		} else {
-			this.progress =  0;
+			this.progress =	 0;
 		}
 		if (!this.tracking) {
 			this.tracking = data.tracking;
 		}
 		this.attachMeta();
 	};
-	
+
 	/* DEFINE RAW
 	Fill object with quest data from Raw API response
 	------------------------------------------*/
@@ -50,11 +50,11 @@ Quest Type:
 		this.type = data.api_type;
 		this.progress = data.api_progress_flag;
 		this.attachMeta();
-		
+
 		// Attach temporary raw data for quick reference
 		this.raw = function(){ return data; };
 	};
-	
+
 	/* OUTPUT SHORT
 	Return tracking text to be shown on Panel
 	------------------------------------------*/
@@ -81,7 +81,7 @@ Quest Type:
 		}
 		return "";
 	};
-	
+
 	/* OUTPUT HTML
 	Return tracking text to be shown on Strategy Room
 	------------------------------------------*/
@@ -96,7 +96,7 @@ Quest Type:
 		}
 		return "";
 	};
-	
+
 	/* INCREMENT
 	Add one to tracking progress
 	@param {number} reqNum - index of counter type, mainly for Bw1. Default: 0
@@ -135,7 +135,7 @@ Quest Type:
 			});
 		}
 	};
-	
+
 	/* ISCOMPLETE
 	Return true iff all of the counters are complete
 	------------------------------------------*/
@@ -143,14 +143,14 @@ Quest Type:
 		if (this.tracking) {
 			for (var ctr in this.tracking) {
 				if (this.tracking[ctr][0] <
-				    this.tracking[ctr][1])
+					this.tracking[ctr][1])
 					return false;
 			}
 			return true;
 		}
 		return false;
 	};
-	
+
 	/* ATTACH META
 	Add reference to its Meta data from the built-in JSON files
 	this.meta assigned as function to avoid being included in JSON.stringify
@@ -161,10 +161,10 @@ Quest Type:
 		if(typeof this.meta == "undefined"){
 			// Get data from Meta Manager
 			var MyMeta = KC3Meta.quest( this.id );
-			
+
 			// If we have meta for this quest
 			if(MyMeta){
-				// Attach meta info to this object 
+				// Attach meta info to this object
 				this.meta = function(){ return {
 					available: true,
 					code : MyMeta.code,
@@ -177,7 +177,7 @@ Quest Type:
 					this.tracking = MyMeta.tracking;
 				}
 			}else{
-				// Attach meta info to this object 
+				// Attach meta info to this object
 				this.meta = function(){ return {
 					code : "N/A",
 					name : KC3Meta.term("UntranslatedQuest"),
@@ -186,33 +186,33 @@ Quest Type:
 			}
 		}
 	};
-	
+
 	KC3Quest.prototype.isDaily = function(){
-		return (this.type == 2) 	// Daily Quest
-			|| (this.type == 4) 	// Bd4
+		return (this.type == 2)		// Daily Quest
+			|| (this.type == 4)		// Bd4
 			|| (this.type == 5);	// Bd6
 	};
-	
+
 	KC3Quest.prototype.isWeekly = function(){
 		return this.type == 3;	// Weekly Quest
 	};
-	
+
 	KC3Quest.prototype.isMonthly = function(){
 		return this.type == 6;	// Weekly Quest
 	};
-	
+
 	KC3Quest.prototype.isUnselected = function(){
-		return this.status == 1;	// Unselected 
+		return this.status == 1;	// Unselected
 	};
-	
+
 	KC3Quest.prototype.isSelected = function(){
 		return this.status == 2;	// Selected
 	};
-	
+
 	KC3Quest.prototype.isCompleted = function(){
 		return this.status == 3;	// Completed
 	};
-	
+
 	KC3Quest.prototype.autoAdjustCounter = function(){
 		if(this.tracking){
 			if(this.isCompleted()) {
@@ -237,7 +237,7 @@ Quest Type:
 			}
 		}
 	};
-	
+
 	KC3Quest.prototype.toggleCompletion = function(forceCompleted){
 		if(this.isSelected() || !!forceCompleted){
 			console.info("Force to complete quest:", this.id);
@@ -257,7 +257,7 @@ Quest Type:
 			console.warn("Quest", this.id, "status", this.status, "invalid");
 		}
 	};
-	
+
 	KC3Quest.prototype.getColor = function(){
 		return [
 			"#555555", //0
@@ -271,5 +271,5 @@ Quest Type:
 			"#D75048", //8
 		][(this.id+"").substring(0,1)];
 	};
-	
+
 })();

--- a/src/library/objects/Quest.js
+++ b/src/library/objects/Quest.js
@@ -118,8 +118,6 @@ Quest Type:
 
 		// is selected on progress, or force to be adjusted on shared counter
 		if(this.tracking && (this.isSelected() || !!isAdjustingCounter)){
-			if(typeof reqNum == "undefined"){ reqNum=0; }
-			if(typeof amount == "undefined"){ amount=1; }
 			// passive adjusted never reach completion
 			var maxValue = !!isAdjustingCounter ? this.tracking[reqNum][1] - 1 : this.tracking[reqNum][1];
 			if (this.tracking[reqNum][0] < maxValue) {

--- a/src/library/objects/Quest.js
+++ b/src/library/objects/Quest.js
@@ -103,9 +103,19 @@ Quest Type:
 	@param {number} amount - progress amount to be increased. Default: 1
 	@param isAdjustingCounter - if true, prevent recursively inc on specific quest itself
 	------------------------------------------*/
-	KC3Quest.prototype.increment = function(reqNum, amount, isAdjustingCounter){
+	KC3Quest.prototype.increment = function(reqNum=0, amount=1, isAdjustingCounter=false){
 		var self = this;
 		var isIncreased = false;
+		if (! ConfigManager.spCounterAdjust) {
+			if (this.tracking && this.isSelected()) {
+				if (this.tracking[reqNum][0] + amount <= this.tracking[reqNum][1]) {
+					this.tracking[reqNum][0] += amount;
+				}
+				KC3QuestManager.save();
+			}
+			return;
+		}
+
 		// is selected on progress, or force to be adjusted on shared counter
 		if(this.tracking && (this.isSelected() || !!isAdjustingCounter)){
 			if(typeof reqNum == "undefined"){ reqNum=0; }


### PR DESCRIPTION
- added `ConfigManager.spCounterAdjust`, default to `true`.
- when set `false`, recover old behavior that doesn't try to deal with shared quest counters
- new term added: `SettingsSpecialCounterAdjust`

@KC3Kai/translators see https://github.com/KC3Kai/kc3-translations/pull/379/files for examples. sorry that we don't really have room to explain this option properly, until things like #1468 can be done. so try to make a concise description.