### PR TITLE
address #1895

### DIFF
--- a/src/pages/strategy/tabs/profile/profile.html
+++ b/src/pages/strategy/tabs/profile/profile.html
@@ -23,8 +23,12 @@
 	<div class="help_q">How to make my changed in-game "Profile Data" affect pages of this tab?</div>
 	<div class="help_a">Not necessary to use "Reload Button" of your Chrome, just click the "Heart Logo" on the top left side to reload latest data at any time.</div>
 	
+	<!--
+		this section is commented out because the statement
+		about having a higher sortie count being 201 catbomb is wrong or lacking evidence.
 	<div class="help_q">What does "Health Metric" mean?</div>
 	<div class="help_a">It shows how hard you have play this game (sortieing to normal maps) recently. Stay healthy gaming :) <br/>Not confirmed yet, but some proofs show that server counts them for you. And higher values you got, higher risk you would receive 201 catbomb.</div>
+	-->
 	
 	<div class="help_q">Can I export my whole history (not just profile data) and move it to another device?</div>
 	<div class="help_a">Go to "Data Backup" page.</div>
@@ -238,7 +242,7 @@
 	</div>
 	<br />
 	
-	<div class="page_section">Health Metric</div>
+	<div class="page_section">Sortie Statistics</div>
 	<div class="section_body">
 		<div class="rank_field month_battle_total">
 			<div class="rank_label bscolor3 fcolor2">Total battles from recent 30 days</div>


### PR DESCRIPTION
Fix #1895

- comment out "Health Metric" section in FAQ because it's simply wrong or lack of an actual proof or at least some sorts of evidence. And because the section name "Sortie Statistics" (see bullet right below) pretty much explains itself we don't need a FAQ section for it.

- rename "Health Metric" to "Sortie Statistics", we should not put value to users and "Sortie Statistics" is a neutral name that I think most of us would agree on.