### PR TITLE
Ship list enhancements

### DIFF
--- a/src/pages/strategy/tabs/ships/ships.css
+++ b/src/pages/strategy/tabs/ships/ships.css
@@ -5,31 +5,52 @@
 /* FILTERS
 ------------------------------*/
 .tab_ships .filters {
-	/*width:700px;
-	margin:0px 0px 10px 0px;
-	background:#f0f5ff;
-	padding:5px 10px;
-	border-bottom:1px solid #369;*/
+}
+.tab_ships .filters .filters_label {
+	font-size:12px;
+	font-weight:bold;
+	margin:0px 0px 2px 0px;
+}
+.tab_ships .filters .fold_button {
+	float:right;
+	margin-right:8px;
+}
+.tab_ships .glyph_plus {
+	position:relative;
+	height:12px;
+	width:4px;
+}
+.tab_ships .glyph_plus:after {
+	content:"";
+	background:inherit;
+	position:absolute;
+	width:12px;
+	height:4px;
+	top:4px;
+	left:-4px;
+}
+.tab_ships .glyph_minus {
+	position:relative;
+	width:12px;
+	height:4px;
+	top:4px;
+	left:4px;
 }
 .tab_ships .massSelect {
-	/*
-	width:680px;
-	height:20px;
-	*/
 	line-height:20px;
 	margin:0px 0px 5px 0px;
 	font-size:12px;
 }
 .tab_ships .massSelect dl{
 	width: 220px;
-	display: 	inline-block;
+	display: inline-block;
 	vertical-align: top;
 	margin: 0px 0px 5px 0px;
-	overflow: 	hidden;
+	overflow: hidden;
 }
 .tab_ships .massSelect dl dt,
 .tab_ships .massSelect dl dd{
-	float: 		left;
+	float: left;
 	line-height:inherit;
 }
 .tab_ships .massSelect .massLabel {
@@ -82,6 +103,7 @@
 	float:right;
 	font-size:12px;
 	line-height:18px;
+	padding:0px 4px 0px 4px;
 }
 
 .tab_ships .advanced_sorter .filter_box {
@@ -192,9 +214,14 @@
 	min-height:50px;
 	margin:0px 0px 5px 0px;
 }
+.tab_ships .ship_list.scroll_fix {
+	width:692px;
+	overflow-x:hidden;
+	overflow-y:scroll;
+}
 /* Row */
 .tab_ships .ship_list .ship_item {
-	width:680px;
+	width:675px;
 	height:20px;
 	line-height:20px;
 	font-size:12px;
@@ -227,7 +254,7 @@
 	border-top:5px solid #333;
 }
 .tab_ships .ingame_page {
-	width:680px;
+	width:675px;
 	line-height:14px;
 	font-size:14px;
 	margin:0px 0px 2px 0px;
@@ -372,3 +399,16 @@
 	display:none;
 }
 
+.tab_ships .ship_item .ship_lock img {
+	width:13px;
+	height:13px;
+	margin:-35px 0px 0px 39px;
+	position:relative;
+}
+.tab_ships .ship_item .ship_marry {
+	display:none;
+}
+
+.tab_ships .page_padding.scroll_fix {
+	padding:0px 3px 0px;
+}

--- a/src/pages/strategy/tabs/ships/ships.html
+++ b/src/pages/strategy/tabs/ships/ships.html
@@ -5,12 +5,12 @@
 
 <!-- HELP TOPICS -->
 <div class="page_help">
-	<div class="help_q">Where is the heartlock column?</div>
-	<div class="help_a">It is currently disabled in favor of the night battle capability column in black. There are plans to enhance this table in the future.</div>
-	<div class="help_q">Where is the speed column?</div>
-	<div class="help_a">The same with heartlock.</div>
-	<div class="help_q">Where are the ship-types of DDE, XBB and AP?</div>
+	<div class="help_q">Where is the heartlock, speed or marry column?</div>
+	<div class="help_a">They are currently disabled or hidden by the limitation of page width.</div>
+	<div class="help_q">Where are the ship types of XBB and AP?</div>
 	<div class="help_a">They are not used by our shipgirls (AP taken by abyssal).</div>
+	<div class="help_q">Can I filter or sort by current HP or repair time of my shipgirls?</div>
+	<div class="help_a">Not here, go to <strong>Docking</strong> page instead.</div>
 	<div class="help_q">What is "Sort By Multiple Keys"?</div>
 	<div class="help_a"><p>Normally you can sort ships by levels, or sort by ship types so that ships of same type are grouped together. But this doesn't give you the ability to say &quot;sort ship by their types, and under the same type, sort them by level.&quot;.</p>
 	  <p>And sorting by multiple keys solves this problem: you can first sort ships by type to group them, then use ship level as the second key to sort under each type.</p>
@@ -31,12 +31,18 @@
 
 <!-- TOGGLE FILTERS -->
 <div class="page_panel filters">
+	<div class="filters_label hover">Options &amp; Filters:<div class="fold_button glyph_minus"></div></div>
+	
 	<div class="massSelect">
 		<dl>
-			<dt class="massLabel">Ship Type</dt>
-			<dd class="hover all">All</dd>
-			<dd class="hover none">None</dd>
-			<dd class="hover invert">Invert</dd>
+			<dt class="massLabel">List Scrollbar</dt>
+			<dd class="hover scroll_fix">Fixed</dd>
+			<dd class="hover scroll_none">None</dd>
+		</dl>
+		<dl>
+			<dt class="massLabel">Pages</dt>
+			<dd class="hover pages_yes">Show</dd>
+			<dd class="hover pages_no">Hide</dd>
 		</dl>
 		<dl>
 			<dt class="massLabel">Equip Stats</dt>
@@ -100,9 +106,16 @@
 			<dd class="hover exslot_no">No</dd>
 		</dl>
 		<dl>
-			<dt class="massLabel">Pages</dt>
-			<dd class="hover pages_yes">Show</dd>
-			<dd class="hover pages_no">Hide</dd>
+			<dt class="massLabel">Duplicated</dt>
+			<dd class="hover dupe_all">All</dd>
+			<dd class="hover dupe_yes">Yes</dd>
+			<dd class="hover dupe_no">No</dd>
+		</dl>
+		<dl>
+			<dt class="massLabel">Ship Type</dt>
+			<dd class="hover all">All</dd>
+			<dd class="hover none">None</dd>
+			<dd class="hover invert">Invert</dd>
 		</dl>
 	</div>
 	<div class="clear"></div>

--- a/src/pages/strategy/tabs/ships/ships.html
+++ b/src/pages/strategy/tabs/ships/ships.html
@@ -11,7 +11,7 @@
 	<div class="help_a">They are not used by our shipgirls (AP taken by abyssal).</div>
 	<div class="help_q">Can I filter or sort by current HP or repair time of my shipgirls?</div>
 	<div class="help_a">Not here, go to <strong>Docking</strong> page instead.</div>
-	<div class="help_q">What is "Sort By Multiple Keys"?</div>
+	<div class="help_q">What is "Sort by Multiple Keys"?</div>
 	<div class="help_a"><p>Normally you can sort ships by levels, or sort by ship types so that ships of same type are grouped together. But this doesn't give you the ability to say &quot;sort ship by their types, and under the same type, sort them by level.&quot;.</p>
 	  <p>And sorting by multiple keys solves this problem: you can first sort ships by type to group them, then use ship level as the second key to sort under each type.</p>
 	  <p>To use this function, select one column header you want to sort as usual. Once the first key is chosen, you can click &quot;Start&quot; to enable multiple key sorting, under this mode, each column header you click <strong>accumulates to</strong>, instead of replacing previous sorting method.</p>
@@ -34,16 +34,6 @@
 	<div class="filters_label hover">Options &amp; Filters:<div class="fold_button glyph_minus"></div></div>
 	
 	<div class="massSelect">
-		<dl>
-			<dt class="massLabel">List Scrollbar</dt>
-			<dd class="hover scroll_fix">Fixed</dd>
-			<dd class="hover scroll_none">None</dd>
-		</dl>
-		<dl>
-			<dt class="massLabel">Pages</dt>
-			<dd class="hover pages_yes">Show</dd>
-			<dd class="hover pages_no">Hide</dd>
-		</dl>
 		<dl>
 			<dt class="massLabel">Equip Stats</dt>
 			<dd class="hover equip_yes">Yes</dd>
@@ -112,10 +102,20 @@
 			<dd class="hover dupe_no">No</dd>
 		</dl>
 		<dl>
+			<dt class="massLabel">Pages</dt>
+			<dd class="hover pages_yes">Show</dd>
+			<dd class="hover pages_no">Hide</dd>
+		</dl>
+		<dl>
 			<dt class="massLabel">Ship Type</dt>
 			<dd class="hover all">All</dd>
 			<dd class="hover none">None</dd>
 			<dd class="hover invert">Invert</dd>
+		</dl>
+		<dl>
+			<dt class="massLabel">List Scrollbar</dt>
+			<dd class="hover scroll_fix">Fixed</dd>
+			<dd class="hover scroll_none">None</dd>
 		</dl>
 	</div>
 	<div class="clear"></div>
@@ -126,7 +126,7 @@
 	<div class="clear"></div>
 
 	<div class="advanced_sorter">
-		<div class="adv_label">Sort By Multiple Keys:</div>
+		<div class="adv_label">Sort by Multiple Keys:</div>
 		<div class="adv_sorter hover">
 			<div class="filter_box"><div class="filter_check"></div></div>
 			<div class="filter_name">Start</div>

--- a/src/pages/strategy/tabs/ships/ships.js
+++ b/src/pages/strategy/tabs/ships/ships.js
@@ -14,6 +14,7 @@
 		isLoading: false,
 		multiKey: false,
 		pageNo: false,
+		scrollList: false,
 
 		newFilterRep: {},
 		// all sorters
@@ -42,6 +43,100 @@
 				let preparedData = this.prepareShipData(shipData);
 				this.shipCache.push(preparedData);
 			}
+		},
+
+		/* EXECUTE
+		Places data onto the interface
+		---------------------------------*/
+		execute :function(){
+			var self = this;
+			// now we need to do this before preparing filters
+			// Ship types
+			var sCtr, cElm;
+
+			for(sCtr in KC3Meta._stype){
+				// stype 12, 15 not used by shipgirl
+				// stype 1 is used from 2017-05-02
+				if(KC3Meta._stype[sCtr] && ["12", "15"].indexOf(sCtr) < 0){
+					cElm = $(".tab_ships .factory .ship_filter_type").clone().appendTo(".tab_ships .filters .ship_types");
+					cElm.data("id", sCtr);
+					$(".filter_name", cElm).text(KC3Meta.stype(sCtr));
+				}
+			}
+
+			$(".filters_label").on("click", function(){
+				$(".filters .ship_types").slideToggle(300);
+				$(".filters .massSelect").slideToggle(300, function(){
+					$(".fold_button").toggleClass("glyph_minus", $(this).is(":visible"));
+					$(".fold_button").toggleClass("glyph_plus", !$(this).is(":visible"));
+					if(self.scrollList){
+						self.toggleTableScrollbar(true);
+					}
+				});
+			});
+			$(".pages_yes").on("click", function(){
+				$(".ingame_page").show();
+				if(!self.pageNo){
+					self.pageNo = true;
+					self.saveSettings();
+				}
+			});
+			$(".pages_no").on("click", function(){
+				$(".ingame_page").hide();
+				if(self.pageNo){
+					self.pageNo = false;
+					self.saveSettings();
+				}
+			});
+			$(".scroll_fix").on("click", function(){
+				self.toggleTableScrollbar(true);
+				if(!self.scrollList){
+					self.scrollList = true;
+					self.saveSettings();
+				}
+			});
+			$(".scroll_none").on("click", function(){
+				self.toggleTableScrollbar(false);
+				if(self.scrollList){
+					self.scrollList = false;
+					self.saveSettings();
+				}
+				KC3StrategyTabs.reloadTab(undefined, true);
+			});
+			$(".control_buttons .reset_default").on("click", function(){
+				self.equipMode = 0;
+				self.pageNo = false;
+				self.scrollList = false;
+				self.multiKey = false;
+				self.currentSorters = [{name:"lv", reverse:false}];
+				delete localStorage.srShiplist;
+				KC3StrategyTabs.reloadTab(undefined, true);
+			});
+
+			var multiKeyCtrl = $( ".advanced_sorter .adv_sorter" );
+			var updateSorterControl = function() {
+				$(".filter_check", multiKeyCtrl).toggle( self.multiKey );
+				self.sorterDescCtrl.toggle(self.multiKey);
+			};
+			multiKeyCtrl.on("click", function() {
+				self.multiKey = ! self.multiKey;
+
+				updateSorterControl();
+
+				if (! self.multiKey) {
+					var needUpdate = self.cutCurrentSorter();
+					if (needUpdate)
+						self.refreshTable();
+				}
+			});
+
+			this.loadSettings();
+			this.sorterDescCtrl = $(".advanced_sorter .sorter_desc");
+			this.updateSorterDescription();
+			updateSorterControl();
+			this.prepareFilters();
+			this.shipList = $(".tab_ships .ship_list");
+			this.showFilters();
 		},
 
 		getLastCurrentSorter: function() {
@@ -113,25 +208,30 @@
 		// create comparator based on current list sorters
 		makeComparator: function() {
 			function reversed(comparator) {
-				return function(a,b) {
-					var result = comparator(a,b);
-					return result === 0
-						? 0
-						: result < 0 ? 1 : -1;
+				return function(l, r) {
+					return -comparator(l, r);
 				};
 			}
-
-			function compose(prevCmp,curCmp) {
-				return function(a,b) {
-					var prevResult = prevCmp(a,b);
-					return prevResult !== 0 ? prevResult : curCmp(a,b);
+			function compose(prevComparator, nextComparator) {
+				return function(l, r) {
+					return prevComparator(l, r) || nextComparator(l, r);
 				};
 			}
-
-			var self = this;
-			return this.currentSorters
-				.map( function(sorterInfo) {
-					var sorter = self.sorters[sorterInfo.name];
+			// Append sortno as default sorter to keep order stable
+			var mergedSorters = this.currentSorters.concat([{
+				name: "sortno",
+				reverse: false
+			}]);
+			// For duplicated ships, final sorter if roster ID not used
+			if(this.currentSorters.every(si => si.name !== "id")){
+				mergedSorters.push({
+					name: "id",
+					reverse: false
+				});
+			}
+			return mergedSorters
+				.map( sorterInfo => {
+					var sorter = this.sorters[sorterInfo.name];
 					return sorterInfo.reverse
 						? reversed(sorter.comparator)
 						: sorter.comparator;
@@ -148,6 +248,8 @@
 				id: ThisShip.rosterId,
 				bid : ThisShip.masterId,
 				stype: MasterShip.api_stype,
+				ctype: MasterShip.api_ctype,
+				sortno: MasterShip.api_sortno,
 				english: ThisShip.name(),
 				level: ThisShip.level,
 				morale: ThisShip.morale,
@@ -189,74 +291,6 @@
 			else
 				ThisShipData.statmax = 0;
 			return cached;
-		},
-
-		/* EXECUTE
-		Places data onto the interface
-		---------------------------------*/
-		execute :function(){
-			var self = this;
-			// now we need to do this before preparing filters
-			// Ship types
-			var sCtr, cElm;
-
-			for(sCtr in KC3Meta._stype){
-				// stype 12, 15 not used by shipgirl
-				// stype 1 is used from 2017-05-02
-				if(KC3Meta._stype[sCtr] && ["12", "15"].indexOf(sCtr) < 0){
-					cElm = $(".tab_ships .factory .ship_filter_type").clone().appendTo(".tab_ships .filters .ship_types");
-					cElm.data("id", sCtr);
-					$(".filter_name", cElm).text(KC3Meta.stype(sCtr));
-				}
-			}
-
-			$(".pages_yes").on("click", function(){
-				$(".ingame_page").show();
-				if(!self.pageNo){
-					self.pageNo = true;
-					self.saveSettings();
-				}
-			});
-			$(".pages_no").on("click", function(){
-				$(".ingame_page").hide();
-				if(self.pageNo){
-					self.pageNo = false;
-					self.saveSettings();
-				}
-			});
-			$(".control_buttons .reset_default").on("click", function(){
-				self.equipMode = 0;
-				self.pageNo = false;
-				self.multiKey = false;
-				self.currentSorters = [{name:"lv", reverse:false}];
-				delete localStorage.srShiplist;
-				KC3StrategyTabs.reloadTab(undefined, true);
-			});
-
-			var multiKeyCtrl = $( ".advanced_sorter .adv_sorter" );
-			var updateSorterControl = function() {
-				$(".filter_check", multiKeyCtrl).toggle( self.multiKey );
-				self.sorterDescCtrl.toggle(self.multiKey);
-			};
-			multiKeyCtrl.on("click", function() {
-				self.multiKey = ! self.multiKey;
-
-				updateSorterControl();
-
-				if (! self.multiKey) {
-					var needUpdate = self.cutCurrentSorter();
-					if (needUpdate)
-						self.refreshTable();
-				}
-			});
-
-			this.loadSettings();
-			this.sorterDescCtrl = $(".advanced_sorter .sorter_desc");
-			this.updateSorterDescription();
-			updateSorterControl();
-			this.prepareFilters();
-			this.shipList = $(".tab_ships .ship_list");
-			this.showFilters();
 		},
 
 		// default UI actions for options that are mutually exclusive
@@ -473,6 +507,19 @@
 						|| (curVal === 1 && (ship.exSlot > 0 || ship.exSlot === -1))
 						|| (curVal === 2 && ship.exSlot === 0);
 				});
+			self.defineShipFilter(
+				"dupe",
+				savedFilterValues.dupe || 0,
+				["all", "yes","no"],
+				function(curVal, ship) {
+					if(curVal === 0) return true;
+					var dupeShips = self.shipCache.filter(s =>
+						(RemodelDb.originOf(ship.bid) === RemodelDb.originOf(s.bid)
+							&& s.id !== ship.id)
+					);
+					return (curVal === 1 && dupeShips.length > 0)
+							|| (curVal === 2 && dupeShips.length === 0);
+				});
 
 			var stypes = Object
 				.keys(KC3Meta._stype)
@@ -561,6 +608,7 @@
 			}
 			shrinkedSettings.views.equip = this.equipMode;
 			shrinkedSettings.views.page = this.pageNo;
+			shrinkedSettings.views.scroll = this.scrollList;
 			this.settings = shrinkedSettings;
 			localStorage.srShiplist = JSON.stringify(this.settings);
 		},
@@ -575,6 +623,7 @@
 			if(this.settings.views){
 				this.equipMode = this.settings.views.equip || 0;
 				this.pageNo = this.settings.views.page || false;
+				this.scrollList = this.settings.views.scroll || false;
 			}
 		},
 
@@ -646,9 +695,7 @@
 				function(a,b) {
 					var va = getter.call(self,a);
 					var vb = getter.call(self,b);
-					return va === vb
-						 ? 0
-						 : (va < vb) ? -1 : 1;
+					return typeof va === "string" ? va.localeCompare(vb) : va - vb;
 				});
 		},
 
@@ -685,6 +732,12 @@
 				   function(x) { return -x.ls[this.equipMode]; });
 			define("lk", "Luck",
 				   function(x) { return -x.lk; });
+			define("ctype", "Class",
+				   function(x) { return x.ctype; });
+			define("bid", "ShipId",
+				   function(x) { return x.bid; });
+			define("sortno", "BookNo",
+				   function(x) { return x.sortno; });
 		},
 
 		/* REFRESH TABLE
@@ -806,6 +859,7 @@
 
 				self.shipList.show();
 				$(".ingame_page").toggle(self.pageNo);
+				self.toggleTableScrollbar(self.scrollList);
 				self.isLoading = false;
 				console.log("Showing this list took", (Date.now() - self.startTime)-100 , "milliseconds");
 			}, 100);
@@ -817,6 +871,14 @@
 
 		gearClickFunc: function(e){
 			KC3StrategyTabs.gotoTab("mstgear", $(this).attr("alt"));
+		},
+
+		toggleTableScrollbar: function(isFixed){
+			$(".ship_list").toggleClass("scroll_fix", isFixed);
+			$(".page_padding").toggleClass("scroll_fix", isFixed);
+			if(isFixed){
+				$(".ship_list").height(window.innerHeight - $(".ship_list").offset().top - 5);
+			}
 		},
 
 		/* Compute Derived Stats without Equipment

--- a/src/pages/strategy/tabs/ships/ships.js
+++ b/src/pages/strategy/tabs/ships/ships.js
@@ -6,18 +6,24 @@
 	KC3StrategyTabs.ships.definition = {
 		tabSelf: KC3StrategyTabs.ships,
 
-		shipCache:[],
-		settings: {},
-		// default sorting method to Level
-		currentSorters: [{name:"lv", reverse:false}],
-		equipMode: 0,
 		isLoading: false,
-		multiKey: false,
-		pageNo: false,
-		scrollList: false,
-
+		shipCache:[],
+		// Formatted settings to be stored into localStorage
+		settings: {},
+		// Default properties of sorters and views
+		defaultSettings: {
+			// default sorting method to Level
+			currentSorters: [{name:"lv", reverse:false}],
+			// default options of view
+			equipMode: 0,
+			multiKey: false,
+			pageNo: false,
+			scrollList: false
+			// default values of filters are defined at `prepareFilters`
+		},
+		// All pre-defined filters instances
 		newFilterRep: {},
-		// all sorters
+		// All pre-defined sorters instances
 		sorters: {},
 		sorterDescCtrl: null,
 		viewElements: {},
@@ -26,6 +32,7 @@
 		Prepares static data needed
 		---------------------------------*/
 		init :function(){
+			$.extend(true, this, this.defaultSettings);
 			this.prepareSorters();
 		},
 
@@ -33,10 +40,10 @@
 		Prepares latest ships data
 		---------------------------------*/
 		reload :function(){
-			// Cache ship info
 			PlayerManager.loadFleets();
 			KC3ShipManager.load();
 			KC3GearManager.load();
+			// Cache pre-processed ship info
 			this.shipCache = [];
 			for(let key in KC3ShipManager.list){
 				let shipData = KC3ShipManager.list[key];
@@ -50,20 +57,8 @@
 		---------------------------------*/
 		execute :function(){
 			var self = this;
-			// now we need to do this before preparing filters
-			// Ship types
-			var sCtr, cElm;
 
-			for(sCtr in KC3Meta._stype){
-				// stype 12, 15 not used by shipgirl
-				// stype 1 is used from 2017-05-02
-				if(KC3Meta._stype[sCtr] && ["12", "15"].indexOf(sCtr) < 0){
-					cElm = $(".tab_ships .factory .ship_filter_type").clone().appendTo(".tab_ships .filters .ship_types");
-					cElm.data("id", sCtr);
-					$(".filter_name", cElm).text(KC3Meta.stype(sCtr));
-				}
-			}
-
+			// Binding click event starts
 			$(".filters_label").on("click", function(){
 				$(".filters .ship_types").slideToggle(300);
 				$(".filters .massSelect").slideToggle(300, function(){
@@ -104,15 +99,25 @@
 				KC3StrategyTabs.reloadTab(undefined, true);
 			});
 			$(".control_buttons .reset_default").on("click", function(){
-				self.equipMode = 0;
-				self.pageNo = false;
-				self.scrollList = false;
-				self.multiKey = false;
-				self.currentSorters = [{name:"lv", reverse:false}];
+				delete self.currentSorters;
+				$.extend(true, self, self.defaultSettings);
 				delete localStorage.srShiplist;
 				KC3StrategyTabs.reloadTab(undefined, true);
 			});
+			// Binding click event ends
 
+			// Add filter elements of ship types before `prepareFilters` executed
+			for(let sCtr in KC3Meta._stype){
+				// stype 12, 15 not used by shipgirl
+				// stype 1 is used from 2017-05-02
+				if(KC3Meta._stype[sCtr] && ["12", "15"].indexOf(sCtr) < 0){
+					let cElm = $(".tab_ships .factory .ship_filter_type").clone().appendTo(".tab_ships .filters .ship_types");
+					cElm.data("id", sCtr);
+					$(".filter_name", cElm).text(KC3Meta.stype(sCtr));
+				}
+			}
+
+			// Update multi sorter elements
 			var multiKeyCtrl = $( ".advanced_sorter .adv_sorter" );
 			var updateSorterControl = function() {
 				$(".filter_check", multiKeyCtrl).toggle( self.multiKey );
@@ -326,7 +331,6 @@
 
 		/*
 		   defineShipFilter defines a filter that has UI controls.
-
 		   see comments on each arguments for detail.
 		 */
 		defineShipFilter: function(

--- a/src/pages/strategy/themes/dark.css
+++ b/src/pages/strategy/themes/dark.css
@@ -497,6 +497,9 @@ button, input, select, textarea {
 	
 }
 /* Ship List */
+.tab_ships .filters .fold_button {
+	background:#cccccc;
+}
 .tab_ships .massSelect .hover {
 	color:#ffffff
 }
@@ -523,6 +526,9 @@ button, input, select, textarea {
 }
 .tab_ships .advanced_sorter .filter_check {
 	background:#ffffff;
+}
+.tab_ships .control_buttons .reset_default:hover {
+	background:#555555;
 }
 .tab_ships .ship_filter_type .filter_box {
 	border:1px solid #888888;

--- a/src/pages/strategy/themes/legacy.css
+++ b/src/pages/strategy/themes/legacy.css
@@ -368,6 +368,9 @@ body {
 	background-color: #bcd;
 }
 /* Ship List */
+.tab_ships .filters .fold_button {
+	background:#333;
+}
 .tab_ships .massSelect .hover {
 	border-radius: 4px;
 	color:#00f;
@@ -387,6 +390,9 @@ body {
 }
 .tab_ships .advanced_sorter .filter_check {
 	background:#000;
+}
+.tab_ships .control_buttons .reset_default:hover {
+	background:#cfc;
 }
 .tab_ships .ship_filter_type .filter_box {
 	border:1px solid #000;


### PR DESCRIPTION
DONE

* Fixed scroll-able ship list table (might solve #2045)
* Duplicated ships filter (similar with #1880)
* Show small heart-lock indicator
* Adjust order of filter controls, put correspond group at proper place
* Fold / unfold filters, could make ship list larger (fold state will not be remembered)
* Add default sorter which in-game also uses, the order will be the same with in-game one when selected sorter are same values
* Update FAQ texts

Usage hint: for fixed scrollbar mode, once u resize your browser window/tab, manually click on `List Scrollbar Fixed` again to auto fit the height of ship list.

SS:
![image](https://cloud.githubusercontent.com/assets/160240/26031897/7cf06078-38b6-11e7-91fb-587127559a32.png)

New filters order:
![image](https://cloud.githubusercontent.com/assets/160240/26186567/1808399e-3bc5-11e7-8b43-40c35f3dc9e1.png)
