### PR TITLE
replaced  DataURI with Blob in showcase exporter

### DIFF
--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -351,12 +351,16 @@
     };
 
     ShowcaseExporter.prototype._openInNewTab = function (dataURL, topLine) {
-        if (dataURL.length >= 2 * 1024 * 1024) {
-            this._download(dataURL, topLine);
-        } else {
-            window.open(dataURL, "_blank");
-            this.complete({});
-        }
+        var byteString = atob(dataURL.split(',')[1]);
+        var mimeString = dataURL.split(',')[0].split(':')[1].split(';')[0];
+        var ab = new ArrayBuffer(byteString.length);
+        var ia = new Uint8Array(ab);
+        for (var i = 0; i < byteString.length; i++)
+            ia[i] = byteString.charCodeAt(i);
+
+        var blob = new Blob([ab], {type: mimeString});
+        window.open(URL.createObjectURL(blob), "_blank");
+        this.complete({});
     };
 
     /* SHIP EXPORT

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -8,6 +8,19 @@
         return weight + " " + px + "px \"Helvetica Neue\", Helvetica, Arial, sans-serif";
     }
 
+    //TODO remove once min supported chrome version will be 50+
+    HTMLCanvasElement.prototype.toBlob || Object.defineProperty( HTMLCanvasElement.prototype, 'toBlob', {
+        value: function( callback, type, quality ) {
+            var xhr = new XMLHttpRequest;
+            xhr.open( 'GET', this.toDataURL( type, quality ) );
+            xhr.responseType = 'arraybuffer';
+            xhr.onload = function(e) {
+                callback( new Blob( [this.response], {type: type || 'image/png'} ) );
+            }
+            xhr.send();
+        }
+    });
+
     window.ShowcaseExporter = function () {
         this.canvas = {};
         this.ctx = {};

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -9,17 +9,19 @@
     }
 
     //TODO remove once min supported chrome version will be 50+
-    HTMLCanvasElement.prototype.toBlob || Object.defineProperty( HTMLCanvasElement.prototype, 'toBlob', {
-        value: function( callback, type, quality ) {
-            var xhr = new XMLHttpRequest;
-            xhr.open( 'GET', this.toDataURL( type, quality ) );
-            xhr.responseType = 'arraybuffer';
-            xhr.onload = function(e) {
-                callback( new Blob( [this.response], {type: type || 'image/png'} ) );
+    if(typeof HTMLCanvasElement.prototype.toBlob!="function"){
+        Object.defineProperty( HTMLCanvasElement.prototype, 'toBlob', {
+            value: function( callback, type, quality ) {
+                var xhr = new XMLHttpRequest();
+                xhr.open( 'GET', this.toDataURL( type, quality ) );
+                xhr.responseType = 'arraybuffer';
+                xhr.onload = function(e) {
+                    callback( new Blob( [this.response], {type: type || 'image/png'} ) );
+                };
+                xhr.send();
             }
-            xhr.send();
-        }
-    });
+        });
+    }
 
     window.ShowcaseExporter = function () {
         this.canvas = {};


### PR DESCRIPTION
Made based on [this so answer](http://stackoverflow.com/a/12300351). Special thanks goes to @Adrymne

1.  It allows to ignore 2 * 1024 * 1024 url size limit for new tab
2.  Browser window resize works WAY faster if Blob used in url instead of dataURI