### PR TITLE
attempt for a smarter auto adjust counter

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -300,11 +300,6 @@
 					"type": "Integer"
 				},
 				"options" : { "label" : "" }
-			},
-			{
-				"id": "spCounterAdjust",
-				"name": "SettingsSpecialCounterAdjust",
-				"type": "check"
 			}
 		]
 	},

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -27,7 +27,6 @@ Retreives when needed to apply on components
 				devOnlyPages		: false,
 				forceDMMLogin		: false,
 				apiRecorder			: false,
-				spCounterAdjust     : true,
 				updateNotification	: 2,
 
 				showCatBombs		: true,

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -1192,10 +1192,6 @@ Used by SortieManager
 							case 15:	// 15 = AP
 								console.log("You sunk a AP");
 								sunkApCnt += 1;
-								if (! ConfigManager.spCounterAdjust ) {
-									KC3QuestManager.get(218).increment();
-									KC3QuestManager.get(212).increment();
-								}
 								KC3QuestManager.get(213).increment();
 								KC3QuestManager.get(221).increment();
 								break;
@@ -1204,7 +1200,7 @@ Used by SortieManager
 
 				}
 			}
-			if(ConfigManager.spCounterAdjust && sunkApCnt > 0){
+			if(sunkApCnt > 0){
 				// Bd6 must inc first than Bd5 as its id smaller :)
 				KC3QuestManager.get(212).increment(0, sunkApCnt);
 				KC3QuestManager.get(218).increment(0, sunkApCnt);

--- a/src/library/objects/Quest.js
+++ b/src/library/objects/Quest.js
@@ -231,6 +231,26 @@ known IDs see QuestManager
 	KC3Quest.prototype.autoAdjustCounter = function() {
 		if (! this.tracking || !Array.isArray(this.tracking))
 			return;
+
+		if (this.isCompleted()) {
+			// avoid using "for ... of" syntax for now
+			// which needs babel-polyfill to work
+			// and getting that to work is bs.
+			for (const ind in this.tracking) {
+				const trackingData = this.tracking[ind];
+				if (trackingData[0] !== trackingData[1]) {
+					console.log("Adjusting quest", this.id, "tracking (multi-counter)",
+								"index", ind, "tracking", trackingData[0],
+								"to", trackingData[1],
+								"upon completion.");
+					trackingData[0] = trackingData[1];
+				}
+			}
+			return;
+		}
+
+		// known fact at this point: the actual quest is *not* completed
+
 		// no adjustment for multi-counter quests
 		// an example of this Bw1 (questId = 214)
 		if (this.tracking.length > 1)
@@ -246,71 +266,65 @@ known IDs see QuestManager
 		// so only need to deal with one tracking data, let's give it a name
 		const trackingData = this.tracking[0];
 
-		if(this.isCompleted()) {
-			trackingData[0] = trackingData[1];
+		let currentCount = trackingData[0];
+		let maxCount = parseFloat(trackingData[1]);
+
+		// pFlag: short for Progress Flag,
+		// for incompleted quests:
+		// pFlag = 2: 80% <= progress percentage < 100%
+		// pFlag = 1: 50% <= progress percentage < 80%
+		// pFlag = 0:        progress percentage < 50%
+		let actualPFlag = this.progress;
+		console.assert([0,1,2].indexOf( actualPFlag ) !== -1);
+		let progress =
+			actualPFlag === 0 ? 0.0
+			: actualPFlag === 1 ? 0.5
+			: actualPFlag === 2 ? 0.8
+			: NaN /* unreachable */;
+
+		// we compare actual pFlag and pFlag under our track
+		// to see if they are consistent,
+		// by doing so we not only correct counter falling-behind problems,
+		// but also overshotting ones.
+		let trackedPFlag =
+			/* cur/max >= 4/5 (80%) */
+			5*currentCount >= 4*maxCount ? 2
+		/* cur/max >= 1/2 (50%) */
+			: 2*currentCount >= maxCount ? 1
+			: 0;
+
+		// does the actual correction and announce it
+		let announcedCorrection = newCurrentCount => {
+			console.log("Adjusting quest", this.id, "tracking", currentCount,
+						"to", newCurrentCount , "=", progress * 100 + "%",
+						"of", maxCount);
+			trackingData[0] = newCurrentCount;
+		};
+
+		// it's good if pFlag is consistent
+		// but something is defintely wrong if cur >= max
+		if (trackedPFlag === actualPFlag &&
+			currentCount < maxCount)
 			return;
+
+		if (maxCount >= 5) {
+			announcedCorrection( Math.ceil(maxCount*progress) );
 		} else {
-			// known fact at this point: the actual quest is *not* completed
-			let currentCount = trackingData[0];
-			let maxCount = parseFloat(trackingData[1]);
+			// things special about maxCount < 5 quests is that
+			// it is possible for:
+			//   ceil(maxCount * 0.8), maxCount
+			// to take the same number
 
-			// pFlag: short for Progress Flag,
-			// for incompleted quests:
-			// pFlag = 2: 80% <= progress percentage < 100%
-			// pFlag = 1: 50% <= progress percentage < 80%
-			// pFlag = 0:        progress percentage < 50%
-			let actualPFlag = this.progress;
-			console.assert([0,1,2].indexOf( actualPFlag ) !== -1);
-			let progress =
-				  actualPFlag === 0 ? 0.0
-				: actualPFlag === 1 ? 0.5
-				: actualPFlag === 2 ? 0.8
-				: NaN /* unreachable */;
-
-			// we compare actual pFlag and pFlag under our track
-			// to see if they are consistent,
-			// by doing so we not only correct counter falling-behind problems,
-			// but also overshotting ones.
-			let trackedPFlag =
-				/* cur/max >= 4/5 (80%) */
-				5*currentCount >= 4*maxCount ? 2
-			    /* cur/max >= 1/2 (50%) */
-				: 2*currentCount >= maxCount ? 1
-				: 0;
-
-			// does the actual correction and announce it
-			let announcedCorrection = newCurrentCount => {
-				console.log("Adjusting quest", this.id, "tracking", currentCount,
-							"to", newCurrentCount , "=", progress * 100 + "%",
-							"of", maxCount);
-				trackingData[0] = newCurrentCount;
-			};
-
-			// it's good if pFlag is consistent
-			// but something is defintely wrong if cur >= max
-			if (trackedPFlag === actualPFlag &&
-			    currentCount < maxCount)
+			// so if we end up making new "currentCount" equal to "maxCount",
+			// we must minus 1 from it to prevent it from completion
+			let potentialCount = Math.ceil(maxCount * progress);
+			if (potentialCount === maxCount)
+				potentialCount = maxCount-1;
+			// if what we have figured out is the same as current counter
+			// then it's still fine.
+			if (potentialCount === currentCount)
 				return;
-
-			if (maxCount >= 5) {
-				announcedCorrection( Math.ceil(maxCount*progress) );
-			} else {
-				// things special about maxCount < 5 quests is that
-				// it is possible for:
-				//   ceil(maxCount * 0.8), maxCount
-				// to take the same number
-
-				// so if we end up making new "currentCount" equal to "maxCount",
-				// we must minus 1 from it to prevent it from completion
-				let potentialCount = Math.ceil(maxCount * progress);
-				if (potentialCount === maxCount)
-					potentialCount = maxCount-1;
-				// if what we have figured out is the same as current counter
-				// then it's still fine.
-				if (potentialCount === currentCount)
-					return;
-				announcedCorrection( potentialCount );
-			}
+			announcedCorrection( potentialCount );
 		}
 	};
 

--- a/src/library/objects/Quest.js
+++ b/src/library/objects/Quest.js
@@ -107,15 +107,6 @@ known IDs see QuestManager
 	KC3Quest.prototype.increment = function(reqNum=0, amount=1, isAdjustingCounter=false){
 		var self = this;
 		var isIncreased = false;
-		if (! ConfigManager.spCounterAdjust) {
-			if (this.tracking && this.isSelected()) {
-				if (this.tracking[reqNum][0] + amount <= this.tracking[reqNum][1]) {
-					this.tracking[reqNum][0] += amount;
-				}
-				KC3QuestManager.save();
-			}
-			return;
-		}
 
 		// is selected on progress, or force to be adjusted on shared counter
 		if(this.tracking && (this.isSelected() || !!isAdjustingCounter)){

--- a/src/library/objects/Quest.js
+++ b/src/library/objects/Quest.js
@@ -256,18 +256,19 @@ known IDs see QuestManager
 		if (this.tracking.length > 1)
 			return;
 
-		// no adjustment for F7 and F8:
-		// these two quests have a weird behavior that 1/3 is marked as being 50% completed
-		// so our auto-adjustment won't work for them.
-		if([607, 608].indexOf(this.id) !== -1)
-			return;
-
 		// at this point we can confirm this is a singleton array
 		// so only need to deal with one tracking data, let's give it a name
 		const trackingData = this.tracking[0];
 
 		let currentCount = trackingData[0];
 		let maxCount = parseFloat(trackingData[1]);
+
+		// no adjustment for F7 and F8:
+		// these two quests have a weird behavior that 1/3 is marked as being 50% completed
+		// so our auto-adjustment won't work for them.
+		if([607, 608].indexOf(this.id) > -1
+			&& currentCount > 0 && currentCount < maxCount)
+			return;
 
 		// pFlag: short for Progress Flag,
 		// for incompleted quests:

--- a/src/library/objects/Quest.js
+++ b/src/library/objects/Quest.js
@@ -236,6 +236,12 @@ known IDs see QuestManager
 		if (this.tracking.length > 1)
 			return;
 
+		// no adjustment for F7 and F8:
+		// these two quests have a weird behavior that 1/3 is marked as being 50% completed
+		// so our auto-adjustment won't work for them.
+		if([607, 608].indexOf(this.id) !== -1)
+			return;
+
 		// at this point we can confirm this is a singleton array
 		// so only need to deal with one tracking data, let's give it a name
 		const trackingData = this.tracking[0];

--- a/src/library/objects/Quest.js
+++ b/src/library/objects/Quest.js
@@ -4,13 +4,14 @@ KC3改 Quest Class
 Instantiatable class to represent a single Quest
 Mainly used by QuestManager to store quest information
 
-Quest Type:
-1 = One time
-2 = Daily
-3 = Weekly
-4 = Sink 3 Aircraft Carrier (only on dates ending in -3rd, -7th, or -0th) Bd4
-5 = Sink Transport Fleet (only on dates ending in -2nd or -8th} Bd6
-6 = Monthly
+Known Quest Type (api_type):
+1 = Daily
+2 = Weekly
+3 = Monthly
+4 = Once
+5 = Other (Bd4, Bd6, Quarterly, etc)
+
+known IDs see QuestManager
 */
 (function(){
 	"use strict";
@@ -196,17 +197,23 @@ Quest Type:
 	};
 
 	KC3Quest.prototype.isDaily = function(){
-		return (this.type == 2)		// Daily Quest
-			|| (this.type == 4)		// Bd4
-			|| (this.type == 5);	// Bd6
+		return (this.type == 1)		// Daily Quest
+			|| (this.id == 211)		// Bd4, but type == 5
+			|| (this.id == 212)		// Bd6, but type == 5
+			// Other known cases
+			|| KC3QuestManager._dailyIds.indexOf(this.id) > -1;
 	};
 
 	KC3Quest.prototype.isWeekly = function(){
-		return this.type == 3;	// Weekly Quest
+		return this.type == 2;	// Weekly Quest
 	};
 
 	KC3Quest.prototype.isMonthly = function(){
-		return this.type == 6;	// Weekly Quest
+		return this.type == 3;	// Monthly Quest
+	};
+
+	KC3Quest.prototype.isQuarterly = function(){
+		return KC3QuestManager._quarterlyIds.indexOf(this.id) > -1;
 	};
 
 	KC3Quest.prototype.isUnselected = function(){
@@ -284,7 +291,7 @@ Quest Type:
 			} else {
 				// things special about maxCount < 5 quests is that
 				// it is possible for:
-				//   ceil(maxCount * 0.5), ceil(maxCount * 0.8), maxCount
+				//   ceil(maxCount * 0.8), maxCount
 				// to take the same number
 
 				// so if we end up making new "currentCount" equal to "maxCount",
@@ -311,8 +318,8 @@ Quest Type:
 		} else if(this.isCompleted()){
 			console.info("Re-select quest again:", this.id);
 			this.status = 2;
-			// Reset counter, but do not touch Bw1
-			if(this.tracking && this.id != 214){
+			// Reset counter, but do not touch multi-counter (Bw1 for now)
+			if(Array.isArray(this.tracking) && this.tracking.length === 1){
 				this.tracking[0][0] = 0;
 			}
 			KC3QuestManager.save();

--- a/tests/library/objects/Quest.html
+++ b/tests/library/objects/Quest.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<link rel="stylesheet" href="../../../node_modules/qunitjs/qunit/qunit.css" media="screen">
+	</head>
+	<body>
+		<div id="qunit"></div>
+		<div id="qunit-fixture"></div>
+		<!-- API DATA -->
+		<!-- TEST TOOLS -->
+		<script src="../../../node_modules/jquery/dist/jquery.min.js"></script>
+		<script src="../../../node_modules/qunitjs/qunit/qunit.js"></script>
+		<!-- SCRIPTS -->
+		<script src="../../../src/assets/js/global.js"></script>
+		<script src="../../../src/library/managers/QuestManager.js"></script>
+		<script src="../../../src/library/objects/Quest.js"></script>
+		<script src="Quest.js"></script>
+	</body>
+</html>

--- a/tests/library/objects/Quest.js
+++ b/tests/library/objects/Quest.js
@@ -1,7 +1,6 @@
 QUnit.module("Quest", function(){ localStorage.clear(); });
 
 QUnit.test("Objects > Quest > Counter Auto Adjustment", function( assert ) {
-
 	// having a large start quest id so their never coincide
 	// with the real ones
 	let questCount = 10000;
@@ -100,4 +99,10 @@ QUnit.test("Objects > Quest > Counter Auto Adjustment", function( assert ) {
 			mkOngoingSingleCounterQuest(fromPercent(percent),i,50),
 			i,50, "no adjustment for correct counter: " + i + "/50");
 	}
+
+
+	testQuestAdjust(
+		mkQuest(3,0,[ [10,20], [40,40], [48,60 ] ]),
+		[ [20,20], [40,40], [60,60 ] ],
+		"multi counter quest adjustment upon completion");
 });

--- a/tests/library/objects/Quest.js
+++ b/tests/library/objects/Quest.js
@@ -1,0 +1,101 @@
+QUnit.module("Quest", function(){ localStorage.clear(); });
+
+QUnit.test("Objects > Quest > Counter Auto Adjustment", function( assert ) {
+
+	let questCount = 0;
+
+	function fromPercent(x) {
+		if (x === 0.8)
+			return 2;
+		if (x === 0.5)
+			return 1;
+		if (x === 0)
+			return 0;
+		throw "invalid input";
+	}
+
+	function mkQuest(status,progress,tracking) {
+		const id = questCount;
+		++questCount;
+
+		const q = new KC3Quest();
+		q.id = id;
+		q.status = status;
+		q.progress = progress;
+		q.tracking = tracking;
+		return q;
+	}
+
+	function mkOngoingQuest(progress,tracking) {
+		return mkQuest(2,progress,tracking);
+	}
+
+	function mkOngoingSingleCounterQuest(progress,cur,max) {
+		return mkQuest(2,progress,[[cur,max]]);
+	}
+
+	function eqTrackingData(x,y) {
+		// nothing dangerous to just stringify and compare for tracking data
+		// so we just do that.
+		return JSON.stringify(x) === JSON.stringify(y);
+	}
+
+	function testQuestAdjust(quest, expectedTracking, msg) {
+		// in case same array is used for quest object creation
+		let expected = $.extend(true,[], expectedTracking);
+		quest.autoAdjustCounter();
+		assert.ok( eqTrackingData(quest.tracking, expected),
+				   msg);
+	}
+
+	function testSingleCounterQuestAdjust(quest, expectedCur, expectedMax, msg) {
+		testQuestAdjust(quest,[[expectedCur,expectedMax]],msg);
+	}
+
+	testQuestAdjust(
+		mkOngoingQuest(fromPercent(0.8), [ [0,1], [0,24], [0,6] ]),
+		[ [0,1], [0,24], [0,6] ],
+		"no adjustment for multi-counter");
+
+	testSingleCounterQuestAdjust(
+		mkOngoingSingleCounterQuest(fromPercent(0.8),2,3),
+		2,3, "no adjustment for 2/3");
+
+	testSingleCounterQuestAdjust(
+		mkOngoingSingleCounterQuest(fromPercent(0),2,3),
+		0,3, "correction for overshotting 1");
+
+	testSingleCounterQuestAdjust(
+		mkOngoingSingleCounterQuest(fromPercent(0.5),40,50),
+		25,50, "correction for overshotting 2");
+
+	testSingleCounterQuestAdjust(
+		mkOngoingSingleCounterQuest(fromPercent(0),40,50),
+		0,50, "correction for overshotting 3");
+
+	testSingleCounterQuestAdjust(
+		mkOngoingSingleCounterQuest(fromPercent(0.5),10,50),
+		25,50, "correction for falling behind counter 1");
+
+	testSingleCounterQuestAdjust(
+		mkOngoingSingleCounterQuest(fromPercent(0.8),50,50),
+		40,50, "prevent completion 1");
+
+	testSingleCounterQuestAdjust(
+		mkOngoingSingleCounterQuest(fromPercent(0.8),5,5),
+		4,5, "prevent completion 2");
+
+	testSingleCounterQuestAdjust(
+		mkOngoingSingleCounterQuest(fromPercent(0.8),3,3),
+		2,3, "prevent completion 3");
+
+	for (let i=0; i<50; ++i) {
+		let percent =
+			  i < 25 ? 0
+			: i < 40 ? 0.5
+			: 0.8;
+		testSingleCounterQuestAdjust(
+			mkOngoingSingleCounterQuest(fromPercent(percent),i,50),
+			i,50, "no adjustment for correct counter: " + i + "/50");
+	}
+});

--- a/tests/library/objects/Quest.js
+++ b/tests/library/objects/Quest.js
@@ -2,7 +2,9 @@ QUnit.module("Quest", function(){ localStorage.clear(); });
 
 QUnit.test("Objects > Quest > Counter Auto Adjustment", function( assert ) {
 
-	let questCount = 0;
+	// having a large start quest id so their never coincide
+	// with the real ones
+	let questCount = 10000;
 
 	function fromPercent(x) {
 		if (x === 0.8)


### PR DESCRIPTION
an attempt to solve the quest counter auto adjusting problem once for all:

- detect both falling-behind and overshotting problems and try to correct them
- prevent an known incompleted quest from completion
- some unit tests included

I admit the code is a bit complicated, but in order to have every case covered, I feel it has to be.
please follow comments in code to see if my reasoning is clear to you.

and in case you are too lazy to read the code, I have also written some unit tests to demonstrate the expected behavior of this auto quest counter adjustment.

despite the fact that this PR is ready for reviewing, let's take our time and don't rush for approvals, as quest tracking is one of those important features, I wish this one can be good enough to replace the old one.

after this we may remove the feature introduced by #1802, after all if the quest counter can correct itself in all cases, that feature won't be necessary.
