### PR TITLE
Update CSS customizations of DMM site play mode

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -224,7 +224,6 @@
 				"id" : "info_salt",
 				"name" : "SettingsSaltyShip",
 				"type" : "check",
-				"hide" : 0,
 				"options" : {}
 			},
 			{
@@ -719,68 +718,11 @@
 				"options" : {}
 			},
 			{
-				"id" : "dmm_translation",
-				"name" : "SettingsQuestOverlay",
-				"type" : "check",
-				"hide" : 1,
-				"options" : {}
-			},
-			{
-				"id" : "dmm_tracking",
-				"name" : "SettingsQuestTracking",
-				"type" : "check",
-				"hide" : 1,
-				"options" : {}
-			},
-			{
-				"id" : "dmm_askExit",
-				"name" : "SettingsConfirmExit",
-				"type" : "check",
-				"hide" : 1,
-				"options" : {}
-			},
-			{
-				"id" : "dmm_margin",
-				"name" : "SettingsScreenMargin",
-				"type" : "small_text",
-				"hide" : 1,
-				"options" : { "label" : "pixels" }
-			},
-			{
-				"id" : "dmm_bg_color",
-				"name" : "SettingsBGColor",
-				"type" : "long_text",
-				"hide" : 1,
+				"id" : "dmm_custom_css",
+				"name" : "SettingsDMMCustomCSS",
+				"type" : "textarea",
 				"options" : {
-					"placeholder" : "SettingsBGColorDesc",
-					"tooltip" : "SettingsBGColorDesc"
-				}
-			},
-			{
-				"id" : "dmm_bg_image",
-				"name" : "SettingsBGImage",
-				"type" : "long_text",
-				"hide" : 1,
-				"options" : { "placeholder" : "http://" }
-			},
-			{
-				"id" : "dmm_bg_size",
-				"name" : "SettingsBGSize",
-				"type" : "long_text",
-				"hide" : 1,
-				"options" : {
-					"placeholder" : "SettingsBGSizeDesc",
-					"tooltip" : "SettingsBGSizeDesc"
-				}
-			},
-			{
-				"id" : "dmm_bg_position",
-				"name" : "SettingsBGPosition",
-				"type" : "long_text",
-				"hide" : 1,
-				"options" : {
-					"placeholder" : "SettingsBGPositionDesc",
-					"tooltip" : "SettingsBGPositionDesc"
+					"tooltip" : "SettingsDMMCustomCSSTip"
 				}
 			}
 		]

--- a/src/library/injections/dmm_takeover.js
+++ b/src/library/injections/dmm_takeover.js
@@ -191,7 +191,7 @@
 			// Keep background image size fitting to window
 			var autoFitWindowHeight = function(){
 				$("body").css("min-height",
-					$(window).height() - self.gameZoomScale * config.api_margin
+					$(window).height() - self.gameZoomScale * $("#area-game").offset().top
 				);
 			};
 			autoFitWindowHeight();

--- a/src/library/injections/dmm_takeover.js
+++ b/src/library/injections/dmm_takeover.js
@@ -106,9 +106,11 @@
 		Override layout to only show game frame
 		--------------------------------------*/
 		resizeTimer: 0,
+		gameZoomScale: 1,
 		layout: function(){
+			this.gameZoomScale = (config.api_gameScale || 100) / 100;
 			$("body").addClass("kc3");
-			$("body").css({ margin:0, padding:0, 'min-width':800, 'min-height':480 });
+			$("body").css({ margin:0, padding:0, 'min-width':0, 'min-height':0 });
 			$("#main-ntg").css({ position: 'static' });
 			$("#area-game").css({
 				'margin-left': 'auto',
@@ -117,7 +119,7 @@
 				width: 800,
 				height: 480,
 				position: 'relative',
-				zoom: (ConfigManager.api_gameScale || 100) / 100
+				zoom: this.gameZoomScale
 			});
 			$("#game_frame").css({
 				width: 800,
@@ -142,7 +144,7 @@
 				if ($("#game_frame").width() != 800 || $("#game_frame").height() != 480) {
 					self.resizeGameFrame();
 				}
-			}, 30000);
+			}, 10000);
 		},
 		// Resize game frame to 800x480
 		resizeGameFrame: function(){
@@ -151,7 +153,6 @@
 				width: 800,
 				height: 480
 			});
-			$("body").css("min-height", $(window).height());
 		},
 		// Final process on document ready
 		resizeGameFrameFinal: function(){
@@ -170,6 +171,7 @@
 		Let users customize background via settings
 		--------------------------------------*/
 		backgrounds: function(){
+			var self = this;
 			// Top Margin from game frame to window
 			$("#area-game").css("margin-top", config.api_margin+"px");
 
@@ -184,6 +186,23 @@
 				$("body").css("background-size", config.api_bg_size);
 				$("body").css("background-position", config.api_bg_position);
 				$("body").css("background-repeat", "no-repeat");
+			}
+
+			// Keep background image size fitting to window
+			var autoFitWindowHeight = function(){
+				$("body").css("min-height",
+					$(window).height() - self.gameZoomScale * config.api_margin
+				);
+			};
+			autoFitWindowHeight();
+			$(window).resize(autoFitWindowHeight);
+
+			// User css customizations
+			if(config.dmm_custom_css !== ""){
+				var customCSS = document.createElement("style");
+				customCSS.type = "text/css";
+				customCSS.innerHTML = ConfigManager.dmm_custom_css;
+				$("head").append(customCSS);
 			}
 		},
 

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -174,17 +174,9 @@ Retreives when needed to apply on components
 				subtitle_speaker	: false,
 				google_translate	: true,
 				map_markers			: true,
-				
 				dmm_forcecookies	: false,
 				dmm_customize		: false,
-				dmm_translation		: true,
-				dmm_tracking		: true,
-				dmm_askExit			: false,
-				dmm_margin			: 0,
-				dmm_bg_color		: "#def",
-				dmm_bg_image		: "",
-				dmm_bg_size			: "cover",
-				dmm_bg_position		: "top center",
+				dmm_custom_css		: "",
 				
 				pan_theme			: "natsuiro",
 				pan_size			: "big",


### PR DESCRIPTION
* Fix background image size issue by dynamically setting window min-height (Close #1824)
* Also take top margin and zoom scale into account (Close #1989)
* Clean config attributes not used any more
* Also add a setting to customize CSS of DMM top page like panel and SRoom one
  * But should keep this in mind: the CSS can be customized by injected content scripts is only applied to the top DMM site. The OSAPI gadget iframe (which game Flash Player inside) will not be affected directly. 
```
top dmm page (www.dmm.com)
|
\ -- `#game_frame` osapi gadget iframe (osapi.dmm.com)
     |
     \ -- `#externalswf` flash player embed (your server ip/kcs/mainD2.swf)
```

@KC3Kai/product the `min-height` of window is a simple calculation to avoid scroll bar appearing, please test this on your side to see if any other factor would cause the unexpected height change.