### PR TITLE
Sync quests data on different machines via Chrome Storage

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -775,6 +775,18 @@
 		]
 	},
 	{
+		"section": "SettingsDataSynchronization",
+		"help": "",
+		"contents": [
+			{
+				"id": "chromeSyncQuests",
+				"name": "SettingsChromeSyncQuests",
+				"type": "check",
+				"options" : {}
+			}
+		]
+	},
+	{
 		"section": "SettingsKC3DBSubmission",
 		"help" : "",
 		"contents" :[

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -28,6 +28,7 @@ Retreives when needed to apply on components
 				forceDMMLogin		: false,
 				apiRecorder			: false,
 				updateNotification	: 2,
+				chromeSyncQuests	: false,
 
 				showCatBombs		: true,
 				showApiError		: true,

--- a/src/library/managers/QuestManager.js
+++ b/src/library/managers/QuestManager.js
@@ -405,6 +405,21 @@ Uses KC3Quest objects to play around with
 		save :function(){
 			// Store only the list. The actives and opens will be redefined on load()
 			localStorage.quests = JSON.stringify(this.list);
+
+			// Check if synchronization is enabled and quests list is not empty
+			if (ConfigManager.chromeSyncQuests && Object.keys(this.list).length > 0) {
+				localStorage.questsTimeStamp = Date.now();
+				var questsData = {
+					quests: localStorage.quests,
+					questsTimeStamp: localStorage.questsTimeStamp,
+					timeToResetDailyQuests: localStorage.timeToResetDailyQuests,
+					timeToResetWeeklyQuests: localStorage.timeToResetWeeklyQuests,
+					timeToResetMonthlyQuests: localStorage.timeToResetMonthlyQuests,
+					timeToResetQuarterlyQuests: localStorage.timeToResetQuarterlyQuests,
+					dataStructVersion: 1
+				};
+				chrome.storage.sync.set({KC3QuestsData: questsData});
+			}
 		},
 		
 		/* LOAD
@@ -424,11 +439,6 @@ Uses KC3Quest objects to play around with
 					tempQuest = tempQuests[ctr];
 					
 					// Add to actives or opens depeding on status
-					// 1: Unselected
-					// 2: Selected
-					if(tempQuest.status==1 || tempQuest.status==2){
-						
-					}
 					switch( tempQuest.status ){
 						case 1:	// Unselected
 							this.isOpen( tempQuest.id, true );


### PR DESCRIPTION
This feature allows you to synchronize quests and progress between different computers.
You should enable account synchronization in your browser settings to use this feature.

Note: This feature also synchronizes the quests reset time to avoid a double reset.

Signed-off-by: Aleksei Mamlin <mamlinav@gmail.com>