### PR TITLE
Show green border around new ship drops

### DIFF
--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -888,6 +888,9 @@ ABYSS FLEET
 	height:15px;
 	vertical-align:top;
 }
+.module.activity .battle_drop.new_ship {
+	 filter: drop-shadow(0px 0px 3px #1f1);
+}
 /* Battle Planes */
 .module.activity .battle_planes {
 	width:180px;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -796,7 +796,7 @@
 		$(".module.activity .battle_rating img").attr("src", "../../../../assets/img/ui/dark_rating.png").css("opacity", "");
 		$(".module.activity .battle_rating").lazyInitTooltip();
 		$(".module.activity .battle_drop img").attr("src", "../../../../assets/img/ui/dark_shipdrop.png");
-		$(".module.activity .battle_drop").removeData("masterId").off("dblclick");
+		$(".module.activity .battle_drop").removeData("masterId").off("dblclick").removeClass("new_ship");
 		$(".module.activity .battle_drop").attr("title", "").lazyInitTooltip();
 		$(".module.activity .battle_cond_value").text("");
 		$(".module.activity .battle_engagement").prev().text(KC3Meta.term("BattleEngangement"));
@@ -2253,6 +2253,7 @@
 						.data("masterId", thisNode.drop)
 						.on("dblclick", this.shipDoubleClickFunction)
 						.attr("title", KC3Meta.shipName( KC3Master.ship(thisNode.drop).api_name ))
+						.toggleClass("new_ship", KC3ShipManager.find(w => RemodelDb.remodelGroup(thisNode.drop) === RemodelDb.remodelGroup(w.masterId)).length === 0)
 						.lazyInitTooltip();
 				}
 


### PR DESCRIPTION
Kind of a reminder that the dropped ship is a ship you don't have and you *might* want to heart lock her.

Possible 'bug': If someone gets a new ship on a early node, and then get the same ship in a further node, it will get tagged as a 'new' ship. This is because ships are added to `KC3ShipManager` **after** returning to port.

![Visual example](https://cloud.githubusercontent.com/assets/5676386/25444586/f3b85d8c-2aab-11e7-9980-340759fae9e9.png)