### PR TITLE
Update data synchronization feature

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -775,13 +775,19 @@
 		]
 	},
 	{
-		"section": "SettingsDataSynchronization",
-		"help": "",
-		"contents": [
+		"section" : "SettingsDataSynchronization",
+		"help" : "",
+		"contents" : [
 			{
-				"id": "chromeSyncQuests",
-				"name": "SettingsChromeSyncQuests",
-				"type": "check",
+				"id" : "chromeSyncQuests",
+				"name" : "SettingsChromeSyncQuests",
+				"type" : "check",
+				"options" : {}
+			},
+			{
+				"id" : "dataSyncNotification",
+				"name" : "SettingsEnableDataSyncNotif",
+				"type" : "check",
 				"options" : {}
 			}
 		]

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -28,6 +28,7 @@ Retreives when needed to apply on components
 				forceDMMLogin		: false,
 				apiRecorder			: false,
 				updateNotification	: 2,
+				dataSyncNotification	: false,
 				chromeSyncQuests	: false,
 
 				showCatBombs		: true,

--- a/src/library/managers/QuestManager.js
+++ b/src/library/managers/QuestManager.js
@@ -13,6 +13,8 @@ Uses KC3Quest objects to play around with
 		open: [], // Array of quests seen on the quests page, regardless of state
 		active: [], // Array of quests that are active and counting
 		
+		syncStructVersion: 2, // Version of data structure, used for quests synchronization
+		
 		timeToResetDailyQuests: -1,
 		timeToResetWeeklyQuests: -1,
 		timeToResetMonthlyQuests: -1,
@@ -405,18 +407,22 @@ Uses KC3Quest objects to play around with
 		save :function(){
 			// Store only the list. The actives and opens will be redefined on load()
 			localStorage.quests = JSON.stringify(this.list);
-
+			
 			// Check if synchronization is enabled and quests list is not empty
 			if (ConfigManager.chromeSyncQuests && Object.keys(this.list).length > 0) {
-				localStorage.questsTimeStamp = Date.now();
+				if (typeof localStorage.questsVersion == "undefined") {
+					localStorage.questsVersion = 0;
+				}
+				localStorage.questsVersion++;
 				var questsData = {
 					quests: localStorage.quests,
-					questsTimeStamp: localStorage.questsTimeStamp,
+					questsVersion: localStorage.questsVersion,
 					timeToResetDailyQuests: localStorage.timeToResetDailyQuests,
 					timeToResetWeeklyQuests: localStorage.timeToResetWeeklyQuests,
 					timeToResetMonthlyQuests: localStorage.timeToResetMonthlyQuests,
 					timeToResetQuarterlyQuests: localStorage.timeToResetQuarterlyQuests,
-					dataStructVersion: 1
+					syncStructVersion: this.syncStructVersion,
+					syncTimeStamp: Date.now()
 				};
 				chrome.storage.sync.set({KC3QuestsData: questsData});
 			}

--- a/src/library/modules/Service.js
+++ b/src/library/modules/Service.js
@@ -492,25 +492,26 @@ See Manifest File [manifest.json] under "background" > "scripts"
 		if (ConfigManager.chromeSyncQuests && changes.KC3QuestsData && namespace == "sync") {
 			var newValue = changes.KC3QuestsData.newValue;
 			// Check if remote data structure version is matching with current expected structure
-			if (newValue.dataStructVersion == 1) {
-				// Check if local timestamp not set or remote timestamp is more then local
-				if ((typeof localStorage.questsTimeStamp == "undefined") || (newValue.questsTimeStamp > localStorage.questsTimeStamp)) {
+			if (newValue.syncStructVersion == KC3QuestManager.syncStructVersion) {
+				// Check if local quests version not set or remote version is more then local
+				if ((typeof localStorage.questsVersion == "undefined") || (newValue.questsVersion > localStorage.questsVersion)) {
+					localStorage.questsVersion = newValue.questsVersion;
 					// Check if JSON strings are the same, then there's nothing to do
 					if (newValue.quests === localStorage.quests) { return true; }
-					// Set new values
+					// Set new quests and reset times
 					localStorage.quests = newValue.quests;
-					localStorage.questsTimeStamp = newValue.questsTimeStamp;
 					localStorage.timeToResetDailyQuests = newValue.timeToResetDailyQuests;
 					localStorage.timeToResetWeeklyQuests = newValue.timeToResetWeeklyQuests;
 					localStorage.timeToResetMonthlyQuests = newValue.timeToResetMonthlyQuests;
 					localStorage.timeToResetQuarterlyQuests = newValue.timeToResetQuarterlyQuests;
-					// Desktop notification
-					if (ConfigManager.alert_desktop) {
+					// Check if desktop notifications enabled
+					if (ConfigManager.dataSyncNotification) {
+						var dt = new Date(+newValue.syncTimeStamp).toLocaleString();
 						chrome.notifications.create("kc3kai_quests", {
 							type: "basic",
 							title: KC3Meta.term("DesktopNotifyQuestsSyncTitle"),
-							message: KC3Meta.term("DesktopNotifyQuestsSyncMessage").format(Date(+newValue.questsTimeStamp)),
-							iconUrl: "../../assets/img/logo/128.png"
+							message: KC3Meta.term("DesktopNotifyQuestsSyncMessage").format(dt),
+							iconUrl: "../../assets/img/quests/sortie.jpg"
 						});
 					}
 				}


### PR DESCRIPTION
Changes:
* Use 'assets/img/quests/sortie.jpg' as icon
* Use locale-based date and time in notification
* Add a setting for enabling data synchronization notification
* Define version of data structure in QuestManager
* Use data version instead of timestamp for checking new data

Related to #1959 

![screenshot at 2017-04-10 19 56 04](https://cloud.githubusercontent.com/assets/1038834/24873426/69e8585c-1e29-11e7-9cf1-ca290a59f441.png)
![screenshot at 2017-04-11 12 08 02](https://cloud.githubusercontent.com/assets/1038834/24901469/dd3b39c4-1eaf-11e7-8622-e6a541a5ea75.png)