### PR TITLE
Improve Akashi Repair timer display

### DIFF
--- a/src/library/objects/AkashiRepair.js
+++ b/src/library/objects/AkashiRepair.js
@@ -89,14 +89,31 @@ Manages the timer for a player's Akashi repairs.
   /*------------------[ INTERNAL CLASSES ]------------------*/
   /*--------------------------------------------------------*/
 
-  var Timer = function () { this.startTime = undefined; };
-  Timer.prototype.start = function () { this.startTime = Date.now(); };
-  Timer.prototype.stop = function () { this.startTime = undefined; };
+  /*-----------------------[ TIMER ]------------------------*/
+
+  var LOCAL_STORAGE_KEY = 'akashiRepairStartTime';
+
+  var Timer = function () {
+    this.startTime = parseInt(localStorage.getItem(LOCAL_STORAGE_KEY), 10) || undefined;
+  };
+
+  Timer.prototype.start = function () {
+    this.startTime = Date.now();
+    localStorage.setItem(LOCAL_STORAGE_KEY, this.startTime);
+  };
+  Timer.prototype.stop = function () {
+    this.startTime = undefined;
+    localStorage.removeItem(LOCAL_STORAGE_KEY);
+  };
+
   Timer.prototype.isRunning = function () { return !!this.startTime; };
+
   Timer.prototype.getElapsed = function () {
     return new KC3AkashiRepair.DeltaTime(this.startTime);
   };
   KC3AkashiRepair.Timer = Timer;
+
+  /*---------------------[ DELTA TIME ]---------------------*/
 
   var DeltaTime = function (startTime) {
     this.startTime = startTime;

--- a/src/library/objects/AkashiRepair.js
+++ b/src/library/objects/AkashiRepair.js
@@ -19,7 +19,11 @@ Manages the timer for a player's Akashi repairs.
   // Calculate the amount of HP that can be repaired,
   // and the amount of time until the next point of HP can be repaired
   KC3AkashiRepair.prototype.getProgress = function (dockTime, hpLost) {
-    if (!dockTime || !hpLost) { return { repairedHp: 0, timeToNextRepair: 0 }; }
+    if (hpLost === 0) { return { repairedHp: 0, timeToNextRepair: 0 }; }
+    // if we don't have enough information, just give up
+    if (!Number.isInteger(hpLost) || !Number.isInteger(dockTime) || !this.timer.isRunning()) {
+      return {/* repairedHp: undefined, timeToNextRepair: undefined */};
+    }
     var elapsed = this.timer.getElapsed();
 
     if (!elapsed.canDoRepair()) {

--- a/src/pages/devtools/themes/natsuiro/js/Shipbox.js
+++ b/src/pages/devtools/themes/natsuiro/js/Shipbox.js
@@ -289,9 +289,10 @@ KC3改 Ship Box for Natsuiro theme
 					((RepairTimes.akashi>0)
 						?String(RepairTimes.akashi).toHHMMSS()
 						:KC3Meta.term("PanelCantRepair"))
-			).lazyInitTooltip();
+			).lazyInitTooltip({ position: { at: "left+25 bottom+5" } });
 		}else{
-			$(".ship_hp_box", this.element).attr("title", KC3Meta.term("PanelNoRepair")).lazyInitTooltip();
+			$(".ship_hp_box", this.element).attr("title", KC3Meta.term("PanelNoRepair"))
+				.lazyInitTooltip({ position: { at: "left+25 bottom+5" } });
 		}
 		
 		// If ship is being repaired

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -53,7 +53,7 @@
 		// A lazy initialzing method, prevent duplicate tooltip instance
 		$.fn.lazyInitTooltip = function(opts) {
 			if(typeof this.tooltip("instance") === "undefined") {
-				this.tooltip(opts || nativeTooltipOptions);
+				this.tooltip($.extend(true, {}, nativeTooltipOptions, opts));
 			}
 			return this;
 		};

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -316,7 +316,8 @@
 					dockTime = shipData.repair[0],
 					repairProgress = PlayerManager.akashiRepair.getProgress(dockTime, hpLost);
 
-				$('.ship_repair_tick', shipBox).attr('data-tick', repairProgress.repairedHp);
+				$('.ship_repair_tick', shipBox).attr('data-tick',
+					Number.isInteger(repairProgress.repairedHp) ? repairProgress.repairedHp : '?');
 				$('.ship_repair_timer', shipBox).text(
 					(function (t) {
 						if (t === 0) {


### PR DESCRIPTION
- Move repair time tooltip down so it doesn't overlap the Akashi repair timer on ship HP bars ([old](http://i.imgur.com/bdF2clk.png), [new](http://i.imgur.com/vfZB18Q.png))
- Persist Akashi Repair timer using localStorage
- Fix Akashi repair timer output if start time is unknown ([example](http://i.imgur.com/DwEvw4J.png))