### PR TITLE
add translation of the strategy room

### DIFF
--- a/src/pages/strategy/strategy.html
+++ b/src/pages/strategy/strategy.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 		<!-- @nonbuildstart -->
@@ -9,7 +9,7 @@
 		<link href="../../assets/css/jquery-ui.min.css" rel="stylesheet" type="text/css">
 		<link href="../../assets/css/bootstrap-slider.min.css" rel="stylesheet" type="text/css">
 		<link href="strategy.css" rel="stylesheet" type="text/css">
-		<title>KC3改 Strategy Room</title>
+		<title class="i18n">KC3KaiStrategyRoom</title>
 		<link rel="shortcut icon" href="../../assets/img/logo/48.png" type="image/x-icon" />
 	</head>
 	<body class="xhidden">
@@ -22,85 +22,85 @@
 						<img src="../../assets/img/logo/128.png" alt="KC3改" />
 					</div>
 					<div class="submenu">
-						<div class="title">Player</div>
+						<div class="title i18n">Player</div>
 						<ul class="menulist">
-							<li data-id="profile" class="active">Profile</li>
+							<li data-id="profile" class="active i18n">Profile</li>
 							<!-- <li data-id="newsfeed">Newsfeed</li> -->
-							<li data-id="screenshots">Screenshots</li>
-							<li data-id="resources">Resources</li>
-							<li data-id="consumables">Consumables</li>
-							<li data-id="experience">Experience</li>
-							<li data-id="showcase">Showcase</li>
-							<li data-id="overlodger">Ledger</li>
-							<li data-id="databackup">Data Backup</li>
+							<li data-id="screenshots" class="i18n">Screenshots</li>
+							<li data-id="resources" class="i18n">Resources</li>
+							<li data-id="consumables" class="i18n">Consumables</li>
+							<li data-id="experience" class="i18n">Experience</li>
+							<li data-id="showcase" class="i18n">Showcase</li>
+							<li data-id="overlodger" class="i18n">Ledger</li>
+							<li data-id="databackup" class="i18n">Data Backup</li>
 						</ul>
 					</div>
 					<div class="submenu">
-						<div class="title">Ships</div>
+						<div class="title i18n">Ships</div>
 						<ul class="menulist">
-							<li data-id="ships">Ship List</li>
-							<li data-id="builds">Construction</li>
-							<li data-id="lscs">LSC</li>
-							<li data-id="docking">Docking</li>
-							<li data-id="expcalc">Leveling</li>
-							<li data-id="badge">Badge</li>
+							<li data-id="ships" class="i18n">Ship List</li>
+							<li data-id="builds" class="i18n">Construction</li>
+							<li data-id="lscs" class="i18n">LSC</li>
+							<li data-id="docking" class="i18n">Docking</li>
+							<li data-id="expcalc" class="i18n">Leveling</li>
+							<li data-id="badge" class="i18n">Badge</li>
 						</ul>
 					</div>
 					<div class="submenu">
-						<div class="title">Equipment</div>
+						<div class="title i18n">Equipment</div>
 						<ul class="menulist">
-							<li data-id="gears">Equipment List</li>
-							<li data-id="crafts">Crafting</li>
-							<li data-id="aircraft">Aircraft</li>
-							<li data-id="akashi">Akashi</li>
+							<li data-id="gears" class="i18n">Equipment List</li>
+							<li data-id="crafts" class="i18n">Crafting</li>
+							<li data-id="aircraft" class="i18n">Aircraft</li>
+							<li data-id="akashi" class="i18n">Akashi</li>
 						</ul>
 					</div>
 					<div class="submenu">
-						<div class="title">Fleet</div>
+						<div class="title i18n">Fleet</div>
 						<ul class="menulist">
-							<li data-id="fleet">Manager</li>
-							<li data-id="locking">Locking</li>
+							<li data-id="fleet" class="i18n">Manager</li>
+							<li data-id="locking" class="i18n">Locking</li>
 						</ul>
 					</div>
 					<div class="submenu">
-						<div class="title">Quests</div>
+						<div class="title i18n">Quests</div>
 						<ul class="menulist">
-							<li data-id="flowchart">Flowchart</li>
-							<li data-id="shipquests">Required Ships</li>
+							<li data-id="flowchart" class="i18n">Flowchart</li>
+							<li data-id="shipquests" class="i18n">Required Ships</li>
 						</ul>
 					</div>
 					<div class="submenu">
-						<div class="title">Battles</div>
+						<div class="title i18n">Battles</div>
 						<ul class="menulist">
-							<li data-id="maps">Maps</li>
-							<li data-id="event">Events</li>
-							<li data-id="encounters">Encounters</li>
-							<li data-id="pvp">PvP History</li>
+							<li data-id="maps" class="i18n">Maps</li>
+							<li data-id="event" class="i18n">Events</li>
+							<li data-id="encounters" class="i18n">Encounters</li>
+							<li data-id="pvp" class="i18n">PvP History</li>
 						</ul>
 					</div>
 					<div class="submenu">
-						<div class="title">Expeditions</div>
+						<div class="title i18n">Expeditions</div>
 						<ul class="menulist">
-							<li data-id="expedpast">History</li>
-							<li data-id="expedscorer">Scorer</li>
-							<li data-id="expedtable">Table</li>
+							<li data-id="expedpast" class="i18n">History</li>
+							<li data-id="expedscorer" class="i18n">Scorer</li>
+							<li data-id="expedtable" class="i18n">Table</li>
 						</ul>
 					</div>
 					<div class="submenu">
-						<div class="title">Library</div>
+						<div class="title i18n">Library</div>
 						<ul class="menulist">
-							<li data-id="mstupdate">Updates</li>
-							<li data-id="mstship">Ships</li>
-							<li data-id="mstgear">Equipment</li>
-							<li data-id="compare">Compare</li>
+							<li data-id="mstupdate" class="i18n">Updates</li>
+							<li data-id="mstship" class="i18n">Ships</li>
+							<li data-id="mstgear" class="i18n">Equipment</li>
+							<li data-id="compare" class="i18n">Compare</li>
 						</ul>
 					</div>
 					<div class="submenu dev-only">
-						<div class="title">Dev-Only</div>
+						<div class="title i18n">Dev-Only</div>
 						<ul class="menulist">
-							<li data-id="playground">Playground</li>
-							<li data-id="translations">Translations</li>
-							<li data-id="quotes">Quotes</li>
+							<li data-id="playground" class="i18n">Playground</li>
+							<li data-id="translations" class="i18n">Translations</li>
+							<li data-id="quotes" class="i18n">Quotes</li>
 						</ul>
 					</div>
 				</div>
@@ -112,8 +112,8 @@
 				<div class="clear"></div>
 			</div>
 			<div class="float_toolbar">
-				<div class="back_to_top hover">Back to Top</div>
-				<div class="reload hover">Refresh Tab</div>
+				<div class="back_to_top hover i18n">Back to Top</div>
+				<div class="reload hover i18n">Refresh Tab</div>
 			</div>
 		</div>
 

--- a/src/pages/strategy/strategy.js
+++ b/src/pages/strategy/strategy.js
@@ -1,12 +1,11 @@
 (function(){
 	"use strict";
 	_gaq.push(['_trackPageview']);
-	
+
 	const HASH_PARAM_DELIM = "-";
-	const WINDOW_TITLE = "KC3改 Strategy Room";
 	var activeTab;
 	var themeName;
-	
+
 	Object.defineProperties(window,{
 		activeTab:{
 			get:function(){return activeTab;},
@@ -18,7 +17,7 @@
 			get:function(){return activeTab.definition;}
 		}
 	});
-	
+
 	$(document).on("ready", function(){
 		// Initialize data managers
 		ConfigManager.load();
@@ -34,7 +33,7 @@
 		RemodelDb.init();
 		KC3Translation.execute();
 		WhoCallsTheFleetDb.init("../../");
-		
+
 		themeName = ConfigManager.sr_theme || "dark";
 		var themeCSS = document.createElement("link");
 		themeCSS.rel = "stylesheet";
@@ -48,32 +47,32 @@
 			customCSS.innerHTML = ConfigManager.sr_custom_css;
 			$("head").append(customCSS);
 		}
-		
+
 		if(!KC3Master.available){
 			$("#error").text("Strategy Room is not ready. Please open the game once so we can get data. Also make sure following the instructions, that open the F12 devtools panel first before the Game Player shown.");
 			$("#error").show();
 		}
-		
+
 		// show dev-only pages conditionally
 		if ( ConfigManager.devOnlyPages ) {
 			$("#menu .submenu.dev-only").show();
 		}
-		
+
 		// Click a menu item
 		$("#menu .submenu ul.menulist li").on("click", function(){
 			// Google Analytics just for click event
 			var gaEvent = "Strategy Room: " + $(this).data("id");
 			_gaq.push(['_trackEvent', gaEvent, 'clicked']);
-			
+
 			KC3StrategyTabs.reloadTab(this);
 		});
-		
+
 		// Refresh current tab and force data reloading
 		$(".logo").on("click", function(){
 			console.debug("Reloading current tab [", KC3StrategyTabs.pageParams[0], "] on demand");
 			KC3StrategyTabs.reloadTab(undefined, true);
 		});
-		
+
 		$("#contentHtml").on("click", ".page_help_btn", function(){
 			if( $(".page_help").is(":visible") ){
 				$(".page_help").fadeOut();
@@ -81,7 +80,7 @@
 				$(".page_help").fadeIn();
 			}
 		});
-		
+
 		// Add back to top and reload float button
 		$(window).scroll(function(){
 			if($(this).scrollTop() > 90){
@@ -96,24 +95,24 @@
 		$(".float_toolbar .reload").on("click", function(){
 			$(".logo").trigger("click");
 		});
-		
+
 		$("#error").on("click", function(){
 			$(this).empty().hide();
 		});
-		
+
 		// Add listener to react on URL hash changed
 		window.addEventListener('popstate', KC3StrategyTabs.onpopstate);
-		
+
 		// If there is a hash tag on URL, set it as initial selected
 		KC3StrategyTabs.pageParams = window.location.hash.substring(1).split(HASH_PARAM_DELIM);
 		if(KC3StrategyTabs.pageParams[0] !== ""){
 			$("#menu .submenu ul.menulist li").removeClass("active");
 			$("#menu .submenu ul.menulist li[data-id="+KC3StrategyTabs.pageParams[0]+"]").addClass("active");
 		}
-		
+
 		// Load initially selected
 		$("#menu .submenu ul.menulist li.active").click();
-		
+
 	});
 
 	KC3StrategyTabs.gotoTab = function(tab, hashParams) {
@@ -148,6 +147,7 @@
 		$("#menu .submenu ul.menulist li").removeClass("active");
 		$(tab).addClass("active");
 		$("#contentHtml").hide().empty();
+		const WINDOW_TITLE = $(document).find("title").text().split("-")[0];
 		window.document.title = "{0} - {1}".format(WINDOW_TITLE, $(tab).text());
 		if(KC3StrategyTabs.loading != KC3StrategyTabs.pageParams[0]) {
 			window.location.hash = KC3StrategyTabs.loading;
@@ -228,7 +228,7 @@
 			return this;
 		};
 	}(jQuery));
-	
+
 	/**
 	 * Simulate throttle/debounce func like the ones in lodash
 	 * docs see: https://github.com/cowboy/jquery-throttle-debounce


### PR DESCRIPTION
strategy room is absolutely an English page now, this commit add the i18n class of some keywords so we can localize it through kc3-translations
here is the terms.json used for translation:
`"KC3KaiStrategyRoom": "KC3改 Strategy Room",
	"Player": "Player",
	"Profile": "Profile",
	"Screenshots": "Screenshots",
	"Resources": "Resources",
	"Consumables": "Consumables",
	"Showcase": "Showcase",
	"Ledger": "Ledger",
	"Data Backup": "Data Backup",
	"Ships": "Ships",
	"Ship List": "Ship List",
	"Construction": "Construction",
	"LSC": "LSC",
	"Docking": "Docking",
	"Leveling": "Leveling",
	"Badge": "Badge",
	"Equipment": "Equipment",
	"Equipment List": "Equipment List",
	"Crafting": "Crafting",
	"Aircraft": "Aircraft",
	"Akashi": "Akashi",
	"Fleet": "Fleet",
	"Manager": "Manager",
	"Locking": "Locking",
	"Quests": "Quests",
	"Flowchart": "Flowchart",
	"Required Ships": "Required Ships",
	"Battles": "Battles",
	"Maps": "Maps",
	"Events": "Events",
	"Encounters": "Encounters",
	"PvP History": "PvP History",
	"Expeditions": "Expeditions",
	"History": "History",
	"Scorer": "Scorer",
	"Table": "Table",
	"Library": "Library",
	"Updates": "Updates",
	"Compare": "Compare"`