### PR TITLE
Fix time unit of API handling and refresh panel materials in time

### DIFF
--- a/src/assets/js/global.js
+++ b/src/assets/js/global.js
@@ -372,6 +372,12 @@ String.prototype.hashCode = function() {
 			return ret;
 		}
 	};
+	
+	Number.prototype.valueBetween = function(lfs, rfs) {
+		lfs = lfs === undefined ? -Infinity : lfs;
+		rfs = rfs === undefined ? Infinity : rfs;
+		return Math.min(Math.max(lfs, rfs), Math.max(Math.min(lfs, rfs), this));
+	};
 }).call(Number);
 
 /* JS NATIVE CLASS */

--- a/src/assets/js/global.js
+++ b/src/assets/js/global.js
@@ -161,7 +161,13 @@ Date.safeToUtcTime = function(date) {
  * Convert String to UTC timestamp/1000.
  */
 Date.toUTCseconds = function(dateStr) {
-	return Math.floor(Date.safeToUtcTime(dateStr)/1000);
+	return Math.hrdInt("floor", Date.safeToUtcTime(dateStr), 3, 1);
+};
+/**
+ * Convert String to UTC timestamp/1000/3600.
+ */
+Date.toUTChours = function(dateStr) {
+	return Math.hrdInt("floor", Date.safeToUtcTime(dateStr) / 3.6, 6, 1);
 };
 
 /* BASE */

--- a/src/library/managers/PlayerManager.js
+++ b/src/library/managers/PlayerManager.js
@@ -2,7 +2,7 @@
 KC3改 Player Manager
 
 Manages info about the player and all its holdings
-Includes HQ, Fleet, Docks
+Includes HQ, Fleets, Docks, LandBases
 Does not include Ships and Gears which are managed by other Managers
 */
 (function(){
@@ -77,7 +77,7 @@ Does not include Ships and Gears which are managed by other Managers
 			if(self.bases.length > 4 && data.length < self.bases.length){
 				self.bases.splice(data.length < 4 ? 4 : data.length);
 			}
-			localStorage.bases = JSON.stringify(self.bases);
+			this.saveBases();
 			localStorage.setObject("baseConvertingSlots", self.baseConvertingSlots);
 			return this;
 		},
@@ -199,7 +199,7 @@ Does not include Ships and Gears which are managed by other Managers
 
 		// data array always: [fuel, ammo, steel, bauxite]
 		setResources :function( serverSeconds, absData, deltaData ){
-			// Only for displaying, because accurracy depends on previous values
+			// Only for displaying, because accuracy depends on previous values
 			if(Array.isArray(deltaData) && deltaData.length === 4){
 				this.hq.lastMaterial[0] += deltaData[0] || 0;
 				this.hq.lastMaterial[1] += deltaData[1] || 0;
@@ -230,7 +230,7 @@ Does not include Ships and Gears which are managed by other Managers
 		// To only save consumables to localStorage without DB recording, let dataObj falsy
 		// basic 4 consumables represented in array always: [torch, buckets, devmats, screws]
 		setConsumables :function( serverSeconds, dataObj, deltaArray ){
-			// Only for displaying, because accurracy depends on previous values
+			// Only for displaying, because accuracy depends on previous values
 			if(Array.isArray(deltaArray) && deltaArray.length === 4){
 				this.consumables.torch += deltaArray[0] || 0;
 				this.consumables.buckets += deltaArray[1] || 0;
@@ -397,6 +397,11 @@ Does not include Ships and Gears which are managed by other Managers
 			return this;
 		},
 
+		saveBases :function(){
+			localStorage.bases = JSON.stringify(this.bases);
+			return this;
+		},
+
 		loadBases :function(){
 			if(typeof localStorage.bases != "undefined"){
 				var oldBases = JSON.parse( localStorage.bases );
@@ -416,7 +421,7 @@ Does not include Ships and Gears which are managed by other Managers
 			});
 		},
 
-		fleets_backup :function(){
+		cloneFleets :function(){
 			return this.fleets.map(function(x,i){
 				return x.ships.map(function(s){
 					return new KC3Ship(KC3ShipManager.get(s));

--- a/src/library/managers/PlayerManager.js
+++ b/src/library/managers/PlayerManager.js
@@ -20,6 +20,8 @@ Does not include Ships and Gears which are managed by other Managers
 		buildSlots: 2,
 		combinedFleet: 0,
 		statistics: {},
+		maxResource: 300000,
+		maxConsumable: 3000,
 
 		init :function(){
 			this.hq = new KC3Player();
@@ -205,6 +207,10 @@ Does not include Ships and Gears which are managed by other Managers
 				this.hq.lastMaterial[1] += deltaData[1] || 0;
 				this.hq.lastMaterial[2] += deltaData[2] || 0;
 				this.hq.lastMaterial[3] += deltaData[3] || 0;
+				// Limit resource values between [0, 300000]
+				this.hq.lastMaterial.map((v, i) => {
+					this.hq.lastMaterial[i] = v.valueBetween(0, this.maxResource);
+				});
 				this.hq.save();
 				return this;
 			}
@@ -233,9 +239,13 @@ Does not include Ships and Gears which are managed by other Managers
 			// Only for displaying, because accuracy depends on previous values
 			if(Array.isArray(deltaArray) && deltaArray.length === 4){
 				this.consumables.torch += deltaArray[0] || 0;
+				this.consumables.torch = this.consumables.torch.valueBetween(0, this.maxConsumable);
 				this.consumables.buckets += deltaArray[1] || 0;
+				this.consumables.buckets = this.consumables.buckets.valueBetween(0, this.maxConsumable);
 				this.consumables.devmats += deltaArray[2] || 0;
+				this.consumables.devmats = this.consumables.devmats.valueBetween(0, this.maxConsumable);
 				this.consumables.screws += deltaArray[3] || 0;
+				this.consumables.screws = this.consumables.screws.valueBetween(0, this.maxConsumable);
 				localStorage.consumables = JSON.stringify(this.consumables);
 				return this;
 			}

--- a/src/library/managers/PlayerManager.js
+++ b/src/library/managers/PlayerManager.js
@@ -304,7 +304,7 @@ Does not include Ships and Gears which are managed by other Managers
 			return this;
 		},
 
-		setNewsfeed :function( data, timestamp ){
+		setNewsfeed :function( data, timestamp = Date.now() ){
 			//console.log("newsfeed", data);
 			localStorage.playerNewsFeed = JSON.stringify({ time: timestamp, log: data });
 			// Give up to save into DB, just keep recent 6 logs

--- a/src/library/managers/PlayerManager.js
+++ b/src/library/managers/PlayerManager.js
@@ -44,6 +44,7 @@ Does not include Ships and Gears which are managed by other Managers
 				new KC3LandBase(),
 				new KC3LandBase()
 			];
+			return this;
 		},
 
 		setHQ :function( data ){
@@ -55,6 +56,7 @@ Does not include Ships and Gears which are managed by other Managers
 			// Update player with new data
 			this.hq.update( data );
 			this.hq.save();
+			return this;
 		},
 
 		setFleets :function( data ){
@@ -63,6 +65,7 @@ Does not include Ships and Gears which are managed by other Managers
 				self.fleets[i].update( data[i] || {} );
 			});
 			this.saveFleets();
+			return this;
 		},
 
 		setBases :function( data ){
@@ -76,6 +79,7 @@ Does not include Ships and Gears which are managed by other Managers
 			}
 			localStorage.bases = JSON.stringify(self.bases);
 			localStorage.setObject("baseConvertingSlots", self.baseConvertingSlots);
+			return this;
 		},
 
 		setBasesOnWorldMap :function( data ){
@@ -118,6 +122,7 @@ Does not include Ships and Gears which are managed by other Managers
 				}
 			}
 			localStorage.setObject("baseConvertingSlots", this.baseConvertingSlots);
+			return this;
 		},
 
 		setRepairDocks :function( data ){
@@ -150,6 +155,7 @@ Does not include Ships and Gears which are managed by other Managers
 			// it record the most recent docking ships
 			// whenever a docking event comes
 			localStorage.dockingShips = JSON.stringify(dockingShips);
+			return this;
 		},
 
 		// cached docking ships' status
@@ -188,40 +194,69 @@ Does not include Ships and Gears which are managed by other Managers
 					KC3TimerManager.build( kdock.api_id ).deactivate();
 				}
 			});
+			return this;
 		},
 
-		setResources :function( data, stime ){
-			if(typeof localStorage.lastResource == "undefined"){ localStorage.lastResource = 0; }
-			var ResourceHour = Math.floor(stime/3600);
-			this.hq.lastMaterial = data;
-			if(ResourceHour == localStorage.lastResource){ return false; }
-			localStorage.lastResource = ResourceHour;
-			KC3Database.Resource({
-				rsc1 : data[0],
-				rsc2 : data[1],
-				rsc3 : data[2],
-				rsc4 : data[3],
-				hour : ResourceHour
-			});
-		},
-
-		setConsumables :function( data, stime ){
-			$.extend(this.consumables, data);
-			localStorage.consumables = JSON.stringify(this.consumables);
-
-			if(typeof localStorage.lastUseitem == "undefined"){ localStorage.lastUseitem = 0; }
-			var ResourceHour = Math.floor(stime/3600);
-			if(ResourceHour == localStorage.lastUseitem || Object.keys(data).length < 4){
-				return false;
+		// data array always: [fuel, ammo, steel, bauxite]
+		setResources :function( serverSeconds, absData, deltaData ){
+			// Only for displaying, because accurracy depends on previous values
+			if(Array.isArray(deltaData) && deltaData.length === 4){
+				this.hq.lastMaterial[0] += deltaData[0] || 0;
+				this.hq.lastMaterial[1] += deltaData[1] || 0;
+				this.hq.lastMaterial[2] += deltaData[2] || 0;
+				this.hq.lastMaterial[3] += deltaData[3] || 0;
+				this.hq.save();
+				return this;
 			}
-			localStorage.lastUseitem = ResourceHour;
-			KC3Database.Useitem({
-				torch : data.torch,
-				screw : data.screws,
-				bucket : data.buckets,
-				devmat : data.devmats,
-				hour : ResourceHour
+			// Sync with API absolute values and save to storage
+			if(!Array.isArray(absData) || absData.length !== 4){ return this; }
+			this.hq.lastMaterial = absData;
+			this.hq.save();
+			// Record values of recent hour if necessary
+			if(typeof localStorage.lastResource == "undefined"){ localStorage.lastResource = 0; }
+			var currentHour = Math.floor(serverSeconds / 3600);
+			if(currentHour == localStorage.lastResource){ return this; }
+			localStorage.lastResource = currentHour;
+			KC3Database.Resource({
+				rsc1 : absData[0],
+				rsc2 : absData[1],
+				rsc3 : absData[2],
+				rsc4 : absData[3],
+				hour : currentHour
 			});
+			return this;
+		},
+
+		// To only save consumables to localStorage without DB recording, let dataObj falsy
+		// basic 4 consumables represented in array always: [torch, buckets, devmats, screws]
+		setConsumables :function( serverSeconds, dataObj, deltaArray ){
+			// Only for displaying, because accurracy depends on previous values
+			if(Array.isArray(deltaArray) && deltaArray.length === 4){
+				this.consumables.torch += deltaArray[0] || 0;
+				this.consumables.buckets += deltaArray[1] || 0;
+				this.consumables.devmats += deltaArray[2] || 0;
+				this.consumables.screws += deltaArray[3] || 0;
+				localStorage.consumables = JSON.stringify(this.consumables);
+				return this;
+			}
+			// Merge and save consumables data to storage
+			$.extend(this.consumables, dataObj);
+			localStorage.consumables = JSON.stringify(this.consumables);
+			// Record values of recent hour if necessary
+			if(typeof localStorage.lastUseitem == "undefined"){ localStorage.lastUseitem = 0; }
+			var currentHour = Math.floor(serverSeconds / 3600);
+			if(currentHour == localStorage.lastUseitem || !dataObj || Object.keys(dataObj).length < 4){
+				return this;
+			}
+			localStorage.lastUseitem = currentHour;
+			KC3Database.Useitem({
+				torch : this.consumables.torch,
+				bucket : this.consumables.buckets,
+				devmat : this.consumables.devmats,
+				screw : this.consumables.screws,
+				hour : currentHour
+			});
+			return this;
 		},
 
 		setStatistics :function( data ){
@@ -256,13 +291,14 @@ Does not include Ships and Gears which are managed by other Managers
 			}
 			// console.log("rates", newStatistics.sortie.rate, newStatistics.pvp.rate, newStatistics.exped.rate);
 			localStorage.statistics = JSON.stringify(newStatistics);
+			return this;
 		},
 
-		setNewsfeed :function( data, stime ){
+		setNewsfeed :function( data, timestamp ){
 			//console.log("newsfeed", data);
-			localStorage.playerNewsFeed = JSON.stringify({ time: stime, log: data });
+			localStorage.playerNewsFeed = JSON.stringify({ time: timestamp, log: data });
 			// Give up to save into DB, just keep recent 6 logs
-			return;
+			return this;
 			// No way to track which logs are already recorded,
 			// because no cursor/timestamp/state could be found in API
 			/*
@@ -271,7 +307,7 @@ Does not include Ships and Gears which are managed by other Managers
 					KC3Database.Newsfeed({
 						type: element.api_type,
 						message: element.api_message,
-						time: stime
+						time: timestamp
 					});
 				}
 			});
@@ -289,18 +325,17 @@ Does not include Ships and Gears which are managed by other Managers
 			};
 		},
 
-		portRefresh :function( data ){
-			var
-				self      = this,
-				// get server time (as usual)
-				ctime     = Math.hrdInt("floor",(new Date(data.time)).getTime(),3,1);
+		// Refresh last home port time and material regeneration
+		// Partially same effects with `setResources`
+		portRefresh :function( serverSeconds, absMaterial ){
+			var self = this;
 
 			if(!(this.hq.lastPortTime && this.hq.lastMaterial)) {
 				if(!this.hq.lastPortTime)
-					this.hq.lastPortTime = ctime;
+					this.hq.lastPortTime = serverSeconds;
 				if(!this.hq.lastMaterial)
-					this.hq.lastMaterial = data.matAbs;
-				return false;
+					this.hq.lastMaterial = absMaterial;
+				return this;
 			}
 
 			this.fleets.forEach(function(fleet){ fleet.checkAkashi(); });
@@ -313,7 +348,7 @@ Does not include Ships and Gears which are managed by other Managers
 					// find next multiplier of 3 from last time
 					start: Math.hrdInt("ceil" ,this.hq.lastPortTime,Math.log10(3 * 60),1),
 					// find last multiplier of 3 that does not exceeds the current time
-					end  : Math.hrdInt("floor",ctime,Math.log10(3 * 60),1),
+					end  : Math.hrdInt("floor",serverSeconds,Math.log10(3 * 60),1),
 				},
 				// get regeneration ticks
 				regenRate = Math.max(0,regenTime.end - regenTime.start + 1),
@@ -321,26 +356,28 @@ Does not include Ships and Gears which are managed by other Managers
 				regenVal  = [3,3,3,1]
 					.map(function(x){return regenRate * x;})
 					.map(function(x,i){return Math.max(0,Math.min(x,regenCap - self.hq.lastMaterial[i]));});
-			console.log(this.hq.lastPortTime,regenTime,ctime);
+			console.log(this.hq.lastPortTime,regenTime,serverSeconds);
 			// Check whether a server time is supplied, or keep the last refresh time.
-			this.hq.lastPortTime = (data.time && ctime) || (this.hq.lastPortTime);
+			this.hq.lastPortTime = serverSeconds || this.hq.lastPortTime;
 			console.info("regen" ,regenVal);
 			console.info.apply(console,["pRegenMat"].concat(this.hq.lastMaterial));
 			console.info.apply(console,["actualMat"].concat((this.hq.lastMaterial || []).map(function(x,i){
 				return (x || 0) + regenVal[i];
 			})));
 			KC3Database.Naverall({
-				hour:Math.hrdInt('floor',ctime/3.6,3,1),
+				hour:Math.hrdInt('floor',serverSeconds/3.6,3,1),
 				type:'regen',
 				data:regenVal.concat([0,0,0,0])
 			});
-			this.hq.lastMaterial = data.matAbs || this.hq.lastMaterial;
+			this.hq.lastMaterial = absMaterial || this.hq.lastMaterial;
 
 			this.hq.save();
+			return this;
 		},
 
 		saveFleets :function(){
 			localStorage.fleets = JSON.stringify(this.fleets);
+			return this;
 		},
 
 		loadFleets :function(){
@@ -350,12 +387,14 @@ Does not include Ships and Gears which are managed by other Managers
 					return (new KC3Fleet()).defineFormatted(oldFleets[i]);
 				});
 			}
+			return this;
 		},
 
 		loadConsumables :function(){
 			if(typeof localStorage.consumables != "undefined"){
 				this.consumables =  $.extend(this.consumables, JSON.parse(localStorage.consumables));
 			}
+			return this;
 		},
 
 		loadBases :function(){
@@ -368,6 +407,7 @@ Does not include Ships and Gears which are managed by other Managers
 			if(typeof localStorage.baseConvertingSlots != "undefined"){
 				this.baseConvertingSlots = localStorage.getObject("baseConvertingSlots");
 			}
+			return this;
 		},
 
 		isBasesSupplied :function(){

--- a/src/library/managers/ShipManager.js
+++ b/src/library/managers/ShipManager.js
@@ -131,7 +131,7 @@ Saves and loads list to and from localStorage
 				rs[2] = -df[2];
 				// Store Difference to Database
 				KC3Database.Naverall({
-					hour: Math.hrdInt('floor', Date.now()/3.6 ,6,1),
+					hour: Date.toUTChours(),
 					type: 'akashi' + sp.masterId,
 					data: rs
 				});

--- a/src/library/managers/SortieManager.js
+++ b/src/library/managers/SortieManager.js
@@ -93,7 +93,7 @@ Xxxxxxx
 		},
 		
 		snapshotFleetState :function(){
-			PlayerManager.hq.lastSortie = PlayerManager.fleets_backup();
+			PlayerManager.hq.lastSortie = PlayerManager.cloneFleets();
 			focusedFleet = (PlayerManager.combinedFleet&&this.fleetSent===1) ? [0,1] : [this.fleetSent-1];
 			PlayerManager.hq.save();
 		},

--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -215,7 +215,6 @@ Previously known as "Reactor"
 				exp: response.api_data.api_experience[0]
 			});
 			
-			//PlayerManager.consumables.fcoin = response.api_data.api_fcoin;
 			PlayerManager.fleetCount = response.api_data.api_deck;
 			PlayerManager.repairSlots = response.api_data.api_ndoc;
 			PlayerManager.buildSlots = response.api_data.api_kdoc;
@@ -244,13 +243,6 @@ Previously known as "Reactor"
 			KC3Network.trigger("Consumables");
 			KC3Network.trigger("ShipSlots");
 			KC3Network.trigger("GearSlots");
-
-			/*chrome.runtime.sendMessage({
-				game:"kancolle",
-				type:"game",
-				action:"record_overlay",
-				record: response.api_data
-			}, function(response){});*/
 		},
 		
 		"api_get_member/material":function(params, response, headers){
@@ -353,36 +345,18 @@ Previously known as "Reactor"
 			PlayerManager.setFleets( response.api_data.api_deck_data );
 			KC3Network.trigger("Timers");
 			KC3Network.trigger("Fleet");
-			/*
-				"api_data":{
-					"api_ship_data":[
-						{"api_id":130,"api_sortno":150,"api_ship_id":150,"api_lv":75,"api_exp":[319098,11902,0],"api_nowhp":83,"api_maxhp":83,"api_leng":3,"api_slot":[6032,6033,6034,-1,-1],"api_onslot":[3,3,3,3,0],"api_slot_ex":0,"api_kyouka":[7,0,16,7,0],"api_backs":7,"api_fuel":100,"api_bull":125,"api_slotnum":4,"api_ndock_time":0,"api_ndock_item":[0,0],"api_srate":1,"api_cond":40,"api_karyoku":[103,98],"api_raisou":[0,0],"api_taiku":[59,82],"api_soukou":[79,95],"api_kaihi":[63,72],"api_taisen":[0,0],"api_sakuteki":[45,49],"api_lucky":[13,79],"api_locked":1,"api_locked_equip":0}
-					],
-					"api_deck_data":[
-						{"api_member_id":16015130,"api_id":1,"api_name":"\u30e1\u30a4\u30f3\u8266\u968a","api_name_id":"123990924","api_mission":[0,0,0,0],"api_flagship":"0","api_ship":[130,403,223,1723,141,3349]},
-						{"api_member_id":16015130,"api_id":2,"api_name":"\u5bfe\u6f5c\u8266\u968a","api_name_id":"129857413","api_mission":[1,38,1454999143020,0],"api_flagship":"0","api_ship":[1,2,22,2112,1122,249]},
-						{"api_member_id":16015130,"api_id":3,"api_name":"\u99c6\u9010\u8266\u968a","api_name_id":"129857436","api_mission":[1,37,1454998550795,0],"api_flagship":"0","api_ship":[232,1439,247,1119,9,28]},
-						{"api_member_id":16015130,"api_id":4,"api_name":"\u7b2c4\u8266\u968a","api_name_id":"","api_mission":[1,6,1454993446222,0],"api_flagship":"0","api_ship":[137,807,2576,2564,-1,-1]}
-					],
-					"api_slot_data":{
-							"api_slottype1":[120,1635,1639,1982,2002,3741,2177,2032,5030,4206,4291],
-							"api_slottype2":[205,443,2509,2833,323,602,3848,57,161,163,165,303,428,491,848,1127,4326,4595,5273,524,810,1032,5954,4407,5068],
-							"api_slottype3":[559,619,663,678,826,5275,103,390,448,474,475,691,2508,2832,3099,3102,4123],
-							"api_slottype4":[75,142,407,915,1011,73,186,207,532,620,629,900,1058,2466,3040,3383,449,692,3983,3997,2464,3122,3896,3849],"api_slottype5":[26,82,119,146,174,179,232,290,298,388,519,958,1469,3049,3733,3782,917,1013,2131,1870],"api_slottype6":[1159,1192,1196,1530,1573,2780,3277,3298,3601,3749,5943,3251,3305],"api_slottype7":[487,646,1574,2195,3240,3246,3252,3264,3268,3308,3687,3750,5829,1572,1610],"api_slottype8":[3226,3244,3269,3303,3310,3356,1158,3217,3243,3245,3249,3302,3602,1531,3241,3304,2498,3023],"api_slottype9":[3399],"api_slottype10":[43,1156,1935,2510,2837,2840,3278,3684,3688,3697,3850,3944,4058,4287,4341,4459],"api_slottype11":[1316,2280,2779,3239,3263,3267,3307,3991,4057],"api_slottype12":[5608],"api_slottype13":[916,1033,1871,2132,5205,6013],"api_slottype14":[683,4241,4286,3904,5387],"api_slottype15":[391,705,744,825,1066,1097,1721,1724,3887,4409,5071,5656,395,3893,4221],"api_slottype16":-1,"api_slottype17":-1,"api_slottype18":[3045,3046,3459],"api_slottype19":[162],"api_slottype20":-1,"api_slottype21":[2440,2674,2966,3090,3895,741,922,2967,3036,3088,3203,3460,4047,4108,5830,2118],"api_slottype22":[189,2283],"api_slottype23":[1,2,215,1108,1613,2041,2499,3025,5564,5602,5613,4371,5048],"api_slottype24":-1,"api_slottype25":-1,"api_slottype26":-1,"api_slottype27":-1,"api_slottype28":[3024],"api_slottype29":[5069],"api_slottype30":[1792,2473,2788,5039,5293,5295,5614,5805],"api_slottype31":-1,"api_slottype32":-1,"api_slottype33":-1,"api_slottype34":[5607],"api_slottype35":-1,"api_slottype36":[2106,4142,5363],"api_slottype37":[2568],"api_slottype38":-1,"api_slottype39":[5366],"api_slottype40":-1,"api_slottype41":-1,"api_slottype42":-1,"api_slottype43":[3371,3372,3373,4372,4373,4871,5072,5910],"api_slottype44":-1
-						}
-					}
-			*/
 		},
 		
 		"api_req_kaisou/open_exslot":function(params, response, headers){
-			var
+			var utcSeconds = Date.toUTCseconds(headers.Date),
 				sid  = parseInt(params.api_id,10),
 				ship = KC3ShipManager.get(sid),
 				mast = ship.master();
 			if(PlayerManager.consumables.reinforceExpansion > 0){
 				PlayerManager.consumables.reinforceExpansion -= 1;
+				PlayerManager.setConsumables(utcSeconds);
 			}
-			console.log("Extra Slot unlocked for",sid,ship.name());
+			console.log("Extra Slot unlocked for", sid, ship.name());
 			KC3Network.trigger("Consumables");
 		},
 		
@@ -391,15 +365,12 @@ Previously known as "Reactor"
 				sid      = parseInt(params.api_id,10),
 				ship     = KC3ShipManager.get(sid),
 				mast     = ship.master(),
-				
 				ship_obj = response.api_data;
-			
-			console.log("Perform Marriage ",sid,ship.name());
+			console.log("Perform Marriage", sid, ship.name());
 		},
 		
 		"api_req_kaisou/remodeling":function(params, response, headers){
-			var
-				utcHour  = Date.toUTChours(headers.Date),
+			var utcHour  = Date.toUTChours(headers.Date),
 				ship     = KC3ShipManager.get(params.api_id),
 				master   = ship.master(),
 				// NOTE: api_afterfuel is steel usage!
@@ -443,7 +414,6 @@ Previously known as "Reactor"
 				type: "remodel" + master.api_id,
 				data: material
 			});
-			// Refresh panel display
 			PlayerManager.setResources(utcHour * 3600, null, material.slice(0, 4));
 			KC3Network.trigger("Consumables");
 		},
@@ -590,7 +560,6 @@ Previously known as "Reactor"
 			KC3QuestManager.get(606).increment(); // F2: Daily Construction 1
 			KC3QuestManager.get(608).increment(); // F4: Daily Construction 2
 			KC3Network.trigger("Quests");
-			// Refresh panel display
 			PlayerManager.setResources(utcHour * 3600, null,
 				this.shipConstruction.resources.slice(0, 4).map(v=>-v));
 			KC3Network.trigger("Consumables");
@@ -634,16 +603,17 @@ Previously known as "Reactor"
 		/* Instant-Torch a construction
 		-------------------------------------------------------*/
 		"api_req_kousyou/createship_speedchange":function(params, response, headers){
+			var utcSeconds = Date.toUTCseconds(headers.Date);
 			var delta = 1;
 			if( KC3TimerManager.build( params.api_kdock_id ).lsc ){
-				delta=10;
+				delta = 10;
 			}
 			PlayerManager.consumables.torch -= delta;
+			PlayerManager.setConsumables(utcSeconds);
 			KC3Database.Naverall({
 				data: [0,0,0,0,-delta,0,0,0]
 			},"crship"+params.api_kdock_id);
-			KC3TimerManager.build(params.api_kdock_id).activate(
-				Date.now());
+			KC3TimerManager.build(params.api_kdock_id).activate(Date.now());
 			KC3Network.trigger("Consumables");
 			KC3Network.trigger("Timers");
 		},
@@ -1187,7 +1157,7 @@ Previously known as "Reactor"
 					base.name = decodeURIComponent(params.api_name);
 				}
 			});
-			localStorage.bases = JSON.stringify(PlayerManager.bases);
+			PlayerManager.saveBases();
 			KC3Network.trigger("Lbas");
 		},
 		
@@ -1203,7 +1173,7 @@ Previously known as "Reactor"
 					});
 				}
 			});
-			localStorage.bases = JSON.stringify(PlayerManager.bases);
+			PlayerManager.saveBases();
 			KC3Network.trigger("Lbas");
 		},
 		
@@ -1223,7 +1193,7 @@ Previously known as "Reactor"
 					});
 				}
 			});
-			localStorage.bases = JSON.stringify(PlayerManager.bases);
+			PlayerManager.saveBases();
 			// Record material consuming. Yes, set plane use your bauxite :)
 			// Known formula:
 			//var landSlot = KC3GearManager.landBaseReconnType2Ids.indexOf(planeMaster.api_type[2])>-1 ?
@@ -1253,7 +1223,7 @@ Previously known as "Reactor"
 					});
 				}
 			});
-			localStorage.bases = JSON.stringify(PlayerManager.bases);
+			PlayerManager.saveBases();
 			// Record material consuming, using a new type called: lbas
 			var utcHour = Date.toUTChours(headers.Date);
 			var consumedFuel = response.api_data.api_after_fuel - PlayerManager.hq.lastMaterial[0],
@@ -1359,19 +1329,20 @@ Previously known as "Reactor"
 		/* Start repair
 		-------------------------------------------------------*/
 		"api_req_nyukyo/start":function(params, response, headers){
-			var
-				ship_id    = parseInt( params.api_ship_id , 10),
+			var utcSeconds = Date.toUTCseconds(headers.Date),
+				shipId     = parseInt( params.api_ship_id , 10),
 				bucket     = parseInt( params.api_highspeed , 10),
 				nDockNum   = parseInt( params.api_ndock_id , 10),
-				shipData   = KC3ShipManager.get( ship_id );
+				shipData   = KC3ShipManager.get( shipId );
 			
 			if(bucket==1){
-				PlayerManager.consumables.buckets--;
+				PlayerManager.consumables.buckets -= 1;
+				PlayerManager.setConsumables(utcSeconds);
 				
 				// If ship is still is the list being repaired, remove Her
-				var HerRepairIndex = PlayerManager.repairShips.indexOf( ship_id );
-				if(HerRepairIndex  > -1){
-					PlayerManager.repairShips.splice(HerRepairIndex, 1);
+				var herRepairIndex = PlayerManager.repairShips.indexOf( shipId );
+				if(herRepairIndex  > -1){
+					PlayerManager.repairShips.splice(herRepairIndex, 1);
 				}
 				
 				KC3Database.Naverall({
@@ -1395,11 +1366,13 @@ Previously known as "Reactor"
 		/* Use bucket
 		-------------------------------------------------------*/
 		"api_req_nyukyo/speedchange":function(params, response, headers){
-			PlayerManager.consumables.buckets--;
+			var utcSeconds = Date.toUTCseconds(headers.Date);
+			PlayerManager.consumables.buckets -= 1;
+			PlayerManager.setConsumables(utcSeconds);
 			// If ship is still is the list being repaired, remove Her
 			var
-				ship_id  = PlayerManager.repairShips[ params.api_ndock_id ],
-				shipData = KC3ShipManager.get(ship_id);
+				shipId   = PlayerManager.repairShips[ params.api_ndock_id ],
+				shipData = KC3ShipManager.get(shipId);
 			PlayerManager.repairShips.splice(params.api_ndock_id, 1);
 			
 			KC3Database.Naverall({
@@ -1495,8 +1468,7 @@ Previously known as "Reactor"
 				deck     = parseInt(params.api_deck_id, 10),
 				timerRef = KC3TimerManager._exped[ deck-2 ],
 				shipList = PlayerManager.fleets[deck - 1].ships.slice(0),
-				expedNum = timerRef.expedNum;
-			expedNum = parseInt(expedNum, 10);
+				expedNum = parseInt(timerRef.expedNum, 10);
 			
 			KC3Network.trigger("ExpedResult",{
 				expedNum:expedNum,

--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -373,7 +373,7 @@ Previously known as "Reactor"
 			var utcHour  = Date.toUTChours(headers.Date),
 				ship     = KC3ShipManager.get(params.api_id),
 				master   = ship.master(),
-				// NOTE: api_afterfuel is steel usage!
+				// NOTE: api_afterfuel is steel consumption!
 				material = [0,-master.api_afterbull,-master.api_afterfuel,0,0,0,0,0];
 			
 			// For every pending supply and repair, it'll be counted towards this
@@ -1335,7 +1335,7 @@ Previously known as "Reactor"
 				nDockNum   = parseInt( params.api_ndock_id , 10),
 				shipData   = KC3ShipManager.get( shipId );
 			
-			if(bucket==1){
+			if(bucket == 1){
 				PlayerManager.consumables.buckets -= 1;
 				PlayerManager.setConsumables(utcSeconds);
 				
@@ -1356,8 +1356,9 @@ Previously known as "Reactor"
 			
 			shipData.perform('repair');
 			KC3ShipManager.save();
-			
 			KC3QuestManager.get(503).increment(); // E3: Daily Repairs
+			PlayerManager.setResources(utcSeconds, null, [-shipData.repair[1],0,-shipData.repair[2],0]);
+			
 			KC3Network.trigger("Consumables");
 			KC3Network.trigger("Quests");
 			KC3Network.trigger("Fleet");
@@ -1977,8 +1978,6 @@ Previously known as "Reactor"
 			KC3GearManager.set([ response.api_data.api_after_slot ]);
 			
 			PlayerManager.setResources(hr * 3600, response.api_data.api_after_material.slice(0, 4));
-			PlayerManager.consumables.torch = response.api_data.api_after_material[4];
-			PlayerManager.consumables.buckets = response.api_data.api_after_material[5];
 			PlayerManager.consumables.devmats = response.api_data.api_after_material[6];
 			PlayerManager.consumables.screws = response.api_data.api_after_material[7];
 			PlayerManager.setConsumables(hr * 3600);

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -400,7 +400,7 @@ Used by SortieManager
 				console.log("Jets LBAS consumed steel:", consumedSteel);
 				if(consumedSteel > 0){
 					KC3Database.Naverall({
-						hour: Math.hrdInt("floor", Date.safeToUtcTime() / 3.6, 6, 1),
+						hour: Date.toUTChours(),
 						type: "lbas" + KC3SortieManager.map_world,
 						data: [0,0,-consumedSteel,0].concat([0,0,0,0])
 					});


### PR DESCRIPTION
As there are many codes changed, open a PR for more tests to check if I missed something or not.

~~No feature changed~~, just unify and refine time handling codes when timestamp converted to seconds or hours, and add time unit to vars name. 

At first, my motivation is the fix thingy. After double checking of each API handling, I have to clarify and explain the enhancement of feature: Keep tracking with game displaying for 8 basic materials (fuel, ammo, steel, bauxite, torch, bucket, devmat, screw), show their latest values in time and correctly at devtools panel.

*Long story*: as we know, there are 3 types of API call which would consume or gain materials:

 1. In api_data of response, there is `api_materials` liked data to tell us all the absoluate values of materials the player hold.
we have used these values as `resources` cached in `Player.lastMaterial` array and record them into IndexDB every hours.
API examples of this type: `api_port/port`, `api_get_member/material`, `api_req_hokyu/charge`, ...
 2. There is no materials data in API request or response, but we (KC client side) are able to infer the increasement or decresement values from other API attributes or known shipgirl data.
we have recorded these changes into IndexDB for ledger, but do nothing with the `Player.lastMaterial` cache array.
API examples: `api_req_kaisou/remodeling`, `api_req_kousyou/createship`, `api_req_quest/clearitemget`, `api_req_nyukyo/start`, `api_req_mission/result`, `api_req_air_corps/set_plane`, ...
 3. No materials data in API and only KC server side update the exact values of resources.
we can only try to compute them by ourselves.
This type of API is mainly new game mechanism about LBAS and jet bombers such as: `api_req_map/start_air_base`

This PR also done:
Check all the API handlers, of type 2 above, add `resources` and `consumables` updating and refresh event triggerring for panel, aside the ledger db recording codes.
This is why I said 'need more tests', to check if all the corresponding APIs are handled and are the values in panel always the same with in-game's.

Tech details:

 * Two frequently used functions at global.js: `toUTCseconds`, `toUTChours`
 * Replace all `Math.hrdInt("floor"...` converters with previous ones
 * Add time unit to those `ctime` vars, such as `...Seconds` or `...Hours`, fix those function calls with wrong time unit argument.
 * Let more API calls update Resources & Consumables in time (might via delta values only)
 * Improve PlayerManager:
   * Let all side-effect only functions return `this` instance for chain usage
   * Clearify acceptable time unit of parameters for `setResources` and other time related functions
   * Let `setResources`, `setConsumables` support delta values updating