### PR TITLE
SRoom Ship List supports settings saving

### DIFF
--- a/src/pages/strategy/tabs/ships/ships.css
+++ b/src/pages/strategy/tabs/ships/ships.css
@@ -57,6 +57,8 @@
 }
 
 .tab_ships .advanced_sorter {
+	float:left;
+	width:600px;
 	margin:0px 0px 3px 0px;
 }
 .tab_ships .advanced_sorter .adv_label {
@@ -70,6 +72,16 @@
 	height:18px;
 	line-height:18px;
 	float:left;
+}
+
+.tab_ships .control_buttons {
+	float:right;
+	margin:0px 0px 3px 0px;
+}
+.tab_ships .control_buttons .reset_default {
+	float:right;
+	font-size:12px;
+	line-height:18px;
 }
 
 .tab_ships .advanced_sorter .filter_box {
@@ -195,6 +207,24 @@
 	height:20px;
 	float:left;
 	margin:0px 2px 0px 0px;
+}
+.tab_ships .ship_item .ship_field .order.asc {
+	float:right;
+	width:0;
+	height:0;
+	margin-top:7px;
+	border-left:3px solid transparent;
+	border-right:3px solid transparent;
+	border-bottom:5px solid #333;
+}
+.tab_ships .ship_item .ship_field .order.desc {
+	float:right;
+	width:0;
+	height:0;
+	margin-top:7px;
+	border-left:3px solid transparent;
+	border-right:3px solid transparent;
+	border-top:5px solid #333;
 }
 .tab_ships .ingame_page {
 	width:680px;

--- a/src/pages/strategy/tabs/ships/ships.html
+++ b/src/pages/strategy/tabs/ships/ships.html
@@ -121,6 +121,9 @@
 		<div class="sorter_desc"></div>
 		<div class="clear"></div>
 	</div>
+	<div class="control_buttons">
+		<div class="reset_default hover">Reset All</div>
+	</div>
 	<div class="clear"></div>
 
 </div>
@@ -153,25 +156,10 @@
 			<div class="ship_field ship_lock"></div>
 			<div class="clear"></div>
 		</div>
-		<!-- <div class="ship_totals">
-			<div class="total_field total_left">Stat totals of currently shown ships:</div>
-			<div class="total_field total_level"></div>
-			<div class="total_field total_stat total_hp"></div>
-			<div class="total_field total_stat total_mod total_fp"></div>
-			<div class="total_field total_stat total_mod total_tp"></div>
-			<div class="total_field total_stat total_mod total_aa"></div>
-			<div class="total_field total_stat total_mod total_ar"></div>
-			<div class="total_field total_stat total_as"></div>
-			<div class="total_field total_stat total_ev"></div>
-			<div class="total_field total_stat total_ls"></div>
-			<div class="total_field total_stat total_lk"></div>
-			<div class="clear"></div>
-		</div> -->
 	</div>
 
 	<!-- SHIP LIST HTML CONTAINER -->
 	<div class="ship_list">
-
 	</div>
 
 	<div class="factory">

--- a/src/pages/strategy/themes/dark.css
+++ b/src/pages/strategy/themes/dark.css
@@ -522,11 +522,13 @@ button, input, select, textarea {
 .tab_ships .ship_list {
 	margin:0px 0px 5px 0px !important;
 }
+.tab_ships .ship_item .ship_field.sorted {
+	background:#303030;
+}
 .tab_ships .ship_item.odd .ship_field {
 	background:#303030;
 }
 .tab_ships .ship_item.even .ship_field {
-	/*background:#404040;*/
 	background:#303030;
 }
 .tab_ships .ship_item:hover .ship_field {

--- a/src/pages/strategy/themes/legacy.css
+++ b/src/pages/strategy/themes/legacy.css
@@ -394,6 +394,9 @@ body {
 .tab_ships .ship_filter_type .filter_check {
 	background:#000;
 }
+.tab_ships .ship_item .ship_field.sorted {
+	background:#c4c4c4;
+}
 .tab_ships .ship_item.odd .ship_field {
 	background:#efefef;
 }


### PR DESCRIPTION
Saving length unfixed filters/sorters to URL hash seems troublesome, instead, store them into `localStorage` like other tabs do. 

* Settings saved to `localStorage`: filters (inc stypes), sorters (inc multi keys), special states of viewing (page no, equip mode)
* Add a button to remove settings from `localStorage` (that means reset all to defaults)
* Indicate sorted column head (not suit to show an order arrow because orders of columns are indeed different...😅)