### PR TITLE
Refactoring ship list based pages

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -55,6 +55,7 @@
 		"KC3Graphable": true,
 		"KC3LodgerBuffer": true,
 		"KC3SortieLogs": true,
+		"KC3ShipListGrid": true,
 		"KC3NatsuiroShipbox": true,
 		"DMMCustomizations": true,
 		"interactions": true,

--- a/src/library/objects/Ship.js
+++ b/src/library/objects/Ship.js
@@ -186,6 +186,13 @@ KC3改 Ship Object
 	KC3Ship.prototype.isTaiha   = function(){ return (this.hp[1]>0) && (this.hp[0]/this.hp[1] <= 0.25) && !this.isRepaired(); };
 	KC3Ship.prototype.speedName = function(){ return KC3Meta.shipSpeed(this.speed); };
 	KC3Ship.prototype.rangeName = function(){ return KC3Meta.shipRange(this.range); };
+	KC3Ship.prototype.levelClass = function(){
+		return this.level === 155 ? "married max" :
+			this.level >= 100 ? "married" :
+			this.level >= 80  ? "high" :
+			this.level >= 50  ? "medium" :
+			"";
+	};
 	KC3Ship.prototype.getDefer = function(){
 		// returns a new defer if possible
 		return deferList[this.rosterId] || [];

--- a/src/pages/devtools/themes/natsuiro/js/Shipbox.js
+++ b/src/pages/devtools/themes/natsuiro/js/Shipbox.js
@@ -36,6 +36,7 @@ KC3改 Ship Box for Natsuiro theme
 		$(".ship_face_tooltip .ship_rosterId span", tooltipBox).text(this.shipData.rosterId);
 		$(".ship_face_tooltip .ship_stype", tooltipBox).text(this.shipData.stype());
 		$(".ship_face_tooltip .ship_level span.value", tooltipBox).text(this.shipData.level);
+		//$(".ship_face_tooltip .ship_level span.value", tooltipBox).addClass(this.shipData.levelClass());
 		$(".ship_face_tooltip .ship_hp span.hp", tooltipBox).text(this.shipData.hp[0]);
 		$(".ship_face_tooltip .ship_hp span.mhp", tooltipBox).text(this.shipData.hp[1]);
 		$(".ship_face_tooltip .stat_hp", tooltipBox).text(this.shipData.hp[1]);

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -3354,6 +3354,15 @@ ABYSS FLEET
 .ui-tooltip-content .ship_face_tooltip .ship_level span.i18n {
 	color:#3ec0bf;
 }
+.ui-tooltip-content .ship_face_tooltip .ship_level span.value.married {
+	color:#a97417;
+}
+.ui-tooltip-content .ship_face_tooltip .ship_level span.value.high {
+	color:#107e57;
+}
+.ui-tooltip-content .ship_face_tooltip .ship_level span.value.medium {
+	color:#36c2db;
+}
 .ui-tooltip-content .ship_face_tooltip .ship_hp {
 	width:64px;
 	height:17px;

--- a/src/pages/strategy/shipgrid.js
+++ b/src/pages/strategy/shipgrid.js
@@ -1,0 +1,228 @@
+(function(){
+
+	class KC3ShipListGrid {
+
+		constructor(tabName) {
+			this.tabName = tabName;
+			this.shipListDiv = null;
+			this.shipRowTemplateDiv = null;
+			this.showListRowCallback = null;
+			this.shipList = [];
+			this.sorters = [{name:"lv", reverse:false}];
+			this.sorterDefinitions = {};
+			this.filterDefinitions = {};
+			this.pageNo = false;
+			this.isLoading = false;
+		}
+
+		registerShipListHeaderEvent(shipHeaderDiv) {
+			if(!shipHeaderDiv) {
+				return;
+			}
+			const self = this;
+			shipHeaderDiv.on("click", function() {
+				const sorter = self.getLastSorter();
+				const sorterName = $(this).data("type");
+				if (sorterName === sorter.name) {
+					self.reverseLastSorter();
+				} else {
+					self.setSorter(sorterName);
+				}
+				self.showListGrid();
+			});
+		}
+
+		showListGrid() {
+			const startTime = Date.now();
+			const delayMillis = 100;
+			if(this.isLoading) {
+				console.debug("Ignored this refresh, still loading from", startTime);
+				return false;
+			}
+			console.assert(this.shipListDiv, "Ship list element must be defined");
+			console.assert(this.shipRowTemplateDiv, "Ship row template element must be defined");
+			this.isLoading = true;
+			// Clear old list
+			this.shipListDiv.empty().hide();
+			setTimeout(() => {
+				// Do list filtering
+				const filteredShipList = this.shipList.filter(ship => this.executeFilters(ship));
+				// Do list sorting
+				filteredShipList.sort(this.makeComparator());
+				// Fill up rows of grid
+				Object.keys(filteredShipList).forEach(shipIdx => {
+					if(shipIdx % 10 === 0){
+						$("<div>").addClass("ingame_page").text(
+							"Page " + Math.ceil((shipIdx + 1) / 10)
+						).appendTo(this.shipListDiv);
+					}
+					let ship = filteredShipList[shipIdx];
+					let shipRow = this.shipRowTemplateDiv.clone().appendTo(this.shipListDiv);
+					shipRow.toggleClass(() => {
+						return shipIdx % 2 === 0 ? "even" : "odd";
+					});
+					$(".ship_id", shipRow).text(ship.id);
+					$(".ship_img .ship_icon", shipRow)
+						.attr("src", KC3Meta.shipIcon(ship.masterId))
+						.attr("alt", ship.masterId)
+						.click(this.shipClickFunc);
+					$(".ship_name", shipRow).text(ship.name);
+					$(".ship_name", shipRow).toggleClass("ship_kekkon-color", ship.level >= 100);
+					$(".ship_type", shipRow).text(KC3Meta.stype(ship.stype));
+					$(".ship_lv .value", shipRow).text(ship.level)
+						.addClass(ship.levelClass);
+					
+					// Invoke more rendering of ship row
+					if(typeof this.showListRowCallback === "function") {
+						this.showListRowCallback.call(this, ship, shipRow);
+					}
+				});
+				this.shipListDiv.show().createChildrenTooltips();
+				$(".ingame_page").toggle(this.pageNo);
+				this.isLoading = false;
+				console.debug("Showing", this.tabName, "list took",
+					(Date.now() - startTime) - delayMillis, "milliseconds");
+			}, delayMillis);
+			return true;
+		}
+
+		shipClickFunc(event) {
+			KC3StrategyTabs.gotoTab("mstship", $(this).attr("alt") || $(this).data("id"));
+		}
+
+		gearClickFunc(event) {
+			KC3StrategyTabs.gotoTab("mstgear", $(this).attr("alt") || $(this).data("id"));
+		}
+
+		prepareShipList(isReload,
+			mapShipDataCallback = this.defaultShipDataMapping,
+			initShipFilter = ((shipObj) => true)) {
+			if(!isReload && this.shipList.length > 0) {
+				return false;
+			}
+			this.shipList.length = 0;
+			for(let key in KC3ShipManager.list){
+				let shipObj = KC3ShipManager.list[key];
+				if(initShipFilter(shipObj)) {
+					let shipData = mapShipDataCallback.call(this, shipObj);
+					this.shipList.push(shipData);
+				}
+			}
+			return true;
+		}
+
+		defaultShipDataMapping(shipObj) {
+			const shipMaster = shipObj.master();
+			const mappedObj = {
+				id: shipObj.rosterId,
+				masterId: shipObj.masterId,
+				stype: shipMaster.api_stype,
+				ctype: shipMaster.api_ctype,
+				sortno: shipMaster.api_sortno,
+				name: shipObj.name(),
+				level: shipObj.level,
+				levelClass: shipObj.levelClass(),
+				morale: shipObj.morale,
+				equip: shipObj.items,
+				slots: shipObj.slots,
+				locked: shipObj.lock,
+				speed: shipObj.speed,
+				range: shipObj.range,
+				fleet: shipObj.onFleet()
+			};
+			return mappedObj;
+		}
+
+		defaultSorterDefinitions() {
+			const define = this.defineSimpleSorter.bind(this);
+			define("id", "Id", ship => ship.id);
+			define("masterId", "ShipId", ship => ship.masterId);
+			define("name", "Name", ship => ship.name);
+			define("type", "Type", ship => ship.stype);
+			define("ctype", "Class", ship => ship.ctype);
+			define("lv", "Level", ship => -ship.level);
+			define("sortno", "SortOrder", ship => ship.sortno);
+			define("morale", "Morale", ship => -ship.morale);
+		}
+
+		defineSimpleFilter(filterName, optionValues, defaultIndex, testShipFunc) {
+			const filterDef = {
+				optionValues: optionValues,
+				currentIndex: defaultIndex || null,
+				testShip: (ship) => testShipFunc(filterDef.currentIndex, ship)
+			};
+			this.filterDefinitions[filterName] = filterDef;
+		}
+
+		executeFilters(ship) {
+			for(let key in this.filterDefinitions) {
+				var filter = this.filterDefinitions[key].testShip;
+				if (!filter(ship)) return false;
+			}
+			return true;
+		}
+
+		getLastSorter() {
+			return this.sorters[this.sorters.length - 1];
+		}
+
+		reverseLastSorter() {
+			var sorter = this.getLastSorter();
+			sorter.reverse = ! sorter.reverse;
+		}
+
+		setSorter(name) {
+			var sorter = this.sorterDefinitions[name];
+			console.assert(sorter, "sorter '" + name + "' should have been registered");
+			this.sorters = [ {name: sorter.name, reverse:false} ];
+		}
+
+		defineSorter(name, desc, comparator) {
+			this.sorterDefinitions[name] = {
+				name: name,
+				desc: desc,
+				comparator: comparator
+			};
+		}
+
+		defineSimpleSorter(name, desc, getter) {
+			this.defineSorter(
+				name, desc,
+				(l, r) => {
+					const vl = getter.call(this, l);
+					const vr = getter.call(this, r);
+					return typeof vl === "string" ? vl.localeCompare(vr) : vl - vr;
+				}
+			);
+		}
+
+		makeComparator() {
+			const reversed = (comparator) => ((l, r) => -comparator(l, r));
+			const compose = (prevComparator, nextComparator) =>
+				((l, r) => prevComparator(l, r) || nextComparator(l, r));
+			const lastSorterReverse = this.getLastSorter().reverse;
+			const mergedSorters = this.sorters.concat([{
+				name: "sortno",
+				reverse: lastSorterReverse
+			}]);
+			if(this.sorters.every(sd => sd.name !== "id")){
+				mergedSorters.push({
+					name: "id",
+					reverse: lastSorterReverse
+				});
+			}
+			return mergedSorters
+				.map(sorterDef => {
+					const sorter = this.sorterDefinitions[sorterDef.name];
+					return sorterDef.reverse
+						? reversed(sorter.comparator)
+						: sorter.comparator;
+				})
+				.reduce(compose);
+		}
+
+	}
+
+	window.KC3ShipListGrid = KC3ShipListGrid;
+
+})();

--- a/src/pages/strategy/strategy.html
+++ b/src/pages/strategy/strategy.html
@@ -179,6 +179,7 @@
 
 		<script type="text/javascript" src="graphable.js"></script>
 		<script type="text/javascript" src="sortielogs.js"></script>
+		<script type="text/javascript" src="shipgrid.js"></script>
 		<!-- @buildimportjs allstrategytabs.js -->
 
 		<!-- @nonbuildstart -->

--- a/src/pages/strategy/tabs/docking/docking.css
+++ b/src/pages/strategy/tabs/docking/docking.css
@@ -140,23 +140,31 @@
 	width:70px;
 	text-align:center;
 	position:relative;
+	overflow:hidden;
+	white-space:nowrap;
 }
-
 .tab_docking .ship_item .ship_lv.ship_kekkon {
 	/*width:70px;*/
 }
 .tab_docking .ship_item .ship_morale {
 	width:20px;
-	/*margin:0px 5px 0px 0px;*/
 	text-align:center;
 }
 .tab_docking .ship_item .ship_morale.sparkled {
 	background:#ff0;
 }
-.tab_docking .ship_item .ship_lv span {
+.tab_docking .ship_item .ship_lv span.i18n {
 	color:#888;
 }
-/* Fields: Stats */
+.tab_docking .ship_item .ship_lv span.value.married {
+	color:#a97417;
+}
+.tab_docking .ship_item .ship_lv span.value.high {
+	color:#107e57;
+}
+.tab_docking .ship_item .ship_lv span.value.medium {
+	color:#36c2db;
+}
 .tab_docking .ship_item .ship_stat {
 	width:25px;
 	text-align:center;

--- a/src/pages/strategy/tabs/docking/docking.html
+++ b/src/pages/strategy/tabs/docking/docking.html
@@ -22,7 +22,7 @@
 			<div class="ship_field hover ship_id" data-type="id">ID</div>
 			<div class="ship_field ship_img"></div>
 			<div class="ship_field hover ship_name" data-type="name">Name</div>
-			<div class="ship_field hover ship_type"  data-type="type">Type</div>
+			<div class="ship_field hover ship_type" data-type="type">Type</div>
 			<div class="ship_field hover ship_lv" data-type="lv">Level</div>
 			<div class="ship_field hover ship_status" data-type="hp">HP</div>
 			<div class="ship_field hover ship_bar" data-type="status"></div>

--- a/src/pages/strategy/tabs/docking/docking.html
+++ b/src/pages/strategy/tabs/docking/docking.html
@@ -41,10 +41,10 @@
 		<!-- SHIP RECORD -->
 		<div class="ship_item">
 			<div class="ship_field ship_id"></div>
-			<div class="ship_field ship_img hover"><img class="ship_icon"/><img class="ship_kekkon" alt=""/></div>
+			<div class="ship_field ship_img hover"><img class="ship_icon"/></div>
 			<div class="ship_field ship_name"></div>
 			<div class="ship_field ship_type"></div>
-			<div class="ship_field ship_lv"></div>
+			<div class="ship_field ship_lv"><span class="i18n">LevelShort</span> <span class="value"></span></div>
 			<div class="ship_field ship_status"></div>
 			<div class="ship_field ship_bar">
 				<div class="ship_hp_box">

--- a/src/pages/strategy/tabs/docking/docking.js
+++ b/src/pages/strategy/tabs/docking/docking.js
@@ -38,6 +38,7 @@
 					sortno: MasterShip.api_sortno,
 					name: ThisShip.name(),
 					level: ThisShip.level,
+					levelClass: ThisShip.levelClass(),
 					morale: ThisShip.morale,
 					equip: ThisShip.items,
 					locked: ThisShip.lock,
@@ -211,9 +212,9 @@
 					$(".ship_img .ship_icon", cElm).click(shipClickFunc);
 					$(".ship_name", cElm).text( cShip.name );
 					$(".ship_type", cElm).text( KC3Meta.stype(cShip.stype) );
-					var shipLevelConv = shipLevel;
-					$(".ship_lv", cElm).html( "<span>Lv.</span>" + shipLevelConv);
-					$(".ship_morale", cElm).html( cShip.morale );
+					$(".ship_lv .value", cElm).text( shipLevel )
+						.addClass( cShip.levelClass );
+					$(".ship_morale", cElm).text( cShip.morale );
 
 					var hpStatus = cShip.hp.toString() + " / " + cShip.maxhp.toString();
 					$(".ship_status", cElm).text( hpStatus );
@@ -227,7 +228,7 @@
 
 					if (cShip.damageStatus == "full" ||
 						cShip.damageStatus == "dummy") {
-						console.warn("damage status shouldn't be full / dummy in this docking page");
+						console.warn("Damage status shouldn't be full / dummy in this docking page", cShip);
 					}
 
 					$(".ship_status", cElm).addClass("ship_" + cShip.damageStatus);

--- a/src/pages/strategy/tabs/docking/docking.js
+++ b/src/pages/strategy/tabs/docking/docking.js
@@ -1,293 +1,200 @@
 (function(){
 	"use strict";
 
-	KC3StrategyTabs.docking = new KC3StrategyTab("docking");
-
-	KC3StrategyTabs.docking.definition = {
-		tabSelf: KC3StrategyTabs.docking,
-
-		shipCache:[],
-		sortBy: "repair_docking",
-		sortAsc: true,
-		isLoading: false,
+	class KC3DockingDefinition extends KC3ShipListGrid {
+		constructor() {
+			super("docking");
+		}
 
 		/* INIT
-		   Prepares static data needed
-		   ---------------------------------*/
-		init :function(){
-		},
+		Prepares initial static data needed.
+		---------------------------------*/
+		init() {
+			this.defineSorters();
+			this.sorters = [{name:"repair_docking", reverse:false}];
+			this.showListRowCallback = this.showShipDockingStatus;
+			this.pageNo = true;
+		}
 
 		/* RELOAD
-		   Prepares reloadable data
-		   ---------------------------------*/
-		reload :function(){
+		Loads latest player or game data if needed.
+		---------------------------------*/
+		reload() {
 			PlayerManager.loadFleets();
-			// in order to get more up-to-date info
-			// we need to refresh the Ship Manager
 			KC3ShipManager.load();
-
-			this.shipCache = [];
-			for(let ctr in KC3ShipManager.list){
-				let ThisShip = KC3ShipManager.list[ctr];
-				let MasterShip = ThisShip.master();
-				let RepairTime = ThisShip.repairTime();
-				let ThisShipData = {
-					id : ThisShip.rosterId,
-					bid : ThisShip.masterId,
-					stype: MasterShip.api_stype,
-					sortno: MasterShip.api_sortno,
-					name: ThisShip.name(),
-					level: ThisShip.level,
-					levelClass: ThisShip.levelClass(),
-					morale: ThisShip.morale,
-					equip: ThisShip.items,
-					locked: ThisShip.lock,
-					hp: ThisShip.hp[0],
-					maxhp: ThisShip.hp[1],
-					damageStatus: ThisShip.damageStatus(),
-					repairDocking: RepairTime.docking,
-					repairAkashi: RepairTime.akashi,
-					stripped: ThisShip.isStriped(),
-					taiha: ThisShip.isTaiha(),
-					slots: ThisShip.slots,
-					fleet: ThisShip.onFleet(),
-				};
-				this.shipCache.push(ThisShipData);
-			}
-		},
+			this.cachedDockingShips = PlayerManager.getCachedDockingShips();
+			// Prepare damaged ship list
+			this.prepareShipList(true, this.mapShipDockingStatus,
+				(shipObj) => shipObj.hp[0] !== shipObj.hp[1]);
+			// Prepare expedition fleets
+			this.expeditionFleets = [];
+			$.each(PlayerManager.fleets, (index, fleet) => {
+				const missionState = fleet.mission[0];
+				// this fleet is either on expedition or being forced back
+				// thus cannot be repaired for now
+				if (missionState == 1 ||
+					missionState == 3) {
+					this.expeditionFleets.push(index);
+				}
+			});
+			// Detect Akashi repairing covered ships
+			this.anchoredShips = this.getAnchoredShips();
+		}
 
 		/* EXECUTE
-		   Places data onto the interface
-		   ---------------------------------*/
-		execute :function(){
-			var self = this;
+		Places data onto the interface from scratch.
+		---------------------------------*/
+		execute() {
 			// Get latest data even clicking on tab
 			this.reload();
-			this.shipList = $(".tab_docking .ship_list");
-			// Column header sorting
-			$(".tab_docking .ship_header .ship_field.hover").on("click", function(){
-				var sortby = $(this).data("type");
-				if(!sortby){ return; }
-				if(sortby == self.sortBy){
-					self.sortAsc = !self.sortAsc;
-				}else{
-					self.sortAsc = true;
-				}
-				self.sortBy = sortby;
-				self.refreshTable();
+			this.shipListDiv = $(".tab_docking .ship_list");
+			this.shipRowTemplateDiv = $(".tab_docking .factory .ship_item");
+			this.registerShipListHeaderEvent(
+				$(".tab_docking .ship_header .ship_field.hover")
+			);
+			this.showListGrid();
+		}
+
+		mapShipDockingStatus(shipObj) {
+			const mappedObj = this.defaultShipDataMapping(shipObj);
+			const repairTime = shipObj.repairTime();
+			$.extend(mappedObj, {
+				hp: shipObj.hp[0],
+				maxhp: shipObj.hp[1],
+				damageStatus: shipObj.damageStatus(),
+				repairDocking: repairTime.docking,
+				repairAkashi: repairTime.akashi
 			});
-			this.refreshTable();
-		},
+			// Update docking time
+			const completeTime = this.cachedDockingShips["x" + mappedObj.id];
+			if (typeof completeTime !== "undefined") {
+				// if we are repairing the ship, show remaining time instead
+				try {
+					const completeDate = new Date(completeTime);
+					let secToComplete = Math.floor( (new Date(completeTime) - new Date()) / 1000 );
+					secToComplete = Math.max(0, secToComplete);
+					mappedObj.repairDocking = secToComplete;
+					// for docking ship, facility cannot be used
+					mappedObj.repairAkashi = Infinity;
+				} catch (err) {
+					console.warn("Error while calculating remaining docking time", err);
+				}
+			}
+			// facility cannot repair chuuha / taiha 'd ships
+			if (mappedObj.damageStatus === "chuuha" ||
+				mappedObj.damageStatus === "taiha") {
+				mappedObj.repairAkashi = Infinity;
+			}
+			return mappedObj;
+		}
 
 		// assuming PlayerManager.fleets is up-to-date
 		// return akashi coverage. (an array of ship ids)
-		getAnchoredShips: function() {
-			var results = [];
-			$.each( PlayerManager.fleets, function(k,fleet) {
-				var fs = KC3ShipManager.get(fleet.ships[0]);
+		getAnchoredShips() {
+			let results = [];
+			$.each( PlayerManager.fleets, function(_, fleet) {
+				const fs = KC3ShipManager.get(fleet.ships[0]);
 				// check if current fleet's flagship is akashi
-				if ([182,187].indexOf( fs.masterId ) === -1)
+				if ([182,187].indexOf( fs.masterId ) === -1) {
 					return;
-
-				var facCount = fs.items.filter( function(x) {
-					return KC3GearManager.get(x).masterId === 86;
-				}).length;
+				}
+				const facCount = fs.items.filter(
+					id => KC3GearManager.get(id).masterId === 86
+				).length;
 				// max num of ships this akashi can repair
-				var repairCap = 2+facCount;
-				var coveredShipIds = fleet.ships.filter( function(x) {
-					return x !== -1; }).slice(0,repairCap);
+				const repairCap = 2 + facCount;
+				const coveredShipIds = fleet.ships.filter(id => id !== -1)
+					.slice(0, repairCap);
 				results = results.concat( coveredShipIds );
 			});
 			return results;
-		},
+		}
 
-		/* REFRESH TABLE
-		   Reload ship list based on filters
-		   ---------------------------------*/
-		refreshTable :function(){
-			if(this.isLoading){ return false; }
-			this.isLoading = true;
+		defineSorters() {
+			this.defaultSorterDefinitions();
+			const define = this.defineSimpleSorter.bind(this);
+			define("hp", "CurrentHp", ship => -ship.hp);
+			define("status", "LeftHpPercent", ship => ship.hp / ship.maxhp);
+			this.defineSorter("repair_docking", "DockingTime", (a, b) => {
+				let r = b.repairDocking - a.repairDocking;
+				if (r === 0 || (!isFinite(a.repairDocking) && !isFinite(b.repairDocking)))
+					r = b.repairAkashi - a.repairAkashi;
+				return r;
+			});
+			this.defineSorter("repair_akashi", "AkashiTime", (a, b) => {
+				let r = b.repairAkashi - a.repairAkashi;
+				if (r === 0 || (!isFinite(a.repairAkashi) && !isFinite(b.repairAkashi)))
+					r = b.repairDocking - a.repairDocking;
+				return r;
+			});
+		}
 
-			var self = this;
-			this.startTime = (new Date()).getTime();
+		showShipDockingStatus(ship, shipRow) {
+			$(".ship_status", shipRow).text("{0} / {1}".format(ship.hp, ship.maxhp));
+			$(".ship_hp_val", shipRow).css("width", parseInt(ship.hp / ship.maxhp * 100, 10)+"px");
+			$(".ship_repair_docking", shipRow).text( String(ship.repairDocking).toHHMMSS() );
+			const akashiText = Number.isFinite(ship.repairAkashi) ?
+				String(ship.repairAkashi).toHHMMSS() : "-";
+			$(".ship_repair_akashi", shipRow).text( akashiText );
+			if (ship.damageStatus === "full" ||
+				ship.damageStatus === "dummy") {
+				console.warn("Damage status shouldn't be full / dummy in this docking page", ship);
+			}
+			$(".ship_status", shipRow).addClass("ship_" + ship.damageStatus);
+			$(".ship_hp_val", shipRow).addClass("ship_" + ship.damageStatus);
 
-			var shipClickFunc = function(e){
-				KC3StrategyTabs.gotoTab("mstship", $(this).attr("alt"));
-			};
+			// Mutually exclusive indicators
+			const completeTime = this.cachedDockingShips["x" + ship.id];
+			if (typeof completeTime !== "undefined") {
+				// adding docking indicator
+				shipRow.addClass("ship_docking");
+			} else if (ship.fleet > 0 &&
+				this.expeditionFleets.indexOf(ship.fleet - 1) !== -1) {
+				// adding expedition indicator
+				shipRow.addClass("ship_expedition");
+			} else if (this.anchoredShips.indexOf(ship.id) !== -1 &&
+						(ship.damageStatus === "normal" ||
+						ship.damageStatus === "shouha")) {
+				// adding akashi repairing indicator
+				shipRow.addClass("ship_akashi_repairing");
+			}
 
-			// Clear list
-			this.shipList.empty().hide();
+			// List up equipment 4 slots (ex-slot not included)
+			[1,2,3,4].forEach(num => {
+				this.showEquipIcon(shipRow, num, ship.slots[num - 1], ship.equip[num - 1]);
+			});
+		}
 
-			// Wait until execute
-			setTimeout(function(){
-				var shipCtr, cElm, cShip, shipLevel;
-				var needsRepair = function(ship,i,a) {
-					return ship.hp !== ship.maxhp;
-				};
-				var FilteredShips = self.shipCache.filter(needsRepair);
-				var dockingShips = PlayerManager.getCachedDockingShips();
-				var anchoredShips = self.getAnchoredShips();
-				var currentFleets = PlayerManager.fleets;
-				var expeditionFleets = [];
-				$.each(currentFleets, function (i,fleet) {
-					try {
-						var missionState = fleet.mission[0];
-						// this fleet is either on expedition or being forced back
-						// thus cannot be repaired for now
-						if (missionState == 1 ||
-							missionState == 3) {
-							expeditionFleets.push( i );
-						}
-					} catch (err) {
-						console.warn("Error while processing fleet info", err);
-					}
-				});
-
-				// update real-time info
-				$.each(FilteredShips, function (i, cShip) {
-					// update docking time
-					var completeTime = dockingShips["x" + cShip.id.toString()];
-					if (typeof completeTime !== "undefined") {
-						// if we are repairing the ship, show remaining time instead
-						try {
-							var completeDate = new Date(completeTime);
-							var secToComplete = Math.floor( (new Date(completeTime) - new Date()) / 1000 );
-							secToComplete = Math.max(0, secToComplete);
-							cShip.repairDocking = secToComplete;
-							// for docking ship, facility cannot be used
-							cShip.repairAkashi = Infinity;
-						} catch (err) {
-							console.warn("Error while calculating remaining docking time", err);
-						}
-					}
-
-					// facility cannot repair chuuha / taiha 'd ships
-					if (cShip.damageStatus == "chuuha" ||
-						cShip.damageStatus == "taiha") {
-						cShip.repairAkashi = Infinity;
-					}
-				});
-
-				// Sorting
-				FilteredShips.sort(function(a, b){
-					var r = 0;
-					switch(self.sortBy){
-					case "id"    : r = a.id - b.id; break;
-					case "name"  : r = a.name.localeCompare(b.name); break;
-					case "type"  : r = a.stype - b.stype; break;
-					case "lv"    : r = b.level - a.level; break;
-					case "morale": r = b.morale - a.morale; break;
-					case "hp"    : r = b.hp - a.hp; break;
-					case "status": r = a.hp / a.maxhp - b.hp / b.maxhp; break;
-					case "repair_docking":
-						r = b.repairDocking - a.repairDocking;
-						if (r === 0 || (!isFinite(a.repairDocking) && !isFinite(b.repairDocking)))
-							r = b.repairAkashi - a.repairAkashi;
-						break;
-					case "repair_akashi":
-						r = b.repairAkashi - a.repairAkashi;
-						if (r === 0 || (!isFinite(a.repairAkashi) && !isFinite(b.repairAkashi)))
-							r = b.repairDocking - a.repairDocking;
-						break;
-					}
-					r = r || a.sortno - b.sortno || a.id - b.id;
-					if(!self.sortAsc){ r = -r; }
-					return r;
-				});
-
-				// Fill up list
-				Object.keys(FilteredShips).forEach(function(shipCtr){
-					if(shipCtr%10 === 0){
-						$("<div>").addClass("ingame_page").html("Page "+Math.ceil((Number(shipCtr)+1)/10)).appendTo(self.shipList);
-					}
-
-					cShip = FilteredShips[shipCtr];
-					shipLevel = cShip.level + 50 * 0; // marry enforcement (debugging toggle)
-					cElm = $(".tab_docking .factory .ship_item").clone().appendTo(self.shipList);
-					if(shipCtr%2 === 0){ cElm.addClass("even"); }else{ cElm.addClass("odd"); }
-
-					$(".ship_id", cElm).text( cShip.id );
-					$(".ship_img .ship_icon", cElm).attr("src", KC3Meta.shipIcon(cShip.bid));
-					$(".ship_img .ship_icon", cElm).attr("alt", cShip.bid);
-					$(".ship_img .ship_icon", cElm).click(shipClickFunc);
-					$(".ship_name", cElm).text( cShip.name );
-					$(".ship_type", cElm).text( KC3Meta.stype(cShip.stype) );
-					$(".ship_lv .value", cElm).text( shipLevel )
-						.addClass( cShip.levelClass );
-					$(".ship_morale", cElm).text( cShip.morale );
-
-					var hpStatus = cShip.hp.toString() + " / " + cShip.maxhp.toString();
-					$(".ship_status", cElm).text( hpStatus );
-
-					$(".ship_hp_val", cElm).css("width", parseInt(cShip.hp/cShip.maxhp*100, 10)+"px");
-
-					$(".ship_repair_docking", cElm).text( String(cShip.repairDocking).toHHMMSS() );
-					var akashiText =
-						Number.isFinite(cShip.repairAkashi) ? String(cShip.repairAkashi).toHHMMSS() : "-";
-					$(".ship_repair_akashi", cElm).text( akashiText );
-
-					if (cShip.damageStatus == "full" ||
-						cShip.damageStatus == "dummy") {
-						console.warn("Damage status shouldn't be full / dummy in this docking page", cShip);
-					}
-
-					$(".ship_status", cElm).addClass("ship_" + cShip.damageStatus);
-					$(".ship_hp_val", cElm).addClass("ship_" + cShip.damageStatus);
-
-					// mutually exclusive indicators
-					var completeTime = dockingShips["x" + cShip.id.toString()];
-					if (typeof completeTime !== "undefined") {
-						// adding docking indicator
-						cElm.addClass("ship_docking");
-					} else if (cShip.fleet !== 0 &&
-						expeditionFleets.indexOf( cShip.fleet-1 ) !== -1) {
-						// adding expedition indicator
-						cElm.addClass("ship_expedition");
-					} else if (anchoredShips.indexOf(cShip.id) !== -1 &&
-							   (cShip.damageStatus === "normal" ||
-								cShip.damageStatus === "shouha")) {
-						// adding akashi repairing indicator
-						cElm.addClass("ship_akashi_repairing");
-					}
-
-					[1,2,3,4].forEach(function(x){
-						self.equipImg(cElm, x, cShip.slots[x-1], cShip.equip[x-1]);
-					});
-
-				});
-
-				self.shipList.show();
-				self.isLoading = false;
-				console.debug("Showing docking list took", ((new Date()).getTime() - self.startTime)-100 , "milliseconds");
-			},100);
-		},
-
-		/* Show single equipment icon
-		   --------------------------------------------*/
-		equipImg :function(cElm, equipNum, equipSlot, gear_id){
-			var element = $(".ship_equip_" + equipNum, cElm);
-			if(gear_id > -1){
-				var gear = KC3GearManager.get(gear_id);
-				if(gear.itemId<=0){ element.hide(); return; }
-				var gearClickFunc = function(e){
-					KC3StrategyTabs.gotoTab("mstgear", $(this).attr("alt"));
-				};
-
-				$("img",element)
+		showEquipIcon(shipRow, equipNum, slotSize, gearId) {
+			const equipDiv = $(".ship_equip_" + equipNum, shipRow);
+			if(gearId > -1){
+				const gear = KC3GearManager.get(gearId);
+				if(gear.itemId <= 0) {
+					equipDiv.hide();
+					return;
+				}
+				$("img", equipDiv)
 					.attr("src", "../../assets/img/items/" + gear.master().api_type[3] + ".png")
 					.attr("title", gear.name())
-					.attr("alt", gear.master().api_id);
-				$("img",element).click(gearClickFunc);
-				$("span",element).css('visibility','hidden');
+					.attr("alt", gear.master().api_id)
+					.click(this.gearClickFunc);
+				$("span", equipDiv).css("visibility", "hidden");
 			} else {
-				$("img",element).hide();
-				$("span",element).each(function(i,x){
-					if(equipSlot > 0)
-						$(x).text(equipSlot);
-					else
-						$(x).css('visibility','hidden');
+				// nothing equipped, show slot capacity instead if possible
+				$("img", equipDiv).hide();
+				$("span", equipDiv).each(function(_, span){
+					if(slotSize > 0) {
+						$(span).text(slotSize);
+					} else {
+						$(span).css("visibility", "hidden");
+					}
 				});
 			}
 		}
-	};
+
+	}
+
+	KC3StrategyTabs.docking = new KC3StrategyTab("docking");
+	KC3StrategyTabs.docking.definition = new KC3DockingDefinition();
+
 })();

--- a/src/pages/strategy/tabs/fleet/fleet.css
+++ b/src/pages/strategy/tabs/fleet/fleet.css
@@ -269,6 +269,15 @@
 .ui-tooltip-content .ship_tooltip .ship_level span.i18n {
 	color:#3ec0bf;
 }
+.ui-tooltip-content .ship_tooltip .ship_level span.value.married {
+	color:#a97417;
+}
+.ui-tooltip-content .ship_tooltip .ship_level span.value.high {
+	color:#107e57;
+}
+.ui-tooltip-content .ship_tooltip .ship_level span.value.medium {
+	color:#36c2db;
+}
 .ui-tooltip-content .ship_tooltip .ship_hp {
 	width:64px;
 	height:17px;

--- a/src/pages/strategy/tabs/fleet/fleet.js
+++ b/src/pages/strategy/tabs/fleet/fleet.js
@@ -412,6 +412,7 @@
 				$(".ship_tooltip .ship_rosterId span", shipBox).text(kcShip.rosterId);
 				$(".ship_tooltip .ship_stype", shipBox).text(kcShip.stype());
 				$(".ship_tooltip .ship_level span.value", shipBox).text(kcShip.level);
+				//$(".ship_tooltip .ship_level span.value", shipBox).addClass(kcShip.levelClass());
 				$(".ship_tooltip .ship_hp span.hp", shipBox).text(kcShip.hp[0]);
 				$(".ship_tooltip .ship_hp span.mhp", shipBox).text(kcShip.hp[1]);
 				$(".ship_tooltip .stat_hp", shipBox).text(kcShip.hp[1]);

--- a/src/pages/strategy/tabs/logger/logger.js
+++ b/src/pages/strategy/tabs/logger/logger.js
@@ -15,9 +15,9 @@
         error: true,
       },
       contexts: {
-        Background: true,
+        'Background': true,
         'Strategy Room': true,
-        Devtools: true,
+        'Devtools': true,
         'Content Script': true,
       },
       logSearch: '',
@@ -60,8 +60,8 @@
         .then(initStackToggle)
         .then(initSearchBox)
         .then(initLogClearButton)
-        .then(initFilter.bind(null, 'logTypes'))
-        .then(initFilter.bind(null, 'contexts'))
+        .then(initFilter.bind(this, 'logTypes'))
+        .then(initFilter.bind(this, 'contexts'))
         .then(initPagination)
         .catch(logError);
     },
@@ -159,7 +159,9 @@
       element.twbsPagination({
         totalPages: pageCount,
         visiblePages: VISIBLE_PAGES,
-        onPageClick(event, page) { renderPage(page); },
+        onPageClick(event, page) {
+          renderPage(page);
+        },
       });
     },
 
@@ -167,7 +169,7 @@
       const { clearEntries, getLogEntries, splitByDate, renderElement } =
         KC3StrategyTabs.logger.definition;
       return Promise.resolve()
-        .then(getLogEntries.bind(null, pageNum))
+        .then(getLogEntries.bind(this, pageNum))
         .then(splitByDate)
         .then((elements) => {
           clearEntries();
@@ -382,6 +384,7 @@
     logError(error) {
       KC3Log.console.error(error, error.stack);
     },
+
   };
 }());
 

--- a/src/pages/strategy/tabs/shipquests/shipquests.css
+++ b/src/pages/strategy/tabs/shipquests/shipquests.css
@@ -199,6 +199,8 @@
 	width:50px;
 	text-align:center;
 	position:relative;
+	overflow:hidden;
+	white-space:nowrap;
 }
 .tab_shipquests .ship_item .ship_lv.ship_kekkon {
 }
@@ -206,10 +208,18 @@
 	width:430px;
 	text-align:left;
 }
-.tab_shipquests .ship_item .ship_lv span {
+.tab_shipquests .ship_item .ship_lv span.i18n {
 	color:#888;
 }
-/* Fields: Stats */
+.tab_shipquests .ship_item .ship_lv span.value.married {
+	color:#a97417;
+}
+.tab_shipquests .ship_item .ship_lv span.value.high {
+	color:#107e57;
+}
+.tab_shipquests .ship_item .ship_lv span.value.medium {
+	color:#36c2db;
+}
 .tab_shipquests .ship_item .ship_stat {
 	width:35px;
 	text-align:center;

--- a/src/pages/strategy/tabs/shipquests/shipquests.html
+++ b/src/pages/strategy/tabs/shipquests/shipquests.html
@@ -35,7 +35,6 @@
 
 	<!-- SHIP LIST HTML CONTAINER -->
 	<div class="ship_list">
-
 	</div>
 
 	<div class="factory">

--- a/src/pages/strategy/tabs/shipquests/shipquests.html
+++ b/src/pages/strategy/tabs/shipquests/shipquests.html
@@ -42,10 +42,10 @@
 		<!-- SHIP RECORD -->
 		<div class="ship_item">
 			<div class="ship_field ship_id"></div>
-			<div class="ship_field ship_img hover"><img class="ship_icon"/><img class="ship_kekkon" alt=""/></div>
+			<div class="ship_field ship_img hover"><img class="ship_icon"/></div>
 			<div class="ship_field ship_name"></div>
 			<div class="ship_field ship_type"></div>
-			<div class="ship_field ship_lv"></div>
+			<div class="ship_field ship_lv"><span class="i18n">LevelShort</span> <span class="value"></span></div>
 			<div class="ship_field ship_quests"></div>
 			<div class="clear"></div>
 		</div>

--- a/src/pages/strategy/tabs/shipquests/shipquests.js
+++ b/src/pages/strategy/tabs/shipquests/shipquests.js
@@ -62,6 +62,7 @@
 				sortno: MasterShip.api_sortno,
 				name: ThisShip.name(),
 				level: ThisShip.level,
+				levelClass: ThisShip.levelClass(),
 				quests: Quests,
 			};
 
@@ -197,8 +198,8 @@
 						$(".ship_name", cElm).addClass("ship_kekkon-color");
 					}
 					$(".ship_type", cElm).text( KC3Meta.stype(cShip.stype) );
-					var shipLevelConv = shipLevel;
-					$(".ship_lv", cElm).html( "<span>Lv.</span>" + shipLevelConv);
+					$(".ship_lv .value", cElm).text( shipLevel )
+						.addClass( cShip.levelClass );
 
 					Object.keys(cShip.quests).forEach(function(questCtr){
 						var questId = cShip.quests[questCtr];

--- a/src/pages/strategy/tabs/shipquests/shipquests.js
+++ b/src/pages/strategy/tabs/shipquests/shipquests.js
@@ -1,235 +1,75 @@
 (function(){
 	"use strict";
 
-	KC3StrategyTabs.shipquests = new KC3StrategyTab("shipquests");
-
-	KC3StrategyTabs.shipquests.definition = {
-		tabSelf: KC3StrategyTabs.shipquests,
-
-		shipCache:[],
-		shipQuests:[],
-
-		// default sorting method to Level
-		currentSorters: [{name:"lv", reverse:false}],
-
-		// all sorters
-		sorters: {},
+	class KC3ShipQuestsDefinition extends KC3ShipListGrid {
+		constructor() {
+			super("shipquests");
+		}
 
 		/* INIT
 		Prepares initial static data needed.
 		---------------------------------*/
-		init :function(){
-			// Load ships quests data
-			var questsData = $.ajax('../../data/ship_quests.json', { async: false }).responseText;
-			this.shipQuests = JSON.parse(questsData);
-
-			this.prepareSorters();
-		},
+		init() {
+			this.shipQuests = {};
+			// Load relationship data of ships and quests
+			try {
+				const questsData = $.ajax('../../data/ship_quests.json', { async: false }).responseText;
+				this.shipQuests = JSON.parse(questsData);
+			} catch(e) {
+				console.error("Loading ship quests data failed", e);
+			}
+			this.showListRowCallback = this.showShipQuests;
+			this.defaultSorterDefinitions();
+		}
 
 		/* RELOAD
 		Loads latest player or game data if needed.
 		---------------------------------*/
-		reload :function(){
+		reload() {
 			KC3ShipManager.load();
 			KC3QuestManager.load();
-
-			// Cache ship info
-			this.shipCache = [];
-			for(let ctr in KC3ShipManager.list){
-				let thisShip = KC3ShipManager.list[ctr];
-				let shipData = this.prepareShipData(thisShip);
-				this.shipCache.push(shipData);
-			}
-		},
-
-		// Get ship quests
-		getShipQuests: function(shipId) {
-			var entry = this.shipQuests[shipId];
-			return entry ? entry : [];
-		},
-
-		// Prepares necessary info
-		prepareShipData: function(ship) {
-			var ThisShip = ship;
-			var MasterShip = ThisShip.master();
-			var BaseRemodelForm = RemodelDb.originOf(ThisShip.masterId);
-			var Quests = this.getShipQuests(BaseRemodelForm);
-
-			var cached = {
-				id: ThisShip.rosterId,
-				masterId: ThisShip.masterId,
-				stype: MasterShip.api_stype,
-				sortno: MasterShip.api_sortno,
-				name: ThisShip.name(),
-				level: ThisShip.level,
-				levelClass: ThisShip.levelClass(),
-				quests: Quests,
-			};
-
-			return cached;
-		},
-
-		getLastCurrentSorter: function() {
-			return this.currentSorters[this.currentSorters.length-1];
-		},
-
-		reverseLastCurrentSorter: function() {
-			var sorter = this.getLastCurrentSorter();
-			sorter.reverse = ! sorter.reverse;
-		},
-
-		setCurrentSorter: function(name) {
-			var sorter = this.sorters[name];
-			console.assert(sorter, "sorter should have been registered");
-			this.currentSorters = [ {name: sorter.name, reverse:false} ];
-		},
-
-		defineSorter: function(name,desc,comparator) {
-			this.sorters[name] = {
-				name: name,
-				desc: desc,
-				comparator: comparator
-			};
-		},
-
-		defineSimpleSorter: function(name,desc,getter) {
-			var self = this;
-			this.defineSorter(
-				name,desc,
-				function(a,b) {
-					var va = getter.call(self,a);
-					var vb = getter.call(self,b);
-					return typeof va === "string" ? va.localeCompare(vb) : va - vb;
-				});
-		},
-
-		prepareSorters: function() {
-			var define = this.defineSimpleSorter.bind(this);
-
-			define("id", "Id", function(x) { return x.id; });
-			define("name", "Name", function(x) { return x.name; });
-			define("type", "Type", function(x) { return x.stype; });
-			define("lv", "Level", function(x) { return -x.level; });
-			define("sortno", "BookNo", function(x) { return x.sortno; });
-		},
-
-		// create comparator based on current list sorters
-		makeComparator: function() {
-			function reversed(comparator) {
-				return (l, r) => -comparator(l, r);
-			}
-			function compose(prevComparator, nextComparator) {
-				return (l, r) => prevComparator(l, r) || nextComparator(l, r);
-			}
-			var mergedSorters = this.currentSorters.concat([{
-				name: "sortno",
-				reverse: false
-			}]);
-			if(this.currentSorters.every(si => si.name !== "id")){
-				mergedSorters.push({
-					name: "id",
-					reverse: false
-				});
-			}
-			return mergedSorters
-				.map( sorterInfo => {
-					var sorter = this.sorters[sorterInfo.name];
-					return sorterInfo.reverse
-						? reversed(sorter.comparator)
-						: sorter.comparator;
-				})
-				.reduce( compose );
-		},
+			this.prepareShipList(true, this.mapShipQuests);
+		}
 
 		/* EXECUTE
 		Places data onto the interface from scratch.
 		---------------------------------*/
-		execute :function(){
-			var self = this;
+		execute() {
+			this.shipListDiv = $(".tab_shipquests .ship_list");
+			this.shipRowTemplateDiv = $(".tab_shipquests .factory .ship_item");
+			this.registerShipListHeaderEvent(
+				$(".tab_shipquests .ship_header .ship_field.hover")
+			);
+			this.showListGrid();
+		}
 
-			// Column header sorting
-			$(".tab_shipquests .ship_header .ship_field.hover").on("click", function(){
-				var sorter = self.getLastCurrentSorter();
-				var sorterName = $(this).data("type");
-				if (sorterName === sorter.name) {
-					self.reverseLastCurrentSorter();
-				} else {
-					self.setCurrentSorter( sorterName  );
-				}
-				self.showList();
+		getShipQuests(baseFormMasterId) {
+			var entry = this.shipQuests[baseFormMasterId];
+			return entry ? entry : [];
+		}
+
+		mapShipQuests(shipObj) {
+			const mappedObj = this.defaultShipDataMapping(shipObj);
+			const baseRemodelForm = RemodelDb.originOf(shipObj.masterId);
+			mappedObj.quests = this.getShipQuests(baseRemodelForm);
+			return mappedObj;
+		}
+
+		showShipQuests(ship, shipRow) {
+			Object.keys(ship.quests).forEach((questIdx) => {
+				const questId = ship.quests[questIdx];
+				const questMeta = KC3Meta.quest(questId);
+				const questDiv = $("<div />")
+					.addClass("ship_field ship_stat questIcon");
+				questDiv.addClass("type" + (String(questId).substring(0,1)));
+				questDiv.text(questMeta.code);
+				questDiv.attr("title", this.buildQuestTooltip(questId, questMeta));
+				$(".ship_quests", shipRow).append(questDiv);
 			});
+		}
 
-			this.shipList = $(".tab_shipquests .ship_list");
-			this.showList();
-		},
-
-		/* SHOW SHIP LIST
-		Pagination not support yet.
-		---------------------------------*/
-		showList :function(){
-			var self = this;
-
-			this.startTime = Date.now();
-
-			// Clear list
-			this.shipList.empty().hide();
-
-			// Wait until execute
-			setTimeout(function(){
-				var shipCtr, cElm, qElm, cShip, shipLevel, questCtr;
-
-				// Sorting
-				self.shipCache.sort( self.makeComparator() );
-
-				// Fill up list
-				Object.keys(self.shipCache).forEach(function(shipCtr){
-					cShip = self.shipCache[shipCtr];
-					shipLevel = cShip.level;
-
-					cElm = $(".tab_shipquests .factory .ship_item").clone().appendTo(self.shipList);
-					if(shipCtr%2 === 0){ cElm.addClass("even"); }else{ cElm.addClass("odd"); }
-
-					$(".ship_id", cElm).text( cShip.id );
-					$(".ship_img .ship_icon", cElm).attr("src", KC3Meta.shipIcon(cShip.masterId));
-					$(".ship_img .ship_icon", cElm).attr("alt", cShip.masterId);
-					$(".ship_img .ship_icon", this).click(self.shipClickFunc);
-					$(".ship_name", cElm).text( cShip.name );
-					if(shipLevel >= 100) {
-						$(".ship_name", cElm).addClass("ship_kekkon-color");
-					}
-					$(".ship_type", cElm).text( KC3Meta.stype(cShip.stype) );
-					$(".ship_lv .value", cElm).text( shipLevel )
-						.addClass( cShip.levelClass );
-
-					Object.keys(cShip.quests).forEach(function(questCtr){
-						var questId = cShip.quests[questCtr];
-						var thisQuest = KC3Meta.quest(questId);
-
-						var divTag = $("<div />").addClass("ship_field");
-						divTag.addClass("ship_stat");
-						divTag.addClass("questIcon");
-						divTag.addClass("type"+(String(questId).substring(0,1)));
-						divTag.text(thisQuest.code);
-						divTag.attr("title", self.buildQuestTooltip(questId, thisQuest));
-
-						$(".ship_quests", cElm).append(divTag);
-
-					});
-
-				});
-
-				self.shipList.show();
-				self.shipList.createChildrenTooltips();
-				console.debug("Showing ship quests took", (Date.now() - self.startTime)-100 , "milliseconds");
-			}, 100);
-		},
-
-		shipClickFunc: function(e){
-			KC3StrategyTabs.gotoTab("mstship", $(this).attr("alt"));
-		},
-
-		buildQuestTooltip :function(questId, questMeta){
-			var title = "[{0:id}] {1:code} {2:name}".format(
+		buildQuestTooltip(questId, questMeta) {
+			let title = "[{0:id}] {1:code} {2:name}".format(
 				questId, questMeta.code || "N/A",
 				questMeta.name || KC3Meta.term("UntranslatedQuest"));
 			title += $("<p></p>").css("font-size", "11px")
@@ -256,7 +96,9 @@
 			}
 			return title;
 		}
+	}
 
-	};
+	KC3StrategyTabs.shipquests = new KC3StrategyTab("shipquests");
+	KC3StrategyTabs.shipquests.definition = new KC3ShipQuestsDefinition();
 
 })();

--- a/src/pages/strategy/tabs/ships/ships.css
+++ b/src/pages/strategy/tabs/ships/ships.css
@@ -331,21 +331,31 @@
 }
 .tab_ships .ship_item .ship_lv {
 	width:50px;
-	/*margin:0px 5px 0px 0px;*/
 	text-align:center;
 	position:relative;
+	overflow:hidden;
+	white-space:nowrap;
 }
 .tab_ships .ship_item .ship_lv.ship_kekkon {
 	/*width:70px;*/
 }
 .tab_ships .ship_item .ship_morale {
 	width:20px;
-	/*margin:0px 5px 0px 0px;*/
 	text-align:center;
 }
-.tab_ships .ship_item .ship_lv span {
+.tab_ships .ship_item .ship_lv span.i18n {
 	color:#888;
 }
+.tab_ships .ship_item .ship_lv span.value.married {
+	color:#a97417;
+}
+.tab_ships .ship_item .ship_lv span.value.high {
+	color:#107e57;
+}
+.tab_ships .ship_item .ship_lv span.value.medium {
+	color:#36c2db;
+}
+
 /* Fields: Stats */
 .tab_ships .ship_item .ship_stat {
 	width:25px;

--- a/src/pages/strategy/tabs/ships/ships.html
+++ b/src/pages/strategy/tabs/ships/ships.html
@@ -200,7 +200,7 @@
 			<div class="ship_field ship_img hover"><img class="ship_icon"/><img class="ship_kekkon" alt=""/></div>
 			<div class="ship_field ship_name"></div>
 			<div class="ship_field ship_type"></div>
-			<div class="ship_field ship_lv"></div>
+			<div class="ship_field ship_lv"><span class="i18n">LevelShort</span> <span class="value"></span></div>
 			<div class="ship_field ship_morale"></div>
 
 			<div class="ship_field ship_stat ship_hp"></div>

--- a/src/pages/strategy/tabs/ships/ships.js
+++ b/src/pages/strategy/tabs/ships/ships.js
@@ -287,6 +287,7 @@
 				sortno: MasterShip.api_sortno,
 				english: ThisShip.name(),
 				level: ThisShip.level,
+				levelClass: ThisShip.levelClass(),
 				morale: ThisShip.morale,
 				equip: ThisShip.items,
 				locked: ThisShip.lock,
@@ -857,9 +858,9 @@
 						$(".ship_name", cElm).addClass("ship_onfleet-color" + cShip.fleet);
 					}
 					$(".ship_type", cElm).text( KC3Meta.stype(cShip.stype) );
-					var shipLevelConv = shipLevel;
-					$(".ship_lv", cElm).html( "<span>Lv.</span>" + shipLevelConv);
-					$(".ship_morale", cElm).html( cShip.morale );
+					$(".ship_lv .value", cElm).text( shipLevel )
+						.addClass( cShip.levelClass );
+					$(".ship_morale", cElm).text( cShip.morale );
 					$(".ship_hp", cElm).text( cShip.hp );
 					$(".ship_lk", cElm).text( cShip.lk[0] );
 					if(cShip.lk[0] >= cShip.lk[1]){

--- a/src/pages/strategy/tabs/ships/ships.js
+++ b/src/pages/strategy/tabs/ships/ships.js
@@ -786,7 +786,7 @@
 				   function(x) { return x.ctype; });
 			define("bid", "ShipId",
 				   function(x) { return x.bid; });
-			define("sortno", "BookNo",
+			define("sortno", "SortOrder",
 				   function(x) { return x.sortno; });
 		},
 


### PR DESCRIPTION
Just wanna reuse more codes for those `ship list` liked pages, current: `docking`, `shipquests`.
Should no feature changed. More similar pages will be easier to be created.
(rebased on `update-cumulative` branch)