### PR TITLE
Make it possible to disable idle timer

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -468,7 +468,7 @@
 			{
 				"id" : "alert_idle_start",
 				"name" : "SettingsIdleWarnStartAt",
-				"type" : "long_text",
+				"type" : "number",
 				"options" : { "placeholder" : "SettingsIdleWarnDesc" }
 			}
 		]

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -350,7 +350,10 @@
 				"id" : "ss_directory",
 				"name" : "SettingsSSDirectory",
 				"type" : "long_text",
-				"options" : { "placeholder" : "SettingsSSDirDesc" }
+				"options" : {
+					"placeholder" : "SettingsSSDirDesc",
+					"tooltip" : "SettingsSSDirDesc"
+				}
 			},
 			{
 				"id" : "ss_dppx",
@@ -468,8 +471,14 @@
 			{
 				"id" : "alert_idle_start",
 				"name" : "SettingsIdleWarnStartAt",
-				"type" : "number",
-				"options" : { "placeholder" : "SettingsIdleWarnDesc" }
+				"type" : "small_text",
+				"bound" : {
+					"min" :  0,
+					"type": "Number"
+				},
+				"options" : {
+					"tooltip" : "SettingsIdleWarnDesc"
+				}
 			}
 		]
 	},
@@ -582,7 +591,10 @@
 				"id" : "api_bg_color",
 				"name" : "SettingsBGColor",
 				"type" : "long_text",
-				"options" : { "placeholder" : "SettingsBGColorDesc" }
+				"options" : {
+					"placeholder" : "SettingsBGColorDesc",
+					"tooltip" : "SettingsBGColorDesc"
+				}
 			},
 			{
 				"id" : "api_bg_image",
@@ -594,13 +606,19 @@
 				"id" : "api_bg_size",
 				"name" : "SettingsBGSize",
 				"type" : "long_text",
-				"options" : { "placeholder" : "SettingsBGSizeDesc" }
+				"options" : {
+					"placeholder" : "SettingsBGSizeDesc",
+					"tooltip" : "SettingsBGSizeDesc"
+				}
 			},
 			{
 				"id" : "api_bg_position",
 				"name" : "SettingsBGPosition",
 				"type" : "long_text",
-				"options" : { "placeholder" : "SettingsBGPositionDesc" }
+				"options" : {
+					"placeholder" : "SettingsBGPositionDesc",
+					"tooltip" : "SettingsBGPositionDesc"
+				}
 			},
 			{
 				"id" : "api_gameScale",
@@ -624,7 +642,8 @@
 				"name" : "SettingsSubtitleFont",
 				"type" : "long_text",
 				"options" : {
-					"placeholder" : "SettingsSubtitleFontDesc"
+					"placeholder" : "SettingsSubtitleFontDesc",
+					"tooltip" : "SettingsSubtitleFontDesc"
 				}
 			},
 			{
@@ -726,7 +745,10 @@
 				"name" : "SettingsBGColor",
 				"type" : "long_text",
 				"hide" : 1,
-				"options" : { "placeholder" : "SettingsBGColorDesc" }
+				"options" : {
+					"placeholder" : "SettingsBGColorDesc",
+					"tooltip" : "SettingsBGColorDesc"
+				}
 			},
 			{
 				"id" : "dmm_bg_image",
@@ -740,14 +762,20 @@
 				"name" : "SettingsBGSize",
 				"type" : "long_text",
 				"hide" : 1,
-				"options" : { "placeholder" : "SettingsBGSizeDesc" }
+				"options" : {
+					"placeholder" : "SettingsBGSizeDesc",
+					"tooltip" : "SettingsBGSizeDesc"
+				}
 			},
 			{
 				"id" : "dmm_bg_position",
 				"name" : "SettingsBGPosition",
 				"type" : "long_text",
 				"hide" : 1,
-				"options" : { "placeholder" : "SettingsBGPositionDesc" }
+				"options" : {
+					"placeholder" : "SettingsBGPositionDesc",
+					"tooltip" : "SettingsBGPositionDesc"
+				}
 			}
 		]
 	},
@@ -816,7 +844,10 @@
 				"id" : "pan_bg_color",
 				"name" : "SettingsBGColor",
 				"type" : "long_text",
-				"options" : { "placeholder" : "SettingsBGColorDesc" }
+				"options" : {
+					"placeholder" : "SettingsBGColorDesc",
+					"tooltip" : "SettingsBGColorDesc"
+				}
 			},
 			{
 				"id" : "pan_bg_image",
@@ -828,13 +859,19 @@
 				"id" : "pan_bg_size",
 				"name" : "SettingsBGSize",
 				"type" : "long_text",
-				"options" : { "placeholder" : "SettingsBGSizeDesc" }
+				"options" : {
+					"placeholder" : "SettingsBGSizeDesc",
+					"tooltip" : "SettingsBGSizeDesc"
+				}
 			},
 			{
 				"id" : "pan_bg_position",
 				"name" : "SettingsBGPosition",
 				"type" : "long_text",
-				"options" : { "placeholder" : "SettingsBGPositionDesc" }
+				"options" : {
+					"placeholder" : "SettingsBGPositionDesc",
+					"tooltip" : "SettingsBGPositionDesc"
+				}
 			},
 			{
 				"id" : "pan_opacity",
@@ -852,7 +889,10 @@
 				"id" : "pan_box_bcolor",
 				"name" : "SettingsPanelBoxBackColor",
 				"type" : "long_text",
-				"options" : { "placeholder" : "SettingsBGColorDesc" }
+				"options" : {
+					"placeholder" : "SettingsBGColorDesc",
+					"tooltip" : "SettingsBGColorDesc"
+				}
 			}
 		]
 	},

--- a/src/library/injections/dmm_takeover.js
+++ b/src/library/injections/dmm_takeover.js
@@ -4,17 +4,17 @@
 	var master = {};
 	var meta = {};
 	var quests = {};
-	
+
 	window.DMMCustomizations = {
 		apply: function(response){
 			console.log('Applying DMM customizations...');
-			
+
 			config =  $.extend(true, ConfigManager, response.config);
 			window.ConfigManager = config;
 			master = $.extend(true, KC3Master, response.master);
 			meta = $.extend(true, KC3Meta, response.meta);
 			quests = $.extend(true, KC3QuestManager, response.quests);
-			
+
 			this.windowFocus();
 			this.attachHTML();
 			this.layout();
@@ -23,7 +23,7 @@
 			this.clearOverlayHotKey();
 			this.exitConfirmation();
 			this.screenshotHotkey();
-			
+
 			chrome.runtime.onMessage.addListener(this.subtitlesOverlay());
 			chrome.runtime.onMessage.addListener(this.clearOverlays());
 			chrome.runtime.onMessage.addListener(this.questOverlay());
@@ -32,14 +32,14 @@
 			chrome.runtime.onMessage.addListener(this.getGamescreenOffset());
 			chrome.runtime.onMessage.addListener(this.idleTimer());
 		},
-		
+
 		/* WINDOW KEEP FOCUS, NOT FLASH
 		So we can detect keydown for hotkeys
 		--------------------------------------*/
 		nonFocusSeconds: 0,
 		windowFocus: function(){
 			var self = this;
-			
+
 			// Timer to keep auto-focusing on window every second
 			setInterval(function(){
 				if(self.nonFocusSeconds === 0){
@@ -48,7 +48,7 @@
 					self.nonFocusSeconds--;
 				}
 			}, 1000);
-			
+
 			// Press F7 to stop focusing on window to get time to focus on flash
 			$(document).on("keydown", function(event){
 				if (event.keyCode == 118) {
@@ -56,7 +56,7 @@
 				}
 			});
 		},
-		
+
 		/* CUSTOM HTML TAGS
 		For tags not in DMM but needed by our UI
 		Looking at ReactJS for KC3KaiNi
@@ -64,24 +64,24 @@
 		attachHTML: function(){
 			// Overlay screens
 			var overlays = $("<div>").addClass("overlays").appendTo("#area-game");
-			
+
 			var overlay_quests = $("<div>").addClass("overlay_box overlay_quests");
 			overlays.append(overlay_quests);
-			
+
 			var overlay_markers = $("<div>").addClass("overlay_box overlay_markers");
 			overlays.append(overlay_markers);
-			
+
 			var overlay_subtitles = $("<div>").addClass("overlay_box overlay_subtitles")
 				.append($("<span>"));
 			overlays.append(overlay_subtitles);
-			
+
 			var overlay_idle = $("<div>").addClass("overlay_box overlay_idle")
 				.append($("<span>"));
 			overlays.append(overlay_idle);
-			
+
 			// Clonable Factory
 			var factory = $("<div>").attr("id", "factory").appendTo("body");
-			
+
 			var ol_quest = $("<div>").addClass("overlay ol_quest ol_quest_exist")
 				.append($("<div>").addClass("icon with_tl"))
 				.append($("<div>").addClass("content with_tl")
@@ -91,11 +91,11 @@
 				.append($("<div>").addClass("tracking with_tl"))
 				.append($("<div>").addClass("no_tl hover").text("?"))
 				.appendTo("#factory");
-			
+
 			var ol_quest_empty = $("<div>").addClass("overlay ol_quest ol_quest_empty")
 				.appendTo("#factory");
 		},
-		
+
 		/* DMM PAGE LAYOUT
 		Override layout to only show game frame
 		--------------------------------------*/
@@ -129,7 +129,7 @@
 			});
 			$(document).on("ready", this.resizeGameFrameFinal);
 			$(window).on("load", this.resizeGameFrameFinal);
-			
+
 			var self = this;
 			this.resizeTimer = setInterval(function(){
 				if ($("#game_frame").width() != 800 || $("#game_frame").height() != 480) {
@@ -152,14 +152,14 @@
 			}
 			window.DMMCustomizations.resizeGameFrame();
 		},
-		
+
 		/* BACKGROUND CUSTOMIZATIONS
 		Let users customize background via settings
 		--------------------------------------*/
 		backgrounds: function(){
 			// Top Margin from game frame to window
 			$("#area-game").css("margin-top", config.api_margin+"px");
-			
+
 			// Background
 			if(config.api_bg_image === ""){
 				// Solid color
@@ -173,14 +173,14 @@
 				$("body").css("background-repeat", "no-repeat");
 			}
 		},
-		
+
 		/* SUBTITLE BOX
 		Only prepares the container box for subtitles
 		--------------------------------------*/
 		subtitlePosition: "bottom",
 		subtitleSpace: function(){
 			var self = this;
-			
+
 			if(config.api_subtitles){
 				// Subtitle font customizations
 				$(".overlay_subtitles").css("font-family", config.subtitle_font);
@@ -188,7 +188,7 @@
 				if(config.subtitle_bold){
 					$(".overlay_subtitles").css("font-weight", "bold");
 				}
-				
+
 				// Subtitle display modes
 				switch (config.subtitle_display) {
 					case "bottom":
@@ -221,7 +221,7 @@
 						break;
 					default: break;
 				}
-				
+
 				// Overlay avoids cursor
 				$(".overlay_subtitles span").on("mouseover", function(){
 					switch (config.subtitle_display) {
@@ -244,7 +244,7 @@
 				});
 			}
 		},
-		
+
 		/* SUBTITLES OVERLAY
 		Only prepares the container box for subtitles
 		--------------------------------------*/
@@ -256,7 +256,7 @@
 			return function(request, sender, response){
 				if(request.action != "subtitle") return true;
 				if(!config.api_subtitles) return true;
-				
+
 				// Get subtitle text
 				var subtitleText = false;
 				var quoteIdentifier = "";
@@ -277,11 +277,11 @@
 						break;
 				}
 				subtitleText = meta.quote( quoteIdentifier, quoteVoiceNum );
-				
+
 				// hide first to fading will stop
 				$(".overlay_subtitles").stop(true, true);
 				$(".overlay_subtitles").hide();
-				
+
 				// If subtitle removal timer is ongoing, reset
 				if(self.subtitleVanishTimer){
 					clearTimeout(self.subtitleVanishTimer);
@@ -293,7 +293,7 @@
 				if(!self.subtitleVanishExtraMillisPerChar){
 					self.subtitleVanishExtraMillisPerChar = Number(meta.quote("timing", "extraMillisPerChar")) || 50;
 				}
-				
+
 				// If subtitles available for the voice
 				if(subtitleText){
 					$(".overlay_subtitles span").html(subtitleText);
@@ -322,13 +322,13 @@
 				}
 			};
 		},
-		
+
 		/* QUEST OVERLAYS
 		On-screen translation on quest page
 		--------------------------------------*/
 		questOverlay: function(){
 			var self = this;
-			
+
 			// untranslated quest clickable google translate
 			$(".overlay_quests").on("click", ".no_tl", function(){
 				window.open("https://translate.google.com/#ja/"+config.language+"/"
@@ -336,38 +336,38 @@
 					+"%0A%0A"
 					+encodeURIComponent($(this).data("qdesc")), "_blank");
 			});
-			
+
 			// runtime listener
 			return function(request, sender, response){
 				if(request.action != "questOverlay") return true;
 				if(!config.api_translation && !config.api_tracking) return true;
-				
+
 				quests = $.extend(true, quests, request.KC3QuestManager);
-				
+
 				$.each(request.questlist, function( index, QuestRaw ){
 					if( QuestRaw !=- 1 ){
 						var QuestBox = $("#factory .ol_quest_exist").clone().appendTo(".overlay_quests");
-						
+
 						// Get quest data
 						var QuestData = new KC3Quest();
 						QuestData.define(quests.get( QuestRaw.api_no ));
-						
+
 						// Show meta, title and description
 						if( typeof QuestData.meta().available != "undefined" ){
-							
+
 							if (config.api_translation){
 								$(".name", QuestBox).text( QuestData.meta().name );
 								$(".desc", QuestBox).text( QuestData.meta().desc );
 							}else{
 								$(".content", QuestBox).css({opacity: 0});
 							}
-							
+
 							if(config.api_tracking){
 								$(".tracking", QuestBox).html( QuestData.outputHtml() );
 							}else{
 								$(".tracking", QuestBox).hide();
 							}
-							
+
 							// Special Bw1 case multiple requirements
 							if( QuestRaw.api_no == 214 ){
 								$(".tracking", QuestBox).addClass("small");
@@ -388,7 +388,7 @@
 				response({success:true});
 			};
 		},
-		
+
 		/* CLEAR OVERLAYS
 		Empties or hides current shown or filled overlays
 		--------------------------------------*/
@@ -410,7 +410,7 @@
 				response({success:true});
 			};
 		},
-		
+
 		/* EXIT CONFIRMATION
 		Attach onUnload listener to stop accidental exit
 		--------------------------------------*/
@@ -420,7 +420,7 @@
 				return meta.term("UnwantedExitDMM");
 			};
 		},
-		
+
 		/* GET WINDOW SIZE
 		Used for "Fit Screen" function
 		FitScreen itself is executed in background service
@@ -437,7 +437,7 @@
 				});
 			};
 		},
-		
+
 		/* SCREENSHOT HOTKEY
 		Ask background service to take my selfie
 		--------------------------------------*/
@@ -450,7 +450,7 @@
 				}
 			});
 		},
-		
+
 		/* GET GAMESCREEN OFFSET
 		Used for taking screenshots
 		FitScreen itself is executed in background service
@@ -465,7 +465,7 @@
 				});
 			};
 		},
-		
+
 		/* MAP MARKERS OVERLAY
 		Node markers on screen during sortie
 		--------------------------------------*/
@@ -476,7 +476,7 @@
 				if(request.action != "markersOverlay") return true;
 				if(!config.map_markers) { response({success:false}); return true; }
 				console.log('markers', request);
-				
+
 				var sortieStartDelayMillis = 2800;
 				var markersShowMillis = 5000;
 				var compassLeastShowMillis = 3500;
@@ -538,7 +538,7 @@
 				response({success:true});
 			};
 		},
-		
+
 		/* IDLE TIMER
 		Ask background service to take my selfie
 		--------------------------------------*/
@@ -546,12 +546,12 @@
 			let lastNetworkTime = (new Date()).getTime();
 			let hideIdleScreen = false;
 			let maxIdleScreenOpacity = 0.8;
-			
+
 			let timeIdleStart = ConfigManager.alert_idle_start;
 			// If less than 1000, assume user input was in seconds
 			if (timeIdleStart < 1000) timeIdleStart = timeIdleStart * 1000;
 			let timeIdleMax = timeIdleStart + 100000;
-			
+
 			// Timer that checks idle time and show UI
 			setInterval(function(){
 				let idleMillis = (new Date()).getTime() - lastNetworkTime;
@@ -567,13 +567,13 @@
 					$(".overlay_idle").css({ background: 'radial-gradient(ellipse at center, rgba(0,0,0,'+(opacity/2)+') 0%, rgba(0,0,0,'+opacity+') 100%)' });
 				}
 			}, 1000);
-			
+
 			// Hide on mouse move
 			$(".overlay_idle").on('click', function(){
 				hideIdleScreen = true;
 				$(this).hide();
 			});
-			
+
 			// Receives and remembers the time when a network request was last made
 			return function(request, sender, response){
 				if (!ConfigManager.alert_idle_start) return true;
@@ -584,5 +584,5 @@
 			};
 		}
 	};
-	
+
 })();

--- a/src/library/injections/dmm_takeover.js
+++ b/src/library/injections/dmm_takeover.js
@@ -30,7 +30,12 @@
 			chrome.runtime.onMessage.addListener(this.mapMarkersOverlay());
 			chrome.runtime.onMessage.addListener(this.getWindowSize());
 			chrome.runtime.onMessage.addListener(this.getGamescreenOffset());
-			chrome.runtime.onMessage.addListener(this.idleTimer());
+			if (ConfigManager.alert_idle_start // to exclude falsy values like NaN and 0
+				&& ConfigManager.alert_idle_start > 0) {
+				chrome.runtime.onMessage.addListener(this.idleTimer());
+			} else {
+				console.log("idleTimer canncelled due to config");
+			}
 		},
 
 		/* WINDOW KEEP FOCUS, NOT FLASH
@@ -547,9 +552,9 @@
 			let hideIdleScreen = false;
 			let maxIdleScreenOpacity = 0.8;
 
-			let timeIdleStart = ConfigManager.alert_idle_start;
-			// If less than 1000, assume user input was in seconds
-			if (timeIdleStart < 1000) timeIdleStart = timeIdleStart * 1000;
+			// idle time unit is second
+			let timeIdleStartSec = ConfigManager.alert_idle_start;
+			let timeIdleStart = timeIdleStartSec * 1000;
 			let timeIdleMax = timeIdleStart + 100000;
 
 			// Timer that checks idle time and show UI

--- a/src/library/injections/dmm_takeover.js
+++ b/src/library/injections/dmm_takeover.js
@@ -554,7 +554,7 @@
 
 			// idle time unit is second
 			let timeIdleStartSec = ConfigManager.alert_idle_start;
-			let timeIdleStart = timeIdleStartSec * 1000;
+			let timeIdleStart = Math.floor(timeIdleStartSec * 1000);
 			let timeIdleMax = timeIdleStart + 100000;
 
 			// Timer that checks idle time and show UI

--- a/src/library/injections/dmm_takeover.js
+++ b/src/library/injections/dmm_takeover.js
@@ -30,12 +30,7 @@
 			chrome.runtime.onMessage.addListener(this.mapMarkersOverlay());
 			chrome.runtime.onMessage.addListener(this.getWindowSize());
 			chrome.runtime.onMessage.addListener(this.getGamescreenOffset());
-			if (ConfigManager.alert_idle_start // to exclude falsy values like NaN and 0
-				&& ConfigManager.alert_idle_start > 0) {
-				chrome.runtime.onMessage.addListener(this.idleTimer());
-			} else {
-				console.log("idleTimer canncelled due to config");
-			}
+			chrome.runtime.onMessage.addListener(this.idleTimer());
 		},
 
 		/* WINDOW KEEP FOCUS, NOT FLASH
@@ -581,7 +576,9 @@
 
 			// Receives and remembers the time when a network request was last made
 			return function(request, sender, response){
-				if (!ConfigManager.alert_idle_start) return true;
+				if (!ConfigManager.alert_idle_start // to exclude falsy values like NaN and 0
+					|| ConfigManager.alert_idle_start <= 0)
+					return true;
 				if(request.action != "goodResponses") return true;
 				lastNetworkTime = (new Date()).getTime();
 				hideIdleScreen = false;

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -139,7 +139,7 @@ Retreives when needed to apply on components
 				alert_supply 		: 3,
 				alert_supply_exped 	:true,
 				alert_idle_counter	: 1,
-				alert_idle_start	: -1,
+				alert_idle_start	: 0,
 				
 				alert_taiha			: false,
 				alert_taiha_blur	: false,

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -139,7 +139,7 @@ Retreives when needed to apply on components
 				alert_supply 		: 3,
 				alert_supply_exped 	:true,
 				alert_idle_counter	: 1,
-				alert_idle_start	: 180000,
+				alert_idle_start	: -1,
 				
 				alert_taiha			: false,
 				alert_taiha_blur	: false,

--- a/src/library/objects/SettingsBox.js
+++ b/src/library/objects/SettingsBox.js
@@ -147,7 +147,36 @@ To be dynamically used on the settings page
 		);
 		$(".options", this.element).append( options.label );
 	};
-	
+
+	SettingsBox.prototype.number = function( options ){
+		var self = this;
+		$(".options", this.element).append(
+			$("<input/>")
+			.attr("type", "text")
+			.attr("placeholder", KC3Meta.term( options.placeholder ) )
+			.addClass("number")
+			.prop("disabled", this.disabled)
+			.val( ConfigManager[ this.config ] )
+			.on("change", function(){
+				// Dangerous Settings Change Attempt
+				if(isDangerous($(this).parent().parent(),self.config,$(this).val())) {
+					$(this).val(ConfigManager[self.config]);
+					return false;
+				}
+				ConfigManager.loadIfNecessary();
+
+				let parsed = parseFloat( $(this).val() );
+				$(this).val( parsed );
+
+				ConfigManager[ self.config ] = parsed;
+				ConfigManager.save();
+
+				elementControl($(this).parent().siblings(".note"),'',KC3Meta.term("SettingsErrorNG"));
+			})
+		);
+		$(".options", this.element).append( options.label );
+	};
+
 	SettingsBox.prototype.radio = function( options ){
 		var self = this;
 		var choiceClass = "choices_" + this.config;

--- a/src/library/objects/SettingsBox.js
+++ b/src/library/objects/SettingsBox.js
@@ -11,6 +11,9 @@ To be dynamically used on the settings page
 		this.config = info.id;
 		this.element = $("#factory .settingBox").clone().appendTo("#wrapper .settings");
 		$(".title", this.element).text( KC3Meta.term( info.name ) );
+		if(info.options && info.options.tooltip){
+			$(".title", this.element).attr("title", KC3Meta.term(info.options.tooltip));
+		}
 		this.soundPreview = false;
 		this.bound = $.extend({
 			min:-Infinity,
@@ -48,6 +51,7 @@ To be dynamically used on the settings page
 		$(".options", this.element).append(
 			$("<input/>")
 			.attr("type", "checkbox")
+			.attr("title", KC3Meta.term( (options || {}).tooltip ) )
 			.addClass("checkbox")
 			.prop("disabled", this.disabled)
 			.prop("checked", ConfigManager[ this.config ])
@@ -70,6 +74,7 @@ To be dynamically used on the settings page
 		$(".options", this.element).append(
 			$("<input/>")
 			.attr("type", "text")
+			.attr("title", KC3Meta.term( (options || {}).tooltip ) )
 			.addClass("small_text")
 			.prop("disabled", this.disabled)
 			.val( ConfigManager[ this.config ] )
@@ -130,6 +135,7 @@ To be dynamically used on the settings page
 			$("<input/>")
 			.attr("type", "text")
 			.attr("placeholder", KC3Meta.term( options.placeholder ) )
+			.attr("title", KC3Meta.term( (options || {}).tooltip ) )
 			.addClass("long_text")
 			.prop("disabled", this.disabled)
 			.val( ConfigManager[ this.config ] )
@@ -142,35 +148,6 @@ To be dynamically used on the settings page
 				ConfigManager.loadIfNecessary();
 				ConfigManager[ self.config ] = $(this).val();
 				ConfigManager.save();
-				elementControl($(this).parent().siblings(".note"),'',KC3Meta.term("SettingsErrorNG"));
-			})
-		);
-		$(".options", this.element).append( options.label );
-	};
-
-	SettingsBox.prototype.number = function( options ){
-		var self = this;
-		$(".options", this.element).append(
-			$("<input/>")
-			.attr("type", "text")
-			.attr("placeholder", KC3Meta.term( options.placeholder ) )
-			.addClass("number")
-			.prop("disabled", this.disabled)
-			.val( ConfigManager[ this.config ] )
-			.on("change", function(){
-				// Dangerous Settings Change Attempt
-				if(isDangerous($(this).parent().parent(),self.config,$(this).val())) {
-					$(this).val(ConfigManager[self.config]);
-					return false;
-				}
-				ConfigManager.loadIfNecessary();
-
-				let parsed = parseFloat( $(this).val() );
-				$(this).val( parsed );
-
-				ConfigManager[ self.config ] = parsed;
-				ConfigManager.save();
-
 				elementControl($(this).parent().siblings(".note"),'',KC3Meta.term("SettingsErrorNG"));
 			})
 		);
@@ -229,6 +206,7 @@ To be dynamically used on the settings page
 		var self = this;
 		$(".options", this.element).append(
 			$("<textarea/>")
+				.attr("title", KC3Meta.term( (options || {}).tooltip ) )
 				.addClass("json_text")
 				.prop("disabled", this.disabled)
 				.val( JSON.stringify(ConfigManager[ this.config ]) )
@@ -251,6 +229,7 @@ To be dynamically used on the settings page
 		var self = this;
 		$(".options", this.element).append(
 			$("<textarea/>")
+				.attr("title", KC3Meta.term( (options || {}).tooltip ) )
 				.addClass("huge_text")
 				.prop("disabled", this.disabled)
 				.val( ConfigManager[ this.config ] )
@@ -269,6 +248,7 @@ To be dynamically used on the settings page
 
 		$(".options", this.element).append(
 			$("<select/>")
+				.attr("title", KC3Meta.term( (options || {}).tooltip ) )
 				.addClass("dropdown")
 				.prop("disabled", this.disabled)
 				.on("change", function(){

--- a/src/library/objects/SettingsBox.js
+++ b/src/library/objects/SettingsBox.js
@@ -5,7 +5,7 @@ To be dynamically used on the settings page
 */
 (function(){
 	"use strict";
-	
+
 	window.SettingsBox = function( info ){
 		var self = this;
 		this.config = info.id;
@@ -42,7 +42,7 @@ To be dynamically used on the settings page
 			$(this.element).addClass("dangerous");
 		}
 	};
-	
+
 	SettingsBox.prototype.check = function( options ){
 		var self = this;
 		$(".options", this.element).append(
@@ -64,7 +64,7 @@ To be dynamically used on the settings page
 			})
 		);
 	};
-	
+
 	SettingsBox.prototype.small_text = function( options ){
 		var self = this;
 		$(".options", this.element).append(
@@ -79,7 +79,7 @@ To be dynamically used on the settings page
 					$(this).val(ConfigManager[self.config]);
 					return false;
 				}
-				
+
 				// Invalid Value Attempt
 				var ERRCODE = isInvalid(self.bound,$(this).val());
 				if(!!ERRCODE) {
@@ -101,7 +101,7 @@ To be dynamically used on the settings page
 				ConfigManager[ self.config ] = window[self.bound.type==="Integer"?"Number":self.bound.type]($(this).val());
 				ConfigManager.save();
 				elementControl($(this).parent().siblings(".note"),'',KC3Meta.term("SettingsErrorNG"));
-				
+
 				// If changed volume, test play the alert sound
 				if(self.config == "alert_volume"){
 					if(self.soundPreview){
@@ -109,7 +109,7 @@ To be dynamically used on the settings page
 					}
 					switch(ConfigManager.alert_type){
 						case 1: self.soundPreview = new Audio("../../../../assets/snd/pop.mp3"); break;
-						case 2: self.soundPreview = new Audio(ConfigManager.alert_custom); break; 
+						case 2: self.soundPreview = new Audio(ConfigManager.alert_custom); break;
 						case 3: self.soundPreview = new Audio("../../../../assets/snd/ding.mp3"); break;
 						default: self.soundPreview = false; break;
 					}
@@ -122,8 +122,8 @@ To be dynamically used on the settings page
 		);
 		$(".options", this.element).append( KC3Meta.term( options.label ) );
 	};
-	
-	
+
+
 	SettingsBox.prototype.long_text = function( options ){
 		var self = this;
 		$(".options", this.element).append(
@@ -162,7 +162,7 @@ To be dynamically used on the settings page
 				.html( KC3Meta.term( options.choices[ctr][1] ) )
 			);
 		}
-		
+
 		$("."+choiceClass, this.element).on("click", function(){
 			console.log(this,arguments);
 			$("."+$(this).data("class")).removeClass("active");
@@ -171,7 +171,7 @@ To be dynamically used on the settings page
 			ConfigManager[ self.config ] = $(this).data("value");
 			ConfigManager.save();
 			elementControl($(this).parent().siblings(".note"),'',KC3Meta.term("SettingsErrorNG"));
-			
+
 			// If changed sound type, test play the alert sound
 			if(self.config == "alert_type"){
 				if(self.soundPreview){
@@ -179,7 +179,7 @@ To be dynamically used on the settings page
 				}
 				switch(ConfigManager.alert_type){
 					case 1: self.soundPreview = new Audio("../../../../assets/snd/pop.mp3"); break;
-					case 2: self.soundPreview = new Audio(ConfigManager.alert_custom); break; 
+					case 2: self.soundPreview = new Audio(ConfigManager.alert_custom); break;
 					case 3: self.soundPreview = new Audio("../../../../assets/snd/ding.mp3"); break;
 					default: self.soundPreview = false; break;
 				}
@@ -188,14 +188,14 @@ To be dynamically used on the settings page
 					self.soundPreview.play();
 				}
 			}
-			
+
 			// Refresh page when a language option is clicked
 			if(self.config == "language"){
 				window.location.reload();
 			}
 		});
 	};
-	
+
 	SettingsBox.prototype.json = function( options ){
 		var self = this;
 		$(".options", this.element).append(
@@ -217,7 +217,7 @@ To be dynamically used on the settings page
 				})
 		);
 	};
-	
+
 	SettingsBox.prototype.textarea = function( options ){
 		var self = this;
 		$(".options", this.element).append(
@@ -233,11 +233,11 @@ To be dynamically used on the settings page
 				})
 		);
 	};
-	
+
 	SettingsBox.prototype.dropdown = function( options ){
 		var self = this;
 		var choiceClass = "choices_" + this.config;
-		
+
 		$(".options", this.element).append(
 			$("<select/>")
 				.addClass("dropdown")
@@ -249,7 +249,7 @@ To be dynamically used on the settings page
 					elementControl($(this).parent().siblings(".note"), '', KC3Meta.term("SettingsErrorNG"));
 				})
 		);
-		
+
 		for(var ctr in options.choices){
 			$(".options select", this.element).append(
 				$("<option/>")
@@ -260,13 +260,13 @@ To be dynamically used on the settings page
 			);
 		}
 	};
-	
+
 	function elementControl(ele,colorCSS,msg) {
 		return ele.stop(true, true).css('color',colorCSS).text(msg).show().fadeOut(colorCSS ? 5000 : 2000);
 	}
-	
+
 	function isDangerous(element,key,current) {
-		var 
+		var
 			isDG = $(element).hasClass("dangerous"),
 			isEqPrev = ConfigManager[key] === current,
 			isEqDef  = ConfigManager.defaults()[key] === current;
@@ -299,5 +299,5 @@ To be dynamically used on the settings page
 			default: return 0;
 		}
 	}
-	
+
 })();

--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -184,7 +184,8 @@ body {
 	background:#ffc;
 	padding:0px 2px;
 }
-.settingBox .options .long_text {
+.settingBox .options .long_text,
+.settingBox .options .number {
 	width:430px;
 	height:22px;
 	line-height:22px;
@@ -193,10 +194,12 @@ body {
 	border:0px none;
 	background:transparent;
 }
-.settingBox .options .long_text:hover {
+.settingBox .options .long_text:hover,
+.settingBox .options .number:hover {
 	background:#ffc;
 }
-.settingBox .options .long_text:focus {
+.settingBox .options .long_text:focus,
+.settingBox .options .number:focus {
 	border:1px inset;
 	background:#ffc;
 	padding:0px 2px;

--- a/src/pages/settings/settings.css
+++ b/src/pages/settings/settings.css
@@ -13,6 +13,18 @@ body {
 	display:none;
 }
 
+.ui-tooltip {
+	max-width:500px;
+	padding:2px 5px 3px 6px;
+	border-width:1px !important;
+	border:1px solid #222;
+	box-shadow:0 0 5px 1px #888;
+	color:#575757;
+	background:#fff;
+	font-family:inherit;
+	font-size:12px;
+}
+
 /* ABOUT
 --------------------------*/
 .about {
@@ -184,8 +196,7 @@ body {
 	background:#ffc;
 	padding:0px 2px;
 }
-.settingBox .options .long_text,
-.settingBox .options .number {
+.settingBox .options .long_text {
 	width:430px;
 	height:22px;
 	line-height:22px;
@@ -194,12 +205,10 @@ body {
 	border:0px none;
 	background:transparent;
 }
-.settingBox .options .long_text:hover,
-.settingBox .options .number:hover {
+.settingBox .options .long_text:hover {
 	background:#ffc;
 }
-.settingBox .options .long_text:focus,
-.settingBox .options .number:focus {
+.settingBox .options .long_text:focus {
 	border:1px inset;
 	background:#ffc;
 	padding:0px 2px;

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -6,6 +6,7 @@
 		<link href="../../assets/css/bootstrap.css" rel="stylesheet" type="text/css">
 		<!-- @nonbuildend -->
 		<link href="../../assets/css/global.css" rel="stylesheet" type="text/css">
+		<link href="../../assets/css/jquery-ui.min.css" rel="stylesheet" type="text/css">
 		<link href="settings.css" rel="stylesheet" type="text/css">
 		<title class="i18n">SettingsTitle</title>
 		<link rel="shortcut icon" href="../../assets/img/logo/48.png" type="image/x-icon" />
@@ -61,6 +62,7 @@
 		<script type="text/javascript" src="../../assets/js/global.js"></script>
 		<!-- @nonbuildstart -->
 		<script type="text/javascript" src="../../assets/js/jquery-2.1.3.min.js"></script>
+		<script type="text/javascript" src="../../assets/js/jquery-ui.min.js"></script>
 		<script type="text/javascript" src="../../library/managers/ConfigManager.js"></script>
 		<script type="text/javascript" src="../../library/objects/SettingsBox.js"></script>
 		<!-- @nonbuildend -->

--- a/src/pages/settings/settings.js
+++ b/src/pages/settings/settings.js
@@ -36,6 +36,7 @@
 						  new SettingsBox( response[sctr].contents[cctr] );
 					}
 				}
+				$(".settings").tooltip();
 			}
 		});
 		


### PR DESCRIPTION
I didn't notice this previously, but now I feel the new idle timer is slightly on the annoying side: most of the time I just let the game open and all I need is just to have secretary ship in sight. and new idle timer ruins that by fading out the whole game screen. more importantly there is no way to officially cancel that - perhaps you can set a rather big number but that doesn't sound right to me.

that's all motivation for this PR, changes (pretty much copied from my commit log):

- ~~new setting box type: `number`~~ `small_text` turns out to be a better option
    - ~~most of the code copied from `long_text`~~
    - ~~no verification on field~~
    - value is parsed and written back to UI upon change 
        (btw the input value was never parsed in the original version so one could only hope the input (as a string) is coerced properly to a number)
- no idle timer on a neg/falsy input (off by def)
    - cancel idleTimer when time set to falsy / neg val
    - disabled by default for a less intrusive behavior
    - make it consistent that user always give time in seconds

I wish this can be merged before our winter update for the reason I mention in the very beginning, so sorry for the short reviewing time window.

(Edit: btw I feel `isInvalid` from `SettingsBox.js` is a bit unreadable as we can just simply passing objects as result values instead of doing bitwise tests and that kind of stuff, this could be a future task, but for the purpose of this PR I'm not going to change that)