### PR TITLE
Sync quests data on different machines via Chrome Storage

### DIFF
--- a/src/library/managers/QuestManager.js
+++ b/src/library/managers/QuestManager.js
@@ -405,6 +405,19 @@ Uses KC3Quest objects to play around with
 		save :function(){
 			// Store only the list. The actives and opens will be redefined on load()
 			localStorage.quests = JSON.stringify(this.list);
+			localStorage.questsTimeStamp = Date.now();
+			// Store quests data to Chrome Storage
+			if (Object.keys(this.list).length > 0) {
+				var questsData = {
+					quests: localStorage.quests,
+					questsTimeStamp: localStorage.questsTimeStamp,
+					timeToResetDailyQuests: localStorage.timeToResetDailyQuests,
+					timeToResetWeeklyQuests: localStorage.timeToResetWeeklyQuests,
+					timeToResetMonthlyQuests: localStorage.timeToResetMonthlyQuests,
+					timeToResetQuarterlyQuests: localStorage.timeToResetQuarterlyQuests
+				};
+				chrome.storage.sync.set({KC3QuestsData: questsData});
+			}
 		},
 		
 		/* LOAD
@@ -424,11 +437,6 @@ Uses KC3Quest objects to play around with
 					tempQuest = tempQuests[ctr];
 					
 					// Add to actives or opens depeding on status
-					// 1: Unselected
-					// 2: Selected
-					if(tempQuest.status==1 || tempQuest.status==2){
-						
-					}
 					switch( tempQuest.status ){
 						case 1:	// Unselected
 							this.isOpen( tempQuest.id, true );

--- a/src/library/modules/Service.js
+++ b/src/library/modules/Service.js
@@ -483,6 +483,27 @@ See Manifest File [manifest.json] under "background" > "scripts"
 		}
 	});
 	
+	/* On Chrome Storage Changed
+	Sync localStorage parts with Chrome Storage
+	Used for sync quests data on different machines
+	------------------------------------------*/
+	chrome.storage.onChanged.addListener(function(changes, namespace) {
+		for (var key in changes) {
+			// console.log(key, changes[key]);
+			if (namespace == "sync" && key == "KC3QuestsData") {
+				var questsTimeStamp = changes[key].newValue.questsTimeStamp;
+				if ((typeof localStorage.questsTimeStamp == "undefined") || (questsTimeStamp > localStorage.questsTimeStamp)) {
+					localStorage.quests = changes[key].newValue.quests;
+					localStorage.questsTimeStamp = changes[key].newValue.questsTimeStamp;
+					localStorage.timeToResetDailyQuests = changes[key].newValue.timeToResetDailyQuests;
+					localStorage.timeToResetWeeklyQuests = changes[key].newValue.timeToResetWeeklyQuests;
+					localStorage.timeToResetMonthlyQuests = changes[key].newValue.timeToResetMonthlyQuests;
+					localStorage.timeToResetQuarterlyQuests = changes[key].newValue.timeToResetQuarterlyQuests;
+					KC3QuestManager.load();
+				}
+			}
+		}
+	});
 	
 	/* On Update Available
 	This will avoid auto-restart when webstore update is available


### PR DESCRIPTION
This feature allows you to synchronize quests and progress between different computers.
You should enable account synchronization in your browser settings to use this feature.

Note: This feature also synchronizes the quests reset time to avoid a double reset.

Signed-off-by: Aleksei Mamlin <mamlinav@gmail.com>