### PR TITLE
Battle replay bossbar

### DIFF
--- a/src/library/managers/SortieManager.js
+++ b/src/library/managers/SortieManager.js
@@ -67,6 +67,14 @@ Stores and manages states and functions during sortie of fleets (including PvP b
 				time: stime
 			};
 			// Add optional properties
+			// Record states of unclear normal (or EO) maps
+			if((world < 10 && mapnum > 4) || typeof thisMap.kills !== "undefined"){
+				sortie.mapinfo = { "api_cleared": thisMap.clear };
+				if(typeof thisMap.kills !== "undefined"){
+					sortie.mapinfo.api_defeat_count = thisMap.kills;
+				}
+			}
+			// Reocrd boss HP gauge states of event maps
 			if(eventData){
 				var mergedEventInfo = {};
 				$.extend(mergedEventInfo, eventData, {

--- a/src/library/objects/Ship.js
+++ b/src/library/objects/Ship.js
@@ -652,9 +652,9 @@ KC3改 Ship Object
 	// check if this ship is capable of equipping Daihatsu (landing craft)
 	KC3Ship.prototype.canEquipDaihatsu = function() {
 		var master = this.master();
-		// ship types: DD=2, CL=3, AV=16, LHA=17, AO=22
+		// ship types: DD=2, CL=3, BB=9, AV=16, LHA=17, AO=22
 		// so far only ships with types above can equip daihatsu.
-		if ([2,3,16,17,22].indexOf( master.api_stype ) === -1)
+		if ([2,3,9,16,17,22].indexOf( master.api_stype ) === -1)
 			return false;
 
 		// excluding Akitsushima(445) and Hayasui(352)
@@ -664,7 +664,7 @@ KC3改 Ship Object
 		
 		// only few DDs and CLs are capable of equipping daihatsu
 		// see comments below.
-		if ([2 /* DD */,3 /* CL */].indexOf( master.api_stype ) !== -1 &&
+		if ([2 /* DD */,3 /* CL */,9 /* BB */].indexOf( master.api_stype ) !== -1 &&
 			[
 				// Abukuma K2(200), Kinu K2(487)
 				200, 487,
@@ -673,7 +673,9 @@ KC3改 Ship Object
 				// Kasumi K2(464), Kasumi K2B(470), Ooshio K2(199), Asashio K2D(468), Arashio K2(490)
 				464, 470, 199, 468, 490,
 				// Verniy(147), Kawakaze K2(469)
-				147, 469
+				147, 469,
+				// Nagato K2(541)
+				541
 			].indexOf( this.masterId ) === -1)
 			return false;
 		return true;

--- a/src/pages/strategy/sortielogs.js
+++ b/src/pages/strategy/sortielogs.js
@@ -791,11 +791,17 @@
 				rcontext.drawImage( domImg, 0, 0, 400, 400, 0, 0, 400, 400 );
 				
 				KC3Database.get_sortie_data( sortieId, function(sortieData){
-					var mapdata = JSON.parse(localStorage.maps)["m"+sortieData.world+sortieData.mapnum];
-					var bossStat = mapdata.stat.onBoss;
-					sortieData.defeat_count = mapdata.kills;
-					sortieData.now_maphp = bossStat.hpdat[sortieData.id][0];
-					sortieData.max_maphp = bossStat.hpdat[sortieData.id][1];
+					var mapdata = self.maps["m"+sortieData.world+sortieData.mapnum];
+					var mapStat = mapdata.stat;
+					
+					if(mapdata.kills) sortieData.defeat_count = mapdata.kills;
+					console.debug("kills", mapdata.kills);
+					console.debug("mapStat", mapdata.stat);
+					if(mapStat) {
+						sortieData.now_maphp = mapStat.onBoss.hpdat[sortieData.id][0];
+						sortieData.max_maphp = mapStat.onBoss.hpdat[sortieData.id][1];
+					}
+					
 					if(sortieData.battles.length===0){
 						self.exportingReplay = false;
 						$("body").css("opacity", "1");

--- a/src/pages/strategy/sortielogs.js
+++ b/src/pages/strategy/sortielogs.js
@@ -791,6 +791,11 @@
 				rcontext.drawImage( domImg, 0, 0, 400, 400, 0, 0, 400, 400 );
 				
 				KC3Database.get_sortie_data( sortieId, function(sortieData){
+					var mapdata = JSON.parse(localStorage.maps)["m"+sortieData.world+sortieData.mapnum];
+					var bossStat = mapdata.stat.onBoss;
+					sortieData.defeat_count = mapdata.kills;
+					sortieData.now_maphp = bossStat.hpdat[sortieData.id][0];
+					sortieData.max_maphp = bossStat.hpdat[sortieData.id][1];
 					if(sortieData.battles.length===0){
 						self.exportingReplay = false;
 						$("body").css("opacity", "1");

--- a/src/pages/strategy/sortielogs.js
+++ b/src/pages/strategy/sortielogs.js
@@ -805,7 +805,22 @@
 							.format(mapId, mapData.kills, KC3Meta.gauge(mapId.substr(1)))
 						);
 					} else if(mapData.stat && mapData.stat.onBoss && mapData.stat.onBoss.hpdat){
-						let bossHpArr = mapData.stat.onBoss.hpdat[sortieData.id];
+						let hpObj = mapData.stat.onBoss.hpdat;
+						let bossHpArr = hpObj[sortieData.id];
+						if(Array.isArray(bossHpArr)){
+							// Get boss HP on previous sortie
+							let hpKeyArr = Object.keys(hpObj);
+							let sortieKeyIdx = hpKeyArr.indexOf(String(sortieData.id));
+							if(sortieKeyIdx > 0){
+								let prevBossHpArr = hpObj[hpKeyArr[sortieKeyIdx - 1]];
+								// Do not use previous HP if max changed
+								if(bossHpArr[1] !== prevBossHpArr[1]){
+									bossHpArr = [bossHpArr[1], bossHpArr[1]];
+								} else {
+									bossHpArr = prevBossHpArr;
+								}
+							}
+						}
 						if(Array.isArray(bossHpArr)){
 							sortieData.now_maphp = bossHpArr[0];
 							sortieData.max_maphp = bossHpArr[1];

--- a/src/pages/strategy/sortielogs.js
+++ b/src/pages/strategy/sortielogs.js
@@ -791,21 +791,28 @@
 				rcontext.drawImage( domImg, 0, 0, 400, 400, 0, 0, 400, 400 );
 				
 				KC3Database.get_sortie_data( sortieId, function(sortieData){
-					var mapdata = self.maps["m"+sortieData.world+sortieData.mapnum];
-					var mapStat = mapdata.stat;
-					
-					if(mapdata.kills) sortieData.defeat_count = mapdata.kills;
-					console.debug("kills", mapdata.kills);
-					console.debug("mapStat", mapdata.stat);
-					if(mapStat) {
-						sortieData.now_maphp = mapStat.onBoss.hpdat[sortieData.id][0];
-						sortieData.max_maphp = mapStat.onBoss.hpdat[sortieData.id][1];
-					}
-					
 					if(sortieData.battles.length===0){
 						self.exportingReplay = false;
 						$("body").css("opacity", "1");
 						return false;
+					}
+					
+					let mapId = ["m", sortieData.world, sortieData.mapnum].join("");
+					let mapData = self.maps[mapId];
+					if(mapData.kills){
+						sortieData.defeat_count = mapData.kills;
+						console.debug("Map {0} boss gauge: {1}/{2} kills"
+							.format(mapId, mapData.kills, KC3Meta.gauge(mapId.substr(1)))
+						);
+					} else if(mapData.stat && mapData.stat.onBoss && mapData.stat.onBoss.hpdat){
+						let bossHpArr = mapData.stat.onBoss.hpdat[sortieData.id];
+						if(Array.isArray(bossHpArr)){
+							sortieData.now_maphp = bossHpArr[0];
+							sortieData.max_maphp = bossHpArr[1];
+							console.debug("Map {0} boss gauge: HP {1}/{2}"
+								.format(mapId, bossHpArr[0], bossHpArr[1])
+							);
+						}
 					}
 					
 					if(e.which === 3) {

--- a/src/pages/strategy/sortielogs.js
+++ b/src/pages/strategy/sortielogs.js
@@ -765,10 +765,15 @@
 		function updateMapHpInfo(self, sortieData) {
 			let mapId = ["m", sortieData.world, sortieData.mapnum].join("");
 			let mapData = self.maps[mapId];
-			if(mapData.kills !== undefined){
-				sortieData.defeat_count = mapData.kills;
+			if(sortieData.mapinfo){
+				let maxKills = KC3Meta.gauge(mapId.substr(1));
+				if(!!sortieData.mapinfo.api_cleared){
+					sortieData.defeat_count = maxKills;
+				} else {
+					sortieData.defeat_count = sortieData.mapinfo.api_defeat_count || 0;
+				}
 				console.debug("Map {0} boss gauge: {1}/{2} kills"
-					.format(mapId, mapData.kills, KC3Meta.gauge(mapId.substr(1)))
+					.format(mapId, sortieData.defeat_count, maxKills)
 				);
 			} else if(sortieData.eventmap && sortieData.eventmap.api_gauge_type !== undefined) {
 				sortieData.now_maphp = sortieData.eventmap.api_now_maphp;


### PR DESCRIPTION
Allows the battle replay to show the boss bar:
 * For regular world maps (including EO maps): only new runs will record boss bar info, old replays will not show.
 * For event world maps: new runs ofc, if old maps stats data not lost, old replays will also show boss hp bar.