### PR TITLE
Export directly to battleplayer site while holding shift key

### DIFF
--- a/src/pages/strategy/sortielogs.js
+++ b/src/pages/strategy/sortielogs.js
@@ -111,8 +111,8 @@
 			});
 			
 			// On-click sortie ID export battle
-			$(".sortie_list").on("click", ".sortie_dl", function(){
-				self.exportBattleImg(parseInt($(this).data("id")));
+			$(".sortie_list").on("click", ".sortie_dl", function(e){
+				self.exportBattleImg(parseInt($(this).data("id")), e);
 			});
 			
 			// On-click sortie toggles
@@ -711,7 +711,7 @@
 		
 		/* EXPORT REPLAY IMAGE
 		-------------------------------*/
-		this.exportBattleImg = function(sortieId){
+		this.exportBattleImg = function(sortieId, e){
 			if(this.exportingReplay) return false;
 			this.exportingReplay = true;
 			
@@ -744,6 +744,13 @@
 						return false;
 					}
 					
+					if(e.shiftKey) {
+						window.open("https://kc3kai.github.io/kancolle-replay/battleplayer.html#" + encodeURIComponent(JSON.stringify(sortieData), "_blank"));
+						self.exportingReplay = false;
+						$("body").css("opacity", "1");
+						return true;
+					}
+
 					console.log("Downloading reply", sortieId, ", data:", sortieData);
 					rcontext.font = "26pt Calibri";
 					rcontext.fillStyle = '#ffffff';


### PR DESCRIPTION
Implements #1901. Holding shift while clicking the replay button will directly open a new tab with that replay. 
Requires [kancolle-replay/#33](https://github.com/KC3Kai/kancolle-replay/pull/33) to work.