### PR TITLE
Improve expedition GS rate prediction

### DIFF
--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -1524,8 +1524,17 @@ ABYSS FLEET
 	font-size: 14px;
 	color:#ccc
 }
-.module.activity .activity_expeditionPlanner .expPlanner_text.gsrate_content.golden {
+.module.activity .activity_expeditionPlanner .expPlanner_text.gsrate_content[data-gsState="impossible"] {
+	color:#FF5555;
+}
+.module.activity .activity_expeditionPlanner .expPlanner_text.gsrate_content[data-gsState="no-overdrum"] {
+	color:orange;
+}
+.module.activity .activity_expeditionPlanner .expPlanner_text.gsrate_content[data-gsState="likely"] {
 	color:gold;
+}
+.module.activity .activity_expeditionPlanner .expPlanner_text.gsrate_content[data-gsState="guaranteed"] {
+	color:#00CC00;
 }
 .module.activity .activity_expeditionPlanner .expPlanner_text_passed {
 	font-size: 14px;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -2962,11 +2962,18 @@
 				if (rate >= 100) { return "guaranteed"; }
 			}(estSuccessRate));
 
-			var tooltipText = KC3Meta.term("ExpedGSRateExplainSparkle").format(sparkledCount);
-			// apply tooltip to overdrum expeds
-			if (typeof gsDrumCount !== "undefined")
-				tooltipText += "\n" + KC3Meta.term("ExpedGSRateExplainExtraDrum").format(fleetDrumCount, gsDrumCount);
 
+			var tooltipText = (function () {
+				if (!condCheckWithoutResupply) { return KC3Meta.term('ExpedGSRateExplainCondUnmet'); }
+				if (condIsUnsparkledShip && !condIsDrumExpedition) {
+					return KC3Meta.term('ExpedGSRateExplainMissingSparkle');
+				}
+				if (condIsDrumExpedition && !condIsOverdrum) {
+					return KC3Meta.term('ExpedGSRateExplainNoOverdrum').format(fleetDrumCount, gsDrumCount);
+				}
+				return KC3Meta.term('ExpedGSRateExplainSparkle').format(sparkledCount);
+			})();
+			
 			jqGSRate.attr("title", tooltipText).lazyInitTooltip();
 
 			// hide GS rate if user does not intend doing so.

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -2953,8 +2953,14 @@
 				})(estSuccessRate)
 			);
 
-			// turn gsRate text gold if high chance of GS
-			jqGSRate.toggleClass("golden", estSuccessRate > 80);
+			// colour GS text based on GS chance
+			jqGSRate.attr('data-gsState', function (rate) {
+				if (rate <= 0) { return "impossible"; }
+				if (condIsDrumExpedition && !condIsOverdrum) { return "no-overdrum"; }
+				if (rate < 80) { return ""; } // no colour
+				if (rate < 100 ) { return "likely"; }
+				if (rate >= 100) { return "guaranteed"; }
+			}(estSuccessRate));
 
 			var tooltipText = KC3Meta.term("ExpedGSRateExplainSparkle").format(sparkledCount);
 			// apply tooltip to overdrum expeds


### PR DESCRIPTION
Changes:

- Fix GS rate for non-drum expeditions with unsparkled ship(s) (see #1951)
- Output GS rate of `"0%"` if expedition requirements are not met (previously was `"???"`)
- Colour GS rate text golden if overdrumming is active (previously would also turn gold when `sparkledCount` >= 4 for regular expeditions)

I am open to advice regarding the latter two changes. The way they behaved previously was bugging me, but I'm uncertain this is better, particularly the last change.