### PR TITLE
png-imgur/ substring(23) doesn't work with PNG

### DIFF
--- a/src/library/objects/Screenshot.js
+++ b/src/library/objects/Screenshot.js
@@ -182,7 +182,7 @@ KCScreenshot.prototype.saveImgur = function(){
 						Accept: 'application/json'
 					},
 					data: {
-						image: self.base64img.substring(23),
+						image: self.base64img.split(',')[1],
 						type: 'base64'
 					},
 					success: function(response){


### PR DESCRIPTION
as found by @DynamicSTOP while developing for showcase exporter in #1792