### PR TITLE
Fix #1378 Rewrite Akashi timer to match ingame behaviour

### DIFF
--- a/src/library/managers/PlayerManager.js
+++ b/src/library/managers/PlayerManager.js
@@ -46,6 +46,7 @@ Does not include Ships and Gears which are managed by other Managers
 				new KC3LandBase(),
 				new KC3LandBase()
 			];
+			this.akashiRepair = new KC3AkashiRepair();
 			return this;
 		},
 
@@ -348,7 +349,7 @@ Does not include Ships and Gears which are managed by other Managers
 				return this;
 			}
 
-			this.fleets.forEach(function(fleet){ fleet.checkAkashi(); });
+			this.akashiRepair.onPort(this.fleets);
 
 			var
 				// get current player regen cap

--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -432,6 +432,7 @@ Previously known as "Reactor"
 		// Use a Preset
 		"api_req_hensei/preset_select":function(params, response, headers){
 			var deckId = parseInt(params.api_deck_id, 10);
+			PlayerManager.akashiRepair.onPresetSelect(PlayerManager.fleets[deckId-1]);
 			PlayerManager.fleets[deckId-1].update( response.api_data );
 			PlayerManager.saveFleets();
 			KC3Network.trigger("Fleet", { switchTo: deckId });
@@ -668,14 +669,16 @@ Previously known as "Reactor"
 					}
 					// If not the same fleet, also recheck akashi repair of source fleet
 					if(oldFleet !== fleetIndex-1){
-						PlayerManager.fleets[oldFleet].checkAkashi(true);
+						PlayerManager.akashiRepair.onChange(PlayerManager.fleets[oldFleet]);
+						PlayerManager.fleets[oldFleet].updateAkashiRepairDisplay();
 					}
 				}
 			} else { // Remove ship
 				PlayerManager.fleets[fleetIndex-1].ships.splice(changedIndex, 1);
 				PlayerManager.fleets[fleetIndex-1].ships.push(-1);
 			}
-			PlayerManager.fleets[fleetIndex-1].checkAkashi(true);
+			PlayerManager.akashiRepair.onChange(PlayerManager.fleets[fleetIndex-1]);
+			PlayerManager.fleets[fleetIndex-1].updateAkashiRepairDisplay();
 			PlayerManager.saveFleets();
 			KC3Network.trigger("Fleet", { switchTo: fleetIndex });
 		},

--- a/src/library/objects/AkashiRepair.js
+++ b/src/library/objects/AkashiRepair.js
@@ -1,0 +1,93 @@
+/* AkashiRepair.js
+
+Manages the timer for a player's Akashi repairs.
+*/
+(function () {
+  "use strict";
+
+  var MS_PER_SECOND = 1000;
+  var MS_PER_MINUTE = 60 * MS_PER_SECOND;
+
+  window.KC3AkashiRepair = function () {
+    this.timer = new KC3AkashiRepair.Timer();
+  };
+
+  /*--------------------------------------------------------*/
+  /*----------------------[ GETTERS ]-----------------------*/
+  /*--------------------------------------------------------*/
+
+  KC3AkashiRepair.prototype.isRunning = function () {
+    return this.timer.isRunning();
+  };
+  KC3AkashiRepair.prototype.canDoRepair = function () {
+    return this.timer.getElapsed().canDoRepair();
+  };
+  KC3AkashiRepair.prototype.getElapsed = function () {
+    return this.timer.getElapsed().ms();
+  };
+
+  /*--------------------------------------------------------*/
+  /*---------------------[ LISTENERS ]----------------------*/
+  /*--------------------------------------------------------*/
+
+  // Listener for api_req_hensei/change
+  KC3AkashiRepair.prototype.onChange = function (fleet) {
+    if (KC3AkashiRepair.hasRepairFlagship(fleet)) {
+      this.timer.start();
+    }
+  };
+
+  // Listener for api_req_hensei/preset_select
+  KC3AkashiRepair.prototype.onPresetSelect = function (fleet) {
+    if (KC3AkashiRepair.hasRepairFlagship(fleet) && !this.timer.isRunning()) {
+      this.timer.start();
+    }
+  };
+
+  // Listener for api_port/port
+  KC3AkashiRepair.prototype.onPort = function (fleets) {
+    if (this.timer.getElapsed().canDoRepair()) {
+      var akashiFlagExists = fleets.some(KC3AkashiRepair.hasRepairFlagship);
+      if (akashiFlagExists) {
+        this.timer.start();
+      } else {
+        this.timer.stop();
+      }
+    }
+  };
+
+  /*--------------------------------------------------------*/
+  /*------------------[ INTERNAL CLASSES ]------------------*/
+  /*--------------------------------------------------------*/
+
+  var Timer = function () { this.startTime = undefined; };
+  Timer.prototype.start = function () { this.startTime = Date.now(); };
+  Timer.prototype.stop = function () { this.startTime = undefined; };
+  Timer.prototype.isRunning = function () { return !!this.startTime; };
+  Timer.prototype.getElapsed = function () {
+    return new KC3AkashiRepair.DeltaTime(this.startTime);
+  };
+  KC3AkashiRepair.Timer = Timer;
+
+  var DeltaTime = function (startTime) {
+    this.startTime = startTime;
+    this.now = Date.now();
+  };
+  DeltaTime.prototype.canDoRepair = function () {
+    return this.ms() >= 20 * MS_PER_MINUTE;
+  };
+  DeltaTime.prototype.ms = function () {
+    return this.now - this.startTime || 0;
+  };
+  KC3AkashiRepair.DeltaTime = DeltaTime;
+
+  /*--------------------------------------------------------*/
+  /*----------------------[ HELPERS ]-----------------------*/
+  /*--------------------------------------------------------*/
+
+  // Returns true if the fleet's flagship is of the Repair Ship class, false otherwise
+  KC3AkashiRepair.hasRepairFlagship = function (fleet) {
+    var flagship = fleet.ship(0);
+    return flagship.master().api_stype === 19;
+  };
+})();

--- a/src/library/objects/AkashiRepair.js
+++ b/src/library/objects/AkashiRepair.js
@@ -26,7 +26,8 @@ Manages the timer for a player's Akashi repairs.
       return KC3AkashiRepair.calculatePreRepairProgress(elapsed);
     }
 
-    var tickLength = KC3AkashiRepair.calculateTickLength(dockTime, hpLost);
+    var repairTime = KC3AkashiRepair.calculateRepairTime(dockTime);
+    var tickLength = KC3AkashiRepair.calculateTickLength(repairTime, hpLost);
     return KC3AkashiRepair.calculateProgress(elapsed, tickLength, hpLost);
   };
 
@@ -71,6 +72,16 @@ Manages the timer for a player's Akashi repairs.
   };
 
   /*--------------------------------------------------------*/
+  /*-------------------[ PUBLIC HELPERS ]-------------------*/
+  /*--------------------------------------------------------*/
+
+  // Calculate the length of an Akashi repair in ms, 
+  // based on the length of an equivalent dock repair
+  KC3AkashiRepair.calculateRepairTime = function (dockTime) {
+    return roundUpToMinute(dockTime - 30 * MS_PER_SECOND);
+  };
+
+  /*--------------------------------------------------------*/
   /*------------------[ INTERNAL CLASSES ]------------------*/
   /*--------------------------------------------------------*/
 
@@ -107,11 +118,10 @@ Manages the timer for a player's Akashi repairs.
 
   /*------------------[ REPAIR PROGRESS ]-------------------*/
 
-  // Calculate the amount of time it takes to repair 1 HP
-  KC3AkashiRepair.calculateTickLength = function (dockTime, hpLost) {
-    var baseTime = dockTime - 30 * MS_PER_SECOND;
-    var akashiTime = Math.ceil(baseTime / MS_PER_MINUTE) * MS_PER_MINUTE;
-    return Math.ceil(akashiTime / hpLost);
+  // Calculate the amount of time it takes to repair 1 HP,
+  // rounded up to the nearest ms
+  KC3AkashiRepair.calculateTickLength = function (repairTime, hpLost) {
+    return Math.ceil(repairTime / hpLost);
   };
 
   // Calculate progress when no repairs are ready yet

--- a/src/library/objects/Fleet.js
+++ b/src/library/objects/Fleet.js
@@ -13,7 +13,6 @@ Contains summary information about a fleet and its 6 ships
 		this.name = "";
 		this.ships = [ -1, -1, -1, -1, -1, -1 ];
 		this.mission = [ 0, 0, 0, 0 ];
-		this.akashi_tick = 0;
 
 		// Define properties not included in stringifications
 		Object.defineProperties(this,{
@@ -104,11 +103,8 @@ Contains summary information about a fleet and its 6 ships
 					KC3TimerManager.exped( this.fleetId ).deactivate();
 				}
 			}
-			
-			if(!shipState.cmp('pre','post')) {
-				this.akashi_tick = 0;
-			}
-			this.checkAkashi();
+
+			this.updateAkashiRepairDisplay();
 		}
 	};
 	
@@ -118,7 +114,6 @@ Contains summary information about a fleet and its 6 ships
 		this.name = data.name;
 		this.ships = data.ships;
 		this.mission = data.mission;
-		this.akashi_tick = data.akashi_tick;
 		return this;
 	};
 	
@@ -167,54 +162,47 @@ Contains summary information about a fleet and its 6 ships
 	};
 	
 	KC3Fleet.prototype.clearNonFlagShips = function(){
-		this.ship(function(x,i,s){s.akashiMark = false;});
 		this.ships.fill(-1,1,6);
-		this.checkAkashi();
+		this.updateAkashiRepairDisplay();
 	};
-	
-	KC3Fleet.prototype.checkAkashi = function(forceReset){
-		forceReset = !!forceReset;
-		
+
+	/*--------------------------------------------------------*/
+	/*-------------------[ AKASHI REPAIR ]--------------------*/
+	/*--------------------------------------------------------*/
+
+	// Mark the fleet's ships as being repaired (or not)
+	// Called when the fleet changes, or their equipment does
+	KC3Fleet.prototype.updateAkashiRepairDisplay = function () {
+		var repairSlots = this._getRepairSlots();
+		this.ship(this._updateRepairStatus(repairSlots));
+	};
+
+	KC3Fleet.prototype._canDoRepair = function (flagship) {
+		return this._isAkashi(flagship) && !flagship.isStriped() && flagship.isFree();
+	};
+
+	KC3Fleet.prototype._isAkashi = function (ship) {
+		return ship.master().api_stype === 19;
+	};
+
+	// Return the number of ships that will be targetted by an Akashi repair
+	KC3Fleet.prototype._getRepairSlots = function () {
 		var flagship = this.ship(0);
-		if(
-			flagship.master().api_stype == 19 &&
-			!(flagship.isStriped() || !flagship.isFree())
-		) {
-			// only applies to AR that is spending her time in port
-			// but neither striped or even bathing.
-			var
-				prevTick = !forceReset && this.akashi_tick,
-				nextTick = Date.now(),
-				shftTick = prevTick && Math.hrdInt('floor',(nextTick - prevTick)/1.2,6)*1.2;
-			this.akashi_tick = (prevTick + shftTick) || nextTick;
-			
-			var akashiRange = flagship.countEquipment(86) + 1;
-			
-			this.ship(function(roster,index,ship){
-				ship.akashiMark = (index <= akashiRange) && ship.isFree() && !ship.isStriped();
-			});
-			return true;
-		} else {
-			this.akashi_tick = 0;
-			this.ship(function(roster,index,ship){
-				ship.akashiMark = false;
-			});
-			return false;
+		if (!this._canDoRepair(flagship)) {
+			return 0;
 		}
+		var cranesEquipped = flagship.countEquipment(86);
+		return cranesEquipped + 2;
 	};
-	
-	KC3Fleet.prototype.checkAkashiValid = function() {
-		return !!this.akashi_tick;
+
+	// Return a function to pass to this.ship() that will update the ships' repair status 
+	KC3Fleet.prototype._updateRepairStatus = function (repairSlotCount) {
+		return function (rosterId, position, ship) {
+			var inRange = position < repairSlotCount;
+			ship.akashiMark = inRange && !ship.isStriped() && ship.isFree();
+		};
 	};
-	
-	KC3Fleet.prototype.checkAkashiExpire = function() {
-		return !!this.checkAkashiTick();
-	};
-	
-	KC3Fleet.prototype.checkAkashiTick = function() {
-		return Math.hrdInt('floor',(Date.now() - this.akashi_tick)/1.2,6,1);
-	};
-	
+
 	/*--------------------------------------------------------*/
 	/*------------------[ FLEET ATTRIBUTES ]------------------*/
 	/*--------------------------------------------------------*/
@@ -582,19 +570,14 @@ Contains summary information about a fleet and its 6 ships
 		var
 			self  = this,
 			highestDocking = 0,
-			highestAkashi = 0,
-			ctime = Date.now();
+			highestAkashi = 0;
 		
 		this.ship(function(rosterId,index,shipData){
 			if(shipData.didFlee) { return false; }
 			var myRepairTime = shipData.repairTime();
-			myRepairTime.akashi -= Math.max(
-				0,
-				(!!akashiReduce &&
-					self.akashi_tick && shipData.akashiMark && myRepairTime.akashi && 
-					Math.hrdInt('floor',(ctime - self.akashi_tick),3,1)
-				)
-			);
+			myRepairTime.akashi -=
+				Math.hrdInt('floor', PlayerManager.akashiRepair.getElapsed(),3,1) ||
+				0;
 			
 			if(myRepairTime.docking > highestDocking){ highestDocking = myRepairTime.docking; }
 			if(myRepairTime.akashi > highestAkashi){ highestAkashi = myRepairTime.akashi; }
@@ -603,7 +586,10 @@ Contains summary information about a fleet and its 6 ships
 		return {
 			docking: highestDocking,
 			akashi: highestAkashi,
-			akashiCheck: [this.checkAkashiValid(),this.checkAkashiExpire()]
+			akashiCheck: [
+				PlayerManager.akashiRepair.isRunning(),
+				PlayerManager.akashiRepair.canDoRepair()
+			],
 		};
 	};
 	
@@ -814,7 +800,6 @@ Contains summary information about a fleet and its 6 ships
 			this.ships.splice(pos,1);
 			this.ships.push(-1);
 		}
-		this.checkAkashi(true);
 	};
 	
 	/**

--- a/src/library/objects/Ship.js
+++ b/src/library/objects/Ship.js
@@ -326,11 +326,15 @@ KC3改 Ship Object
 
 			hpArr = optAfterHp ? this.afterHp : this.hp;
 
-		var result = {};
+		var result = { akashi: 0 };
 
-		result.akashi = ( HPPercent > 0.50 && HPPercent < 1.00 && this.isFree()) ?
-			/* RepairCalc.facilityInSecJSNum( this.master().api_stype, this.level, this.hp[0], this.hp[1] ) */
-			Math.max(Math.min((1200 * (this.hp[1] - this.hp[0])),RepairTSec),1200) : 0;
+		if (HPPercent > 0.5 && HPPercent < 1.00 && this.isFree()) {
+			var repairTime = KC3AkashiRepair.calculateRepairTime(this.repair[0]);
+			result.akashi = Math.max(
+				Math.hrdInt('floor', repairTime,3,1), // convert to seconds
+				20 * 60 // should be at least 20 minutes
+			);
+		}
 
 		if (optAfterHp) {
 			result.docking = RepairCalc.dockingInSecJSNum( this.master().api_stype, this.level, hpArr[0], hpArr[1] );

--- a/src/pages/devtools/themes/default/default.html
+++ b/src/pages/devtools/themes/default/default.html
@@ -46,6 +46,7 @@
 		<!-- @nonbuildstart -->
 		<script type="text/javascript" src="../../../../library/objects/Node.js"></script>
 		<script type="text/javascript" src="../../../../library/objects/Fleet.js"></script>
+		<script type="text/javascript" src="../../../../library/objects/AkashiRepair.js"></script>
 		<script type="text/javascript" src="../../../../library/objects/Gear.js"></script>
 		<script type="text/javascript" src="../../../../library/objects/Messengers.js"></script>
 		<script type="text/javascript" src="../../../../library/objects/Player.js"></script>

--- a/src/pages/devtools/themes/natsuiro/natsuiro.html
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.html
@@ -1187,6 +1187,7 @@
 		<!-- @nonbuildstart -->
 		<script type="text/javascript" src="../../../../library/objects/Node.js"></script>
 		<script type="text/javascript" src="../../../../library/objects/Fleet.js"></script>
+		<script type="text/javascript" src="../../../../library/objects/AkashiRepair.js"></script>
 		<script type="text/javascript" src="../../../../library/objects/Gear.js"></script>
 		<script type="text/javascript" src="../../../../library/objects/Messengers.js"></script>
 		<script type="text/javascript" src="../../../../library/objects/Player.js"></script>

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -306,12 +306,9 @@
 		var baseElement = (TotalFleet.length > 1) ? ['main','escort'] : ['single'];
 		var ctime = Date.now();
 		baseElement.forEach(function(baseKey,index){
-			var FleetData = PlayerManager.fleets[TotalFleet[index]];
-
 			var baseContainer = $([".shiplist",baseKey].join('_'));
-			var akashiDuration = (function(){
-				return Math.min(359999,Math.hrdInt('floor',ctime - this.akashi_tick,3,1));
-			}).call(FleetData);
+			var akashiDuration = Math.hrdInt('floor', PlayerManager.akashiRepair.getElapsed(), 3, 1);
+			var canDoRepair = PlayerManager.akashiRepair.canDoRepair();
 
 			$(".sship,.lship",baseContainer).each(function(index,shipBox){
 				var repairBox = $('.ship_repair_data',shipBox);
@@ -322,7 +319,7 @@
 					repairTime = Math.max(0,Math.hrdInt('floor',shipData.repair[0],3,1) - 30),
 					repairTick = Math.max(1,(hpLoss > 0) ? (repairTime/hpLoss) : 1),
 					repairHP   = Math.min(hpLoss,
-						FleetData.checkAkashiExpire() ?
+						canDoRepair ?
 							Math.floor(hpLoss*Math.min(1,Math.max(akashiDuration-30,0) / repairTime)) :
 							0
 					);
@@ -330,7 +327,8 @@
 				$('.ship_repair_tick' ,shipBox).attr('data-tick',repairHP);
 				$('.ship_repair_timer',shipBox).text((
 					(repairHP < hpLoss) ? (
-						!FleetData.checkAkashiExpire() ? (1200-akashiDuration) :
+						!canDoRepair ?
+							(1200-akashiDuration) :
 							(repairTick - Math.min(repairTime,akashiDuration - 30) % repairTick)
 					) : NaN
 				).toString().toHHMMSS() );

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -304,34 +304,29 @@
 		
 		// Akashi current
 		var baseElement = (TotalFleet.length > 1) ? ['main','escort'] : ['single'];
-		var ctime = Date.now();
 		baseElement.forEach(function(baseKey,index){
 			var baseContainer = $([".shiplist",baseKey].join('_'));
-			var akashiDuration = Math.hrdInt('floor', PlayerManager.akashiRepair.getElapsed(), 3, 1);
-			var canDoRepair = PlayerManager.akashiRepair.canDoRepair();
 
 			$(".sship,.lship",baseContainer).each(function(index,shipBox){
 				var repairBox = $('.ship_repair_data',shipBox);
 
 				var
-					shipData   = KC3ShipManager.get(repairBox.data('sid')),
-					hpLoss     = shipData.hp[1] - shipData.hp[0],
-					repairTime = Math.max(0,Math.hrdInt('floor',shipData.repair[0],3,1) - 30),
-					repairTick = Math.max(1,(hpLoss > 0) ? (repairTime/hpLoss) : 1),
-					repairHP   = Math.min(hpLoss,
-						canDoRepair ?
-							Math.floor(hpLoss*Math.min(1,Math.max(akashiDuration-30,0) / repairTime)) :
-							0
-					);
+					shipData = KC3ShipManager.get(repairBox.data('sid')),
+					hpLost = shipData.hp[1] - shipData.hp[0],
+					dockTime = shipData.repair[0],
+					repairProgress = PlayerManager.akashiRepair.getProgress(dockTime, hpLost);
 
-				$('.ship_repair_tick' ,shipBox).attr('data-tick',repairHP);
-				$('.ship_repair_timer',shipBox).text((
-					(repairHP < hpLoss) ? (
-						!canDoRepair ?
-							(1200-akashiDuration) :
-							(repairTick - Math.min(repairTime,akashiDuration - 30) % repairTick)
-					) : NaN
-				).toString().toHHMMSS() );
+				$('.ship_repair_tick', shipBox).attr('data-tick', repairProgress.repairedHp);
+				$('.ship_repair_timer', shipBox).text(
+					(function (t) {
+						if (t === 0) {
+							return '--:--:--';
+						} else if (!t || Number.isNaN(parseInt(t))) {
+							return '??:??:??';
+						}
+						return Math.ceil(t / 1000).toString().toHHMMSS();
+					})(repairProgress.timeToNextRepair)
+				);
 			});
 		});
 	}

--- a/src/pages/devtools/themes/plain/plain.html
+++ b/src/pages/devtools/themes/plain/plain.html
@@ -383,6 +383,7 @@
 		<!-- @nonbuildstart -->
 		<script type="text/javascript" src="../../../../library/objects/Node.js"></script>
 		<script type="text/javascript" src="../../../../library/objects/Fleet.js"></script>
+		<script type="text/javascript" src="../../../../library/objects/AkashiRepair.js"></script>
 		<script type="text/javascript" src="../../../../library/objects/Gear.js"></script>
 		<script type="text/javascript" src="../../../../library/objects/Messengers.js"></script>
 		<script type="text/javascript" src="../../../../library/objects/Player.js"></script>

--- a/src/pages/devtools/themes/plain/plain.js
+++ b/src/pages/devtools/themes/plain/plain.js
@@ -430,34 +430,29 @@
 			
 			// Akashi current
 			var baseElement = (TotalFleet.length > 1) ? ['main','escort'] : ['single'];
-			var ctime = Date.now();
 			baseElement.forEach(function(baseKey,index){
 				var baseContainer = $([".shiplist",baseKey].join('_'));
-				var akashiDuration = Math.hrdInt('floor', PlayerManager.akashiRepair.getElapsed(), 3, 1);
-				var canDoRepair = PlayerManager.akashiRepair.canDoRepair();
 				
 				$(".sship,.lship",baseContainer).each(function(index,shipBox){
 					var repairBox = $('.ship_repair_data',shipBox);
 					
-					var
-						shipData   = KC3ShipManager.get(repairBox.data('sid')),
-						hpLoss     = shipData.hp[1] - shipData.hp[0],
-						repairTime = Math.max(0,Math.hrdInt('floor',shipData.repair[0],3,1) - 30),
-						repairTick = Math.max(1,(hpLoss > 0) ? (repairTime/hpLoss) : 1),
-						repairHP   = Math.min(hpLoss,
-							canDoRepair ?
-								Math.floor(hpLoss*Math.min(1,Math.max(akashiDuration-30,0) / repairTime)) :
-								0
-						);
+				var
+					shipData = KC3ShipManager.get(repairBox.data('sid')),
+					hpLost = shipData.hp[1] - shipData.hp[0],
+					dockTime = shipData.repair[0],
+					repairProgress = PlayerManager.akashiRepair.getProgress(dockTime, hpLost);
 					
-					$('.ship_repair_tick' ,shipBox).attr('data-tick',repairHP);
-					$('.ship_repair_timer',shipBox).text((
-						(repairHP < hpLoss) ? (
-							!canDoRepair ?
-								(1200-akashiDuration) : 
-								(repairTick - Math.min(repairTime,akashiDuration - 30) % repairTick)
-						) : NaN
-					).toString().toHHMMSS() );
+					$('.ship_repair_tick', shipBox).attr('data-tick', repairProgress.repairedHp);
+					$('.ship_repair_timer', shipBox).text(
+						(function (t) {
+							if (t === 0) {
+								return '--:--:--';
+							} else if (!t || Number.isNaN(parseInt(t))) {
+								return '??:??:??';
+							}
+							return Math.ceil(t / 1000).toString().toHHMMSS();
+						})(repairProgress.timeToNextRepair)
+					);
 				});
 			});
 		}, 1000);

--- a/src/pages/devtools/themes/plain/plain.js
+++ b/src/pages/devtools/themes/plain/plain.js
@@ -432,12 +432,9 @@
 			var baseElement = (TotalFleet.length > 1) ? ['main','escort'] : ['single'];
 			var ctime = Date.now();
 			baseElement.forEach(function(baseKey,index){
-				var FleetData = PlayerManager.fleets[TotalFleet[index]];
-				
 				var baseContainer = $([".shiplist",baseKey].join('_'));
-				var akashiDuration = (function(){
-					return Math.min(359999,Math.hrdInt('floor',ctime - this.akashi_tick,3,1));
-				}).call(FleetData);
+				var akashiDuration = Math.hrdInt('floor', PlayerManager.akashiRepair.getElapsed(), 3, 1);
+				var canDoRepair = PlayerManager.akashiRepair.canDoRepair();
 				
 				$(".sship,.lship",baseContainer).each(function(index,shipBox){
 					var repairBox = $('.ship_repair_data',shipBox);
@@ -448,7 +445,7 @@
 						repairTime = Math.max(0,Math.hrdInt('floor',shipData.repair[0],3,1) - 30),
 						repairTick = Math.max(1,(hpLoss > 0) ? (repairTime/hpLoss) : 1),
 						repairHP   = Math.min(hpLoss,
-							FleetData.checkAkashiExpire() ?
+							canDoRepair ?
 								Math.floor(hpLoss*Math.min(1,Math.max(akashiDuration-30,0) / repairTime)) :
 								0
 						);
@@ -456,7 +453,8 @@
 					$('.ship_repair_tick' ,shipBox).attr('data-tick',repairHP);
 					$('.ship_repair_timer',shipBox).text((
 						(repairHP < hpLoss) ? (
-							!FleetData.checkAkashiExpire() ? (1200-akashiDuration) : 
+							!canDoRepair ?
+								(1200-akashiDuration) : 
 								(repairTick - Math.min(repairTime,akashiDuration - 30) % repairTick)
 						) : NaN
 					).toString().toHHMMSS() );

--- a/src/pages/strategy/strategy.html
+++ b/src/pages/strategy/strategy.html
@@ -137,6 +137,7 @@
 		<script type="text/javascript" src="../../library/objects/StrategyTab.js"></script>
 		<script type="text/javascript" src="../../library/objects/Node.js"></script>
 		<script type="text/javascript" src="../../library/objects/Fleet.js"></script>
+		<script type="text/javascript" src="../../library/objects/AkashiRepair.js"></script>
 		<script type="text/javascript" src="../../library/objects/Gear.js"></script>
 		<script type="text/javascript" src="../../library/objects/Messengers.js"></script>
 		<script type="text/javascript" src="../../library/objects/Player.js"></script>

--- a/tests/library/modules/BattlePrediction.html
+++ b/tests/library/modules/BattlePrediction.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html>
 <html>
 	<head>
@@ -23,6 +24,7 @@
 
 		<script src="../../../src/library/objects/Node.js"></script>
 		<script src="../../../src/library/objects/Fleet.js"></script>
+		<script src="../../../src/library/objects/AkashiRepair.js"></script>
 		<script src="../../../src/library/objects/Gear.js"></script>
 		<script src="../../../src/library/objects/Player.js"></script>
 		<script src="../../../src/library/objects/Ship.js"></script>

--- a/tests/library/objects/AkashiRepair.html
+++ b/tests/library/objects/AkashiRepair.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../../../node_modules/qunitjs/qunit/qunit.css" media="screen">
+  </head>
+  <body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+    <!-- API DATA -->
+    <!-- TEST TOOLS -->
+    <script src="../../../node_modules/jquery/dist/jquery.min.js"></script>
+    <script src="../../../node_modules/qunitjs/qunit/qunit.js"></script>
+    <!-- SCRIPTS -->
+    <script src="../../../src/assets/js/global.js"></script>
+    <script src="../../../src/library/objects/AkashiRepair.js"></script>
+    <script src="AkashiRepair.js"></script>
+  </body>
+</html>

--- a/tests/library/objects/AkashiRepair.js
+++ b/tests/library/objects/AkashiRepair.js
@@ -1,160 +1,167 @@
 QUnit.module('Objects > AkashiRepair', function () {
-    QUnit.module('DeltaTime', function () {
-      QUnit.module('.canDoRepair()', {
-        beforeEach() {
-          this.deltaTime = new KC3AkashiRepair.DeltaTime();
-          this.subject = this.deltaTime.canDoRepair.bind(this.deltaTime);
-        }
-      }, function () {
-        QUnit.test('timeElapsed > 20 minutes', function (assert) {
-          this.deltaTime.startTime = this.deltaTime.now - 20 * 60 * 1000 - 1;
-
-          const result = this.subject();
-
-          assert.equal(result, true);
-        });
-
-        QUnit.test('timeElapsed = 20 minutes', function (assert) {
-          this.deltaTime.startTime = this.deltaTime.now - 20 * 60 * 1000;
-
-          const result = this.subject();
-
-          assert.equal(result, true);
-        });
-
-        QUnit.test('timeElapsed < 20 minutes', function (assert) {
-          this.deltaTime.startTime = this.deltaTime.now - 20 * 60 * 1000 + 1;
-
-          const result = this.subject();
-
-          assert.equal(result, false);
-        });
-
-        QUnit.test('no timer running', function (assert) {
-          this.deltaTime.startTime = undefined;
-
-          const result = this.subject();
-
-          assert.equal(result, false);
-        });
-      });
-
-      QUnit.module('.ms()', {
-        beforeEach() {
-          this.deltaTime = new KC3AkashiRepair.DeltaTime();
-          this.subject = this.deltaTime.ms.bind(this.deltaTime);
-        }
-      }, function () {
-        QUnit.test('no timer running', function (assert) {
-          this.startTime = undefined;
-
-          const result = this.subject();
-
-          assert.equal(result, 0);
-        });
-
-        QUnit.test('timer running', function (assert) {
-          this.deltaTime.startTime = 0;
-          this.deltaTime.now = 10;
-
-          const result = this.subject();
-
-          assert.equal(result, 10);
-        });
-      });
+  QUnit.module('.calculateRepairTime', {
+    beforeEach() {
+      this.subject = KC3AkashiRepair.calculateRepairTime;
+    }
+  }, function () {
+    QUnit.test('success', function (assert) {
+      // subtract 30 seconds, then round up to the nearest minute
+      assert.equal(this.subject(10.5 * 60 * 1000 - 1), 10 * 60 * 1000);
+      assert.equal(this.subject(10.5 * 60 * 1000), 10 * 60 * 1000);
+      assert.equal(this.subject(10.5 * 60 * 1000 + 1), 11 * 60 * 1000);
     });
+  });
 
-    QUnit.module('.calculateProgress', {
+  QUnit.module('DeltaTime', function () {
+    QUnit.module('.canDoRepair()', {
       beforeEach() {
-        this.subject = KC3AkashiRepair.calculateProgress;
+        this.deltaTime = new KC3AkashiRepair.DeltaTime();
+        this.subject = this.deltaTime.canDoRepair.bind(this.deltaTime);
       }
     }, function () {
-      QUnit.test('timeElapsed > tickLength', function (assert) {
-        var dt = new KC3AkashiRepair.DeltaTime(0);
-        dt.now = 20.5 * 60 * 1000;
-        var tickLength = 8.75 * 60 * 1000;
+      QUnit.test('timeElapsed > 20 minutes', function (assert) {
+        this.deltaTime.startTime = this.deltaTime.now - 20 * 60 * 1000 - 1;
 
-        const result = this.subject(dt, tickLength, 12345);
+        const result = this.subject();
 
-        assert.propEqual(result, {
-          repairedHp: 2,
-          timeToNextRepair: 6.5 * 60 * 1000,
-        });
+        assert.equal(result, true);
       });
 
-      QUnit.test('timeElapsed < tickLength', function (assert) {
-        var dt = new KC3AkashiRepair.DeltaTime(0);
-        dt.now = 20.5 * 60 * 1000;
-        var tickLength = 22.75 * 60 * 1000;
+      QUnit.test('timeElapsed = 20 minutes', function (assert) {
+        this.deltaTime.startTime = this.deltaTime.now - 20 * 60 * 1000;
 
-        const result = this.subject(dt, tickLength, 12345);
+        const result = this.subject();
 
-        assert.propEqual(result, {
-          repairedHp: 1,
-          timeToNextRepair: 25.5 * 60 * 1000,
-        });
+        assert.equal(result, true);
       });
 
-      QUnit.test('cap repairedHp', function (assert) {
-        var dt = new KC3AkashiRepair.DeltaTime(0);
-        dt.now = 40 * 60 * 1000;
-        var tickLength = 22 * 60 * 1000 / 4;
-        var hpLost = 4;
+      QUnit.test('timeElapsed < 20 minutes', function (assert) {
+        this.deltaTime.startTime = this.deltaTime.now - 20 * 60 * 1000 + 1;
 
-        const result = this.subject(dt, tickLength, hpLost);
+        const result = this.subject();
 
-        assert.propEqual(result, {
-          repairedHp: 4,
-          timeToNextRepair: 0,
-        });
+        assert.equal(result, false);
+      });
+
+      QUnit.test('no timer running', function (assert) {
+        this.deltaTime.startTime = undefined;
+
+        const result = this.subject();
+
+        assert.equal(result, false);
       });
     });
 
-    QUnit.module('.calculateTickLength', {
+    QUnit.module('.ms()', {
       beforeEach() {
-        this.subject = KC3AkashiRepair.calculateTickLength;
+        this.deltaTime = new KC3AkashiRepair.DeltaTime();
+        this.subject = this.deltaTime.ms.bind(this.deltaTime);
       }
     }, function () {
-      QUnit.test('convert to akashiTime', function (assert) {
-        // subtract 30s, then round up to nearest minute
-        assert.equal(this.subject(21.5 * 60 * 1000 + 1, 1), 22 * 60 * 1000);
-        assert.equal(this.subject(21.5 * 60 * 1000, 1), 21 * 60 * 1000);
+      QUnit.test('no timer running', function (assert) {
+        this.startTime = undefined;
+
+        const result = this.subject();
+
+        assert.equal(result, 0);
       });
 
-      QUnit.test('calculate time per tick', function (assert) {
-        var dockTime = 21.5 * 60 * 1000;
-        var hpLost = 2;
+      QUnit.test('timer running', function (assert) {
+        this.deltaTime.startTime = 0;
+        this.deltaTime.now = 10;
 
-        const result = this.subject(dockTime, hpLost);
+        const result = this.subject();
 
-        assert.equal(result, 10.5 * 60 * 1000);
+        assert.equal(result, 10);
       });
+    });
+  });
 
-      QUnit.test('round up to nearest ms', function (assert) {
-        var dockTime = 10 * 60 * 1000;
-        var hpLost = 7;
+  QUnit.module('.calculateProgress', {
+    beforeEach() {
+      this.subject = KC3AkashiRepair.calculateProgress;
+    }
+  }, function () {
+    QUnit.test('timeElapsed > tickLength', function (assert) {
+      var dt = new KC3AkashiRepair.DeltaTime(0);
+      dt.now = 20.5 * 60 * 1000;
+      var tickLength = 8.75 * 60 * 1000;
 
-        const result = this.subject(dockTime, hpLost);
+      const result = this.subject(dt, tickLength, 12345);
 
-        assert.equal(result, 85715);
+      assert.propEqual(result, {
+        repairedHp: 2,
+        timeToNextRepair: 6.5 * 60 * 1000,
       });
     });
 
-    QUnit.module('.calculatePreRepairProgress', {
-      beforeEach() {
-        this.subject = KC3AkashiRepair.calculatePreRepairProgress;
-      }
-    }, function () {
-      QUnit.test('success', function (assert) {
-        var dt = new KC3AkashiRepair.DeltaTime(0);
-        dt.now = 10.5 * 60 * 1000;
+    QUnit.test('timeElapsed < tickLength', function (assert) {
+      var dt = new KC3AkashiRepair.DeltaTime(0);
+      dt.now = 20.5 * 60 * 1000;
+      var tickLength = 22.75 * 60 * 1000;
 
-        const result = this.subject(dt);
+      const result = this.subject(dt, tickLength, 12345);
 
-        assert.propEqual(result, {
-          repairedHp: 0,
-          timeToNextRepair: 9.5 * 60 * 1000,
-        });
+      assert.propEqual(result, {
+        repairedHp: 1,
+        timeToNextRepair: 25.5 * 60 * 1000,
       });
     });
+
+    QUnit.test('cap repairedHp', function (assert) {
+      var dt = new KC3AkashiRepair.DeltaTime(0);
+      dt.now = 40 * 60 * 1000;
+      var tickLength = 22 * 60 * 1000 / 4;
+      var hpLost = 4;
+
+      const result = this.subject(dt, tickLength, hpLost);
+
+      assert.propEqual(result, {
+        repairedHp: 4,
+        timeToNextRepair: 0,
+      });
+    });
+  });
+
+  QUnit.module('.calculateTickLength', {
+    beforeEach() {
+      this.subject = KC3AkashiRepair.calculateTickLength;
+    }
+  }, function () {
+    QUnit.test('calculate time per tick', function (assert) {
+      var repairTime = 21 * 60 * 1000;
+      var hpLost = 2;
+
+      const result = this.subject(repairTime, hpLost);
+
+      assert.equal(result, 10.5 * 60 * 1000);
+    });
+
+    QUnit.test('round up to nearest ms', function (assert) {
+      var repairTime = 10 * 60 * 1000;
+      var hpLost = 7;
+
+      const result = this.subject(repairTime, hpLost);
+
+      assert.equal(result, 85715);
+    });
+  });
+
+  QUnit.module('.calculatePreRepairProgress', {
+    beforeEach() {
+      this.subject = KC3AkashiRepair.calculatePreRepairProgress;
+    }
+  }, function () {
+    QUnit.test('success', function (assert) {
+      var dt = new KC3AkashiRepair.DeltaTime(0);
+      dt.now = 10.5 * 60 * 1000;
+
+      const result = this.subject(dt);
+
+      assert.propEqual(result, {
+        repairedHp: 0,
+        timeToNextRepair: 9.5 * 60 * 1000,
+      });
+    });
+  });
 });

--- a/tests/library/objects/AkashiRepair.js
+++ b/tests/library/objects/AkashiRepair.js
@@ -1,0 +1,66 @@
+QUnit.module('Objects > AkashiRepair', function () {
+    QUnit.module('DeltaTime', function () {
+      QUnit.module('.canDoRepair()', {
+        beforeEach() {
+          this.deltaTime = new KC3AkashiRepair.DeltaTime();
+          this.subject = this.deltaTime.canDoRepair.bind(this.deltaTime);
+        }
+      }, function () {
+        QUnit.test('timeElapsed > 20 minutes', function (assert) {
+          this.deltaTime.startTime = this.deltaTime.now - 20 * 60 * 1000 - 1;
+
+          const result = this.subject();
+
+          assert.equal(result, true);
+        });
+
+        QUnit.test('timeElapsed = 20 minutes', function (assert) {
+          this.deltaTime.startTime = this.deltaTime.now - 20 * 60 * 1000;
+
+          const result = this.subject();
+
+          assert.equal(result, true);
+        });
+
+        QUnit.test('timeElapsed < 20 minutes', function (assert) {
+          this.deltaTime.startTime = this.deltaTime.now - 20 * 60 * 1000 + 1;
+
+          const result = this.subject();
+
+          assert.equal(result, false);
+        });
+
+        QUnit.test('no timer running', function (assert) {
+          this.deltaTime.startTime = undefined;
+
+          const result = this.subject();
+
+          assert.equal(result, false);
+        });
+      });
+
+      QUnit.module('.ms()', {
+        beforeEach() {
+          this.deltaTime = new KC3AkashiRepair.DeltaTime();
+          this.subject = this.deltaTime.ms.bind(this.deltaTime);
+        }
+      }, function () {
+        QUnit.test('no timer running', function (assert) {
+          this.startTime = undefined;
+
+          const result = this.subject();
+
+          assert.equal(result, 0);
+        });
+
+        QUnit.test('timer running', function (assert) {
+          this.deltaTime.startTime = 0;
+          this.deltaTime.now = 10;
+
+          const result = this.subject();
+
+          assert.equal(result, 10);
+        });
+      });
+    });
+});

--- a/tests/library/objects/AkashiRepair.js
+++ b/tests/library/objects/AkashiRepair.js
@@ -63,4 +63,98 @@ QUnit.module('Objects > AkashiRepair', function () {
         });
       });
     });
+
+    QUnit.module('.calculateProgress', {
+      beforeEach() {
+        this.subject = KC3AkashiRepair.calculateProgress;
+      }
+    }, function () {
+      QUnit.test('timeElapsed > tickLength', function (assert) {
+        var dt = new KC3AkashiRepair.DeltaTime(0);
+        dt.now = 20.5 * 60 * 1000;
+        var tickLength = 8.75 * 60 * 1000;
+
+        const result = this.subject(dt, tickLength, 12345);
+
+        assert.propEqual(result, {
+          repairedHp: 2,
+          timeToNextRepair: 6.5 * 60 * 1000,
+        });
+      });
+
+      QUnit.test('timeElapsed < tickLength', function (assert) {
+        var dt = new KC3AkashiRepair.DeltaTime(0);
+        dt.now = 20.5 * 60 * 1000;
+        var tickLength = 22.75 * 60 * 1000;
+
+        const result = this.subject(dt, tickLength, 12345);
+
+        assert.propEqual(result, {
+          repairedHp: 1,
+          timeToNextRepair: 25.5 * 60 * 1000,
+        });
+      });
+
+      QUnit.test('cap repairedHp', function (assert) {
+        var dt = new KC3AkashiRepair.DeltaTime(0);
+        dt.now = 40 * 60 * 1000;
+        var tickLength = 22 * 60 * 1000 / 4;
+        var hpLost = 4;
+
+        const result = this.subject(dt, tickLength, hpLost);
+
+        assert.propEqual(result, {
+          repairedHp: 4,
+          timeToNextRepair: 0,
+        });
+      });
+    });
+
+    QUnit.module('.calculateTickLength', {
+      beforeEach() {
+        this.subject = KC3AkashiRepair.calculateTickLength;
+      }
+    }, function () {
+      QUnit.test('convert to akashiTime', function (assert) {
+        // subtract 30s, then round up to nearest minute
+        assert.equal(this.subject(21.5 * 60 * 1000 + 1, 1), 22 * 60 * 1000);
+        assert.equal(this.subject(21.5 * 60 * 1000, 1), 21 * 60 * 1000);
+      });
+
+      QUnit.test('calculate time per tick', function (assert) {
+        var dockTime = 21.5 * 60 * 1000;
+        var hpLost = 2;
+
+        const result = this.subject(dockTime, hpLost);
+
+        assert.equal(result, 10.5 * 60 * 1000);
+      });
+
+      QUnit.test('round up to nearest ms', function (assert) {
+        var dockTime = 10 * 60 * 1000;
+        var hpLost = 7;
+
+        const result = this.subject(dockTime, hpLost);
+
+        assert.equal(result, 85715);
+      });
+    });
+
+    QUnit.module('.calculatePreRepairProgress', {
+      beforeEach() {
+        this.subject = KC3AkashiRepair.calculatePreRepairProgress;
+      }
+    }, function () {
+      QUnit.test('success', function (assert) {
+        var dt = new KC3AkashiRepair.DeltaTime(0);
+        dt.now = 10.5 * 60 * 1000;
+
+        const result = this.subject(dt);
+
+        assert.propEqual(result, {
+          repairedHp: 0,
+          timeToNextRepair: 9.5 * 60 * 1000,
+        });
+      });
+    });
 });

--- a/tests/library/objects/Fleet.html
+++ b/tests/library/objects/Fleet.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../../../node_modules/qunitjs/qunit/qunit.css" media="screen">
+  </head>
+  <body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+    <!-- API DATA -->
+    <!-- TEST TOOLS -->
+    <script src="../../../node_modules/jquery/dist/jquery.min.js"></script>
+    <script src="../../../node_modules/qunitjs/qunit/qunit.js"></script>
+    <!-- SCRIPTS -->
+    <script src="../../../src/assets/js/global.js"></script>
+    <script src="../../../src/library/objects/Fleet.js"></script>
+    <script src="Fleet.js"></script>
+  </body>
+</html>

--- a/tests/library/objects/Fleet.js
+++ b/tests/library/objects/Fleet.js
@@ -1,0 +1,137 @@
+QUnit.module('Objects > Fleet > AkashiRepair', {
+  beforeEach() {
+    this.fleet = new KC3Fleet();
+  }
+}, function () {
+  QUnit.module('._updateRepairStatus', {
+    beforeEach() {
+      this.shipObj = {
+        isStriped() { return false; },
+        isFree() { return true; },
+        akashiMark: null,
+      };
+
+      this.subject = this.fleet._updateRepairStatus.bind(this.fleet);
+    }
+  }, function () {
+    QUnit.test('0 slots', function (assert) {
+      var func = this.subject(0);
+      
+      func(1234, 0, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+      func(1234, 1, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+      func(1234, 2, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+      func(1234, 3, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+      func(1234, 4, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+      func(1234, 5, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+    });
+
+    QUnit.test('2 slots', function (assert) {
+      var func = this.subject(2);
+      
+      func(1234, 0, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 1, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 2, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+      func(1234, 3, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+      func(1234, 4, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+      func(1234, 5, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+    });
+
+    QUnit.test('3 slots', function (assert) {
+      var func = this.subject(3);
+      
+      func(1234, 0, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 1, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 2, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 3, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+      func(1234, 4, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+      func(1234, 5, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+    });
+
+    QUnit.test('4 slots', function (assert) {
+      var func = this.subject(4);
+      
+      func(1234, 0, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 1, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 2, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 3, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 4, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+      func(1234, 5, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+    });
+
+    QUnit.test('5 slots', function (assert) {
+      var func = this.subject(5);
+      
+      func(1234, 0, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 1, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 2, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 3, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 4, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 5, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, false);
+    });
+
+    QUnit.test('6 slots', function (assert) {
+      var func = this.subject(6);
+      
+      func(1234, 0, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 1, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 2, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 3, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 4, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+      func(1234, 5, this.shipObj);
+      assert.equal(this.shipObj.akashiMark, true);
+    });
+
+    QUnit.test('isStriped', function (assert) {
+      var func = this.subject(1);
+      this.shipObj.isStriped = function () { return true; };
+
+      func(1234, 0, this.shipObj);
+
+      assert.equal(this.shipObj.akashiMark, false);
+    });
+
+    QUnit.test('!isFree', function (assert) {
+      var func = this.subject(1);
+      this.shipObj.isFree = function () { return false; };
+
+      func(1234, 0, this.shipObj);
+
+      assert.equal(this.shipObj.akashiMark, false);
+    });
+  });
+});


### PR DESCRIPTION
The repair timer should behave as follows: a repair (re)starts when the
player modifies their fleet from the Organize screen, and the resultant
fleet has meets the correct conditions (Akashi flagship, not red/orange
HP, not in docks). Modifying the fleet in other ways - i.e. scrapping,
modernization, equipment change - will not affect the timer.

When the player visits the homeport and at least 20 minutes have passed
since the repair started, HP will be recovered and the timer resets. If
it has been less than 20 minutes, no action is taken.

The number of ships affected by the repair is based on the number of
Ship Repair Facilities equipped by Akashi at the time the repair is
applied.

(This is my first time contributing to a public repository, so hopefully I didn't make too much of a mess of things...)