### PR TITLE
Refactoring ship list based pages

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -55,6 +55,7 @@
 		"KC3Graphable": true,
 		"KC3LodgerBuffer": true,
 		"KC3SortieLogs": true,
+		"KC3ShipListGrid": true,
 		"KC3NatsuiroShipbox": true,
 		"DMMCustomizations": true,
 		"interactions": true,

--- a/src/pages/strategy/shipgrid.js
+++ b/src/pages/strategy/shipgrid.js
@@ -1,0 +1,234 @@
+(function(){
+
+	class KC3ShipListGrid {
+
+		constructor(tabName) {
+			this.tabName = tabName;
+			this.shipListDiv = null;
+			this.shipRowTemplateDiv = null;
+			this.showListRowCallback = null;
+			this.shipList = [];
+			this.sorters = [{name:"lv", reverse:false}];
+			this.sorterDefinitions = {};
+			this.filterDefinitions = {};
+			this.pageNo = false;
+			this.isLoading = false;
+		}
+
+		registerShipListHeaderEvent(shipHeaderDiv) {
+			if(!shipHeaderDiv || !shipHeaderDiv.length) {
+				console.assert(false, "ship list header element not found");
+				return;
+			}
+			const self = this;
+			shipHeaderDiv.off("click").on("click", function() {
+				const sorter = self.getLastSorter();
+				const sorterName = $(this).data("type");
+				if (sorterName === sorter.name) {
+					self.reverseLastSorter();
+				} else {
+					self.setSorter(sorterName);
+				}
+				self.showListGrid();
+			});
+		}
+
+		showListGrid() {
+			if(this.isLoading) {
+				console.debug("Ignored this refresh, still loading from", this.loadStartTime);
+				return false;
+			}
+			console.assert(this.shipListDiv, "ship list element must be defined");
+			console.assert(this.shipListDiv.length, "ship list element not found");
+			console.assert(this.shipRowTemplateDiv, "ship row template element must be defined");
+			console.assert(this.shipRowTemplateDiv.length, "ship row template element not found");
+			this.isLoading = true;
+			this.loadStartTime = Date.now();
+			// Clear old list
+			this.shipListDiv.empty().hide();
+			const delayMillis = 100;
+			setTimeout(() => {
+				// Do list filtering
+				const filteredShipList = this.shipList.filter(ship => this.executeFilters(ship));
+				// Do list sorting
+				filteredShipList.sort(this.makeComparator());
+				// Fill up rows of grid
+				const oddEvenClass = (index) => {
+					return index % 2 === 0 ? "even" : "odd";
+				};
+				for(let shipIdx in filteredShipList) {
+					if(shipIdx % 10 === 0) {
+						$("<div />").addClass("ingame_page").text(
+							"Page {0}".format(Math.ceil((1 + Number(shipIdx)) / 10))
+						).appendTo(this.shipListDiv);
+					}
+					const ship = filteredShipList[shipIdx];
+					const shipRow = this.shipRowTemplateDiv.clone().appendTo(this.shipListDiv);
+					
+					shipRow.toggleClass(oddEvenClass.bind(this, shipIdx));
+					$(".ship_id", shipRow).text(ship.id);
+					$(".ship_img .ship_icon", shipRow)
+						.attr("src", KC3Meta.shipIcon(ship.masterId))
+						.attr("alt", ship.masterId)
+						.click(this.shipClickFunc);
+					$(".ship_name", shipRow).text(ship.name)
+						.toggleClass("ship_kekkon-color", ship.level >= 100);
+					$(".ship_type", shipRow).text(KC3Meta.stype(ship.stype));
+					$(".ship_lv .value", shipRow).text(ship.level)
+						.addClass(ship.levelClass);
+					
+					// Invoke more rendering of ship row
+					if(typeof this.showListRowCallback === "function") {
+						this.showListRowCallback.call(this, ship, shipRow);
+					}
+				}
+				this.shipListDiv.show().createChildrenTooltips();
+				$(".ingame_page").toggle(this.pageNo);
+				this.shipListDiv.trigger("onshow", {shipList: filteredShipList});
+				this.isLoading = false;
+				console.debug("Showing", this.tabName, "list took",
+					(Date.now() - this.loadStartTime) - delayMillis, "milliseconds");
+			}, delayMillis);
+			return true;
+		}
+
+		shipClickFunc(event) {
+			KC3StrategyTabs.gotoTab("mstship", $(this).attr("alt") || $(this).data("id"));
+		}
+
+		gearClickFunc(event) {
+			KC3StrategyTabs.gotoTab("mstgear", $(this).attr("alt") || $(this).data("id"));
+		}
+
+		prepareShipList(isReload,
+			mapShipDataCallback = this.defaultShipDataMapping,
+			initShipFilter = ((shipObj) => true)) {
+			if(!isReload && this.shipList.length > 0) {
+				return false;
+			}
+			this.shipList.length = 0;
+			for(let key in KC3ShipManager.list) {
+				const shipObj = KC3ShipManager.list[key];
+				if(initShipFilter(shipObj)) {
+					const shipData = mapShipDataCallback.call(this, shipObj);
+					this.shipList.push(shipData);
+				}
+			}
+			return true;
+		}
+
+		defaultShipDataMapping(shipObj) {
+			const shipMaster = shipObj.master();
+			const mappedObj = {
+				id: shipObj.rosterId,
+				masterId: shipObj.masterId,
+				stype: shipMaster.api_stype,
+				ctype: shipMaster.api_ctype,
+				sortno: shipMaster.api_sortno,
+				name: shipObj.name(),
+				level: shipObj.level,
+				levelClass: shipObj.levelClass(),
+				morale: shipObj.morale,
+				equip: shipObj.items,
+				slots: shipObj.slots,
+				locked: shipObj.lock,
+				speed: shipObj.speed,
+				range: shipObj.range,
+				fleet: shipObj.onFleet()
+			};
+			return mappedObj;
+		}
+
+		defaultSorterDefinitions() {
+			const define = this.defineSimpleSorter.bind(this);
+			define("id", "Id", ship => ship.id);
+			define("masterId", "ShipId", ship => ship.masterId);
+			define("name", "Name", ship => ship.name);
+			define("type", "Type", ship => ship.stype);
+			define("ctype", "Class", ship => ship.ctype);
+			define("lv", "Level", ship => -ship.level);
+			define("sortno", "SortOrder", ship => ship.sortno);
+			define("morale", "Morale", ship => -ship.morale);
+		}
+
+		defineSimpleFilter(filterName, optionValues, defaultIndex, testShipFunc) {
+			const filterDef = {
+				optionValues: optionValues,
+				currentIndex: defaultIndex || null,
+				testShip: (ship) => testShipFunc(filterDef.currentIndex, ship)
+			};
+			this.filterDefinitions[filterName] = filterDef;
+		}
+
+		executeFilters(ship) {
+			for(let key in this.filterDefinitions) {
+				var filter = this.filterDefinitions[key].testShip;
+				if (!filter(ship)) return false;
+			}
+			return true;
+		}
+
+		getLastSorter() {
+			return this.sorters[this.sorters.length - 1];
+		}
+
+		reverseLastSorter() {
+			var sorter = this.getLastSorter();
+			sorter.reverse = ! sorter.reverse;
+		}
+
+		setSorter(name) {
+			var sorter = this.sorterDefinitions[name];
+			console.assert(sorter, `sorter '${name}' should have been registered`);
+			this.sorters = [ {name: sorter.name, reverse:false} ];
+		}
+
+		defineSorter(name, desc, comparator) {
+			this.sorterDefinitions[name] = {
+				name: name,
+				desc: desc,
+				comparator: comparator
+			};
+		}
+
+		defineSimpleSorter(name, desc, getter) {
+			this.defineSorter(
+				name, desc,
+				(l, r) => {
+					const vl = getter.call(this, l);
+					const vr = getter.call(this, r);
+					return typeof vl === "string" ? vl.localeCompare(vr) : vl - vr;
+				}
+			);
+		}
+
+		makeComparator() {
+			const reversed = (comparator) => ((l, r) => -comparator(l, r));
+			const compose = (prevComparator, nextComparator) =>
+				((l, r) => prevComparator(l, r) || nextComparator(l, r));
+			const lastSorterReverse = this.getLastSorter().reverse;
+			const mergedSorters = this.sorters.concat([{
+				name: "sortno",
+				reverse: lastSorterReverse
+			}]);
+			if(this.sorters.every(sd => sd.name !== "id")) {
+				mergedSorters.push({
+					name: "id",
+					reverse: lastSorterReverse
+				});
+			}
+			return mergedSorters
+				.map(sorterDef => {
+					const sorter = this.sorterDefinitions[sorterDef.name];
+					return sorterDef.reverse
+						? reversed(sorter.comparator)
+						: sorter.comparator;
+				})
+				.reduce(compose);
+		}
+
+	}
+
+	window.KC3ShipListGrid = KC3ShipListGrid;
+
+})();

--- a/src/pages/strategy/strategy.html
+++ b/src/pages/strategy/strategy.html
@@ -179,6 +179,7 @@
 
 		<script type="text/javascript" src="graphable.js"></script>
 		<script type="text/javascript" src="sortielogs.js"></script>
+		<script type="text/javascript" src="shipgrid.js"></script>
 		<!-- @buildimportjs allstrategytabs.js -->
 
 		<!-- @nonbuildstart -->

--- a/src/pages/strategy/tabs/docking/docking.html
+++ b/src/pages/strategy/tabs/docking/docking.html
@@ -22,7 +22,7 @@
 			<div class="ship_field hover ship_id" data-type="id">ID</div>
 			<div class="ship_field ship_img"></div>
 			<div class="ship_field hover ship_name" data-type="name">Name</div>
-			<div class="ship_field hover ship_type"  data-type="type">Type</div>
+			<div class="ship_field hover ship_type" data-type="type">Type</div>
 			<div class="ship_field hover ship_lv" data-type="lv">Level</div>
 			<div class="ship_field hover ship_status" data-type="hp">HP</div>
 			<div class="ship_field hover ship_bar" data-type="status"></div>

--- a/src/pages/strategy/tabs/docking/docking.js
+++ b/src/pages/strategy/tabs/docking/docking.js
@@ -1,293 +1,208 @@
 (function(){
 	"use strict";
 
-	KC3StrategyTabs.docking = new KC3StrategyTab("docking");
-
-	KC3StrategyTabs.docking.definition = {
-		tabSelf: KC3StrategyTabs.docking,
-
-		shipCache:[],
-		sortBy: "repair_docking",
-		sortAsc: true,
-		isLoading: false,
+	class KC3DockingDefinition extends KC3ShipListGrid {
+		constructor() {
+			super("docking");
+		}
 
 		/* INIT
-		   Prepares static data needed
-		   ---------------------------------*/
-		init :function(){
-		},
+		Prepares initial static data needed.
+		---------------------------------*/
+		init() {
+			this.defineSorters();
+			this.sorters = [{name:"repair_docking", reverse:false}];
+			this.showListRowCallback = this.showShipDockingStatus;
+			this.pageNo = true;
+		}
 
 		/* RELOAD
-		   Prepares reloadable data
-		   ---------------------------------*/
-		reload :function(){
+		Loads latest player or game data if needed.
+		---------------------------------*/
+		reload() {
+			// Load latest states of ships and repair docks
 			PlayerManager.loadFleets();
-			// in order to get more up-to-date info
-			// we need to refresh the Ship Manager
 			KC3ShipManager.load();
-
-			this.shipCache = [];
-			for(let ctr in KC3ShipManager.list){
-				let ThisShip = KC3ShipManager.list[ctr];
-				let MasterShip = ThisShip.master();
-				let RepairTime = ThisShip.repairTime();
-				let ThisShipData = {
-					id : ThisShip.rosterId,
-					bid : ThisShip.masterId,
-					stype: MasterShip.api_stype,
-					sortno: MasterShip.api_sortno,
-					name: ThisShip.name(),
-					level: ThisShip.level,
-					levelClass: ThisShip.levelClass(),
-					morale: ThisShip.morale,
-					equip: ThisShip.items,
-					locked: ThisShip.lock,
-					hp: ThisShip.hp[0],
-					maxhp: ThisShip.hp[1],
-					damageStatus: ThisShip.damageStatus(),
-					repairDocking: RepairTime.docking,
-					repairAkashi: RepairTime.akashi,
-					stripped: ThisShip.isStriped(),
-					taiha: ThisShip.isTaiha(),
-					slots: ThisShip.slots,
-					fleet: ThisShip.onFleet(),
-				};
-				this.shipCache.push(ThisShipData);
-			}
-		},
+			this.cachedDockingShips = PlayerManager.getCachedDockingShips();
+			
+			// Prepare damaged ship list
+			this.prepareShipList(true, this.mapShipDockingStatus,
+				(shipObj) => shipObj.hp[0] !== shipObj.hp[1]);
+			
+			// For detecting ships in expedition fleets
+			this.expeditionFleets = [];
+			$.each(PlayerManager.fleets, (index, fleet) => {
+				const missionState = fleet.mission[0];
+				// this fleet is either on expedition or being forced back
+				// thus cannot be repaired for now
+				if (missionState == 1 ||
+					missionState == 3) {
+					this.expeditionFleets.push(index);
+				}
+			});
+			// For detecting ships covered by Akashi repairing
+			this.anchoredShips = this.getAnchoredShips();
+		}
 
 		/* EXECUTE
-		   Places data onto the interface
-		   ---------------------------------*/
-		execute :function(){
-			var self = this;
+		Places data onto the interface from scratch.
+		---------------------------------*/
+		execute() {
 			// Get latest data even clicking on tab
 			this.reload();
-			this.shipList = $(".tab_docking .ship_list");
-			// Column header sorting
-			$(".tab_docking .ship_header .ship_field.hover").on("click", function(){
-				var sortby = $(this).data("type");
-				if(!sortby){ return; }
-				if(sortby == self.sortBy){
-					self.sortAsc = !self.sortAsc;
-				}else{
-					self.sortAsc = true;
-				}
-				self.sortBy = sortby;
-				self.refreshTable();
+			this.shipListDiv = $(".tab_docking .ship_list");
+			this.shipRowTemplateDiv = $(".tab_docking .factory .ship_item");
+			this.registerShipListHeaderEvent(
+				$(".tab_docking .ship_header .ship_field.hover")
+			);
+			this.showListGrid();
+		}
+
+		mapShipDockingStatus(shipObj) {
+			const mappedObj = this.defaultShipDataMapping(shipObj);
+			const repairTime = shipObj.repairTime();
+			$.extend(mappedObj, {
+				hp: shipObj.hp[0],
+				maxhp: shipObj.hp[1],
+				damageStatus: shipObj.damageStatus(),
+				repairDocking: repairTime.docking,
+				repairAkashi: repairTime.akashi
 			});
-			this.refreshTable();
-		},
+			// Update docking time
+			const completeTime = this.cachedDockingShips["x" + mappedObj.id];
+			if (typeof completeTime !== "undefined") {
+				// if we are repairing the ship, show remaining time instead
+				try {
+					const completeDate = new Date(completeTime);
+					let secToComplete = Math.floor( (new Date(completeTime) - new Date()) / 1000 );
+					secToComplete = Math.max(0, secToComplete);
+					mappedObj.repairDocking = secToComplete;
+					// for docking ship, facility cannot be used
+					mappedObj.repairAkashi = Infinity;
+				} catch (err) {
+					console.warn("Error while calculating remaining docking time", err);
+				}
+			}
+			// facility cannot repair chuuha / taiha 'd ships
+			if (mappedObj.damageStatus === "chuuha" ||
+				mappedObj.damageStatus === "taiha") {
+				mappedObj.repairAkashi = Infinity;
+			}
+			return mappedObj;
+		}
 
 		// assuming PlayerManager.fleets is up-to-date
 		// return akashi coverage. (an array of ship ids)
-		getAnchoredShips: function() {
-			var results = [];
-			$.each( PlayerManager.fleets, function(k,fleet) {
-				var fs = KC3ShipManager.get(fleet.ships[0]);
-				// check if current fleet's flagship is akashi
-				if ([182,187].indexOf( fs.masterId ) === -1)
+		getAnchoredShips() {
+			let results = [];
+			$.each( PlayerManager.fleets, function(_, fleet) {
+				const fs = KC3ShipManager.get(fleet.ships[0]);
+				// check if current fleet's flagship is Akashi (or Kai)
+				if ([182, 187].indexOf( fs.masterId ) === -1) {
 					return;
-
-				var facCount = fs.items.filter( function(x) {
-					return KC3GearManager.get(x).masterId === 86;
-				}).length;
-				// max num of ships this akashi can repair
-				var repairCap = 2+facCount;
-				var coveredShipIds = fleet.ships.filter( function(x) {
-					return x !== -1; }).slice(0,repairCap);
+				}
+				// count of equipped Repair Facility
+				const facCount = fs.items.filter(
+					id => KC3GearManager.get(id).masterId === 86
+				).length;
+				// max num of ships this Akashi can repair
+				const repairCap = 2 + facCount;
+				const coveredShipIds = fleet.ships.filter(id => id !== -1)
+					.slice(0, repairCap);
 				results = results.concat( coveredShipIds );
 			});
 			return results;
-		},
+		}
 
-		/* REFRESH TABLE
-		   Reload ship list based on filters
-		   ---------------------------------*/
-		refreshTable :function(){
-			if(this.isLoading){ return false; }
-			this.isLoading = true;
+		defineSorters() {
+			this.defaultSorterDefinitions();
+			const define = this.defineSimpleSorter.bind(this);
+			define("hp", "CurrentHp", ship => -ship.hp);
+			define("status", "LeftHpPercent", ship => ship.hp / ship.maxhp);
+			this.defineSorter("repair_docking", "DockingTime", (a, b) => {
+				let c = b.repairDocking - a.repairDocking;
+				if (c === 0 || (!isFinite(a.repairDocking) && !isFinite(b.repairDocking)))
+					c = b.repairAkashi - a.repairAkashi;
+				return c;
+			});
+			this.defineSorter("repair_akashi", "AkashiTime", (a, b) => {
+				let c = b.repairAkashi - a.repairAkashi;
+				if (c === 0 || (!isFinite(a.repairAkashi) && !isFinite(b.repairAkashi)))
+					c = b.repairDocking - a.repairDocking;
+				return c;
+			});
+		}
 
-			var self = this;
-			this.startTime = (new Date()).getTime();
+		showShipDockingStatus(ship, shipRow) {
+			$(".ship_status", shipRow).text("{0} / {1}".format(ship.hp, ship.maxhp));
+			$(".ship_hp_val", shipRow).css("width", parseInt(ship.hp / ship.maxhp * 100, 10)+"px");
+			$(".ship_repair_docking", shipRow).text( String(ship.repairDocking).toHHMMSS() );
+			$(".ship_repair_akashi", shipRow).text(
+				Number.isFinite(ship.repairAkashi) ?
+				String(ship.repairAkashi).toHHMMSS() : "-"
+			);
+			if (ship.damageStatus === "full" ||
+				ship.damageStatus === "dummy") {
+				console.warn("Damage status shouldn't be full or dummy in this docking page", ship);
+			}
+			$(".ship_status", shipRow).addClass("ship_" + ship.damageStatus);
+			$(".ship_hp_val", shipRow).addClass("ship_" + ship.damageStatus);
 
-			var shipClickFunc = function(e){
-				KC3StrategyTabs.gotoTab("mstship", $(this).attr("alt"));
-			};
+			// Mutually exclusive indicators
+			const completeTime = this.cachedDockingShips["x" + ship.id];
+			if (typeof completeTime !== "undefined") {
+				// adding docking indicator
+				shipRow.addClass("ship_docking");
+			} else if (ship.fleet > 0 &&
+				this.expeditionFleets.indexOf(ship.fleet - 1) !== -1) {
+				// adding expedition indicator
+				shipRow.addClass("ship_expedition");
+			} else if (this.anchoredShips.indexOf(ship.id) !== -1 &&
+						(ship.damageStatus === "normal" ||
+						ship.damageStatus === "shouha")) {
+				// adding akashi repairing indicator
+				shipRow.addClass("ship_akashi_repairing");
+			}
 
-			// Clear list
-			this.shipList.empty().hide();
+			// List up equipment 4 slots (ex-slot not included)
+			[1, 2, 3, 4].forEach(num => {
+				this.showEquipIcon(shipRow, num, ship.slots[num - 1], ship.equip[num - 1]);
+			});
+		}
 
-			// Wait until execute
-			setTimeout(function(){
-				var shipCtr, cElm, cShip, shipLevel;
-				var needsRepair = function(ship,i,a) {
-					return ship.hp !== ship.maxhp;
-				};
-				var FilteredShips = self.shipCache.filter(needsRepair);
-				var dockingShips = PlayerManager.getCachedDockingShips();
-				var anchoredShips = self.getAnchoredShips();
-				var currentFleets = PlayerManager.fleets;
-				var expeditionFleets = [];
-				$.each(currentFleets, function (i,fleet) {
-					try {
-						var missionState = fleet.mission[0];
-						// this fleet is either on expedition or being forced back
-						// thus cannot be repaired for now
-						if (missionState == 1 ||
-							missionState == 3) {
-							expeditionFleets.push( i );
-						}
-					} catch (err) {
-						console.warn("Error while processing fleet info", err);
-					}
-				});
-
-				// update real-time info
-				$.each(FilteredShips, function (i, cShip) {
-					// update docking time
-					var completeTime = dockingShips["x" + cShip.id.toString()];
-					if (typeof completeTime !== "undefined") {
-						// if we are repairing the ship, show remaining time instead
-						try {
-							var completeDate = new Date(completeTime);
-							var secToComplete = Math.floor( (new Date(completeTime) - new Date()) / 1000 );
-							secToComplete = Math.max(0, secToComplete);
-							cShip.repairDocking = secToComplete;
-							// for docking ship, facility cannot be used
-							cShip.repairAkashi = Infinity;
-						} catch (err) {
-							console.warn("Error while calculating remaining docking time", err);
-						}
-					}
-
-					// facility cannot repair chuuha / taiha 'd ships
-					if (cShip.damageStatus == "chuuha" ||
-						cShip.damageStatus == "taiha") {
-						cShip.repairAkashi = Infinity;
-					}
-				});
-
-				// Sorting
-				FilteredShips.sort(function(a, b){
-					var r = 0;
-					switch(self.sortBy){
-					case "id"    : r = a.id - b.id; break;
-					case "name"  : r = a.name.localeCompare(b.name); break;
-					case "type"  : r = a.stype - b.stype; break;
-					case "lv"    : r = b.level - a.level; break;
-					case "morale": r = b.morale - a.morale; break;
-					case "hp"    : r = b.hp - a.hp; break;
-					case "status": r = a.hp / a.maxhp - b.hp / b.maxhp; break;
-					case "repair_docking":
-						r = b.repairDocking - a.repairDocking;
-						if (r === 0 || (!isFinite(a.repairDocking) && !isFinite(b.repairDocking)))
-							r = b.repairAkashi - a.repairAkashi;
-						break;
-					case "repair_akashi":
-						r = b.repairAkashi - a.repairAkashi;
-						if (r === 0 || (!isFinite(a.repairAkashi) && !isFinite(b.repairAkashi)))
-							r = b.repairDocking - a.repairDocking;
-						break;
-					}
-					r = r || a.sortno - b.sortno || a.id - b.id;
-					if(!self.sortAsc){ r = -r; }
-					return r;
-				});
-
-				// Fill up list
-				Object.keys(FilteredShips).forEach(function(shipCtr){
-					if(shipCtr%10 === 0){
-						$("<div>").addClass("ingame_page").html("Page "+Math.ceil((Number(shipCtr)+1)/10)).appendTo(self.shipList);
-					}
-
-					cShip = FilteredShips[shipCtr];
-					shipLevel = cShip.level + 50 * 0; // marry enforcement (debugging toggle)
-					cElm = $(".tab_docking .factory .ship_item").clone().appendTo(self.shipList);
-					if(shipCtr%2 === 0){ cElm.addClass("even"); }else{ cElm.addClass("odd"); }
-
-					$(".ship_id", cElm).text( cShip.id );
-					$(".ship_img .ship_icon", cElm).attr("src", KC3Meta.shipIcon(cShip.bid));
-					$(".ship_img .ship_icon", cElm).attr("alt", cShip.bid);
-					$(".ship_img .ship_icon", cElm).click(shipClickFunc);
-					$(".ship_name", cElm).text( cShip.name );
-					$(".ship_type", cElm).text( KC3Meta.stype(cShip.stype) );
-					$(".ship_lv .value", cElm).text( shipLevel )
-						.addClass( cShip.levelClass );
-					$(".ship_morale", cElm).text( cShip.morale );
-
-					var hpStatus = cShip.hp.toString() + " / " + cShip.maxhp.toString();
-					$(".ship_status", cElm).text( hpStatus );
-
-					$(".ship_hp_val", cElm).css("width", parseInt(cShip.hp/cShip.maxhp*100, 10)+"px");
-
-					$(".ship_repair_docking", cElm).text( String(cShip.repairDocking).toHHMMSS() );
-					var akashiText =
-						Number.isFinite(cShip.repairAkashi) ? String(cShip.repairAkashi).toHHMMSS() : "-";
-					$(".ship_repair_akashi", cElm).text( akashiText );
-
-					if (cShip.damageStatus == "full" ||
-						cShip.damageStatus == "dummy") {
-						console.warn("Damage status shouldn't be full / dummy in this docking page", cShip);
-					}
-
-					$(".ship_status", cElm).addClass("ship_" + cShip.damageStatus);
-					$(".ship_hp_val", cElm).addClass("ship_" + cShip.damageStatus);
-
-					// mutually exclusive indicators
-					var completeTime = dockingShips["x" + cShip.id.toString()];
-					if (typeof completeTime !== "undefined") {
-						// adding docking indicator
-						cElm.addClass("ship_docking");
-					} else if (cShip.fleet !== 0 &&
-						expeditionFleets.indexOf( cShip.fleet-1 ) !== -1) {
-						// adding expedition indicator
-						cElm.addClass("ship_expedition");
-					} else if (anchoredShips.indexOf(cShip.id) !== -1 &&
-							   (cShip.damageStatus === "normal" ||
-								cShip.damageStatus === "shouha")) {
-						// adding akashi repairing indicator
-						cElm.addClass("ship_akashi_repairing");
-					}
-
-					[1,2,3,4].forEach(function(x){
-						self.equipImg(cElm, x, cShip.slots[x-1], cShip.equip[x-1]);
-					});
-
-				});
-
-				self.shipList.show();
-				self.isLoading = false;
-				console.debug("Showing docking list took", ((new Date()).getTime() - self.startTime)-100 , "milliseconds");
-			},100);
-		},
-
-		/* Show single equipment icon
-		   --------------------------------------------*/
-		equipImg :function(cElm, equipNum, equipSlot, gear_id){
-			var element = $(".ship_equip_" + equipNum, cElm);
-			if(gear_id > -1){
-				var gear = KC3GearManager.get(gear_id);
-				if(gear.itemId<=0){ element.hide(); return; }
-				var gearClickFunc = function(e){
-					KC3StrategyTabs.gotoTab("mstgear", $(this).attr("alt"));
-				};
-
-				$("img",element)
+		showEquipIcon(shipRow, equipNum, slotSize, gearId) {
+			const equipDiv = $(".ship_equip_" + equipNum, shipRow);
+			if(gearId > -1){
+				const gear = KC3GearManager.get(gearId);
+				if(gear.itemId <= 0) {
+					equipDiv.hide();
+					return;
+				}
+				$("img", equipDiv)
 					.attr("src", "../../assets/img/items/" + gear.master().api_type[3] + ".png")
 					.attr("title", gear.name())
-					.attr("alt", gear.master().api_id);
-				$("img",element).click(gearClickFunc);
-				$("span",element).css('visibility','hidden');
+					.attr("alt", gear.master().api_id)
+					.click(this.gearClickFunc)
+					.error(function() {
+						$(this).unbind("error").attr("src", "../../assets/img/ui/empty.png");
+					});
+				$("span", equipDiv).css("visibility", "hidden");
 			} else {
-				$("img",element).hide();
-				$("span",element).each(function(i,x){
-					if(equipSlot > 0)
-						$(x).text(equipSlot);
-					else
-						$(x).css('visibility','hidden');
+				// nothing equipped, show slot capacity instead if possible
+				$("img", equipDiv).hide();
+				$("span", equipDiv).each(function(_, span) {
+					if(slotSize > 0) {
+						$(span).text(slotSize);
+					} else {
+						$(span).css("visibility", "hidden");
+					}
 				});
 			}
 		}
-	};
+
+	}
+
+	KC3StrategyTabs.docking = new KC3StrategyTab("docking");
+	KC3StrategyTabs.docking.definition = new KC3DockingDefinition();
+
 })();

--- a/src/pages/strategy/tabs/shipquests/shipquests.html
+++ b/src/pages/strategy/tabs/shipquests/shipquests.html
@@ -35,7 +35,6 @@
 
 	<!-- SHIP LIST HTML CONTAINER -->
 	<div class="ship_list">
-
 	</div>
 
 	<div class="factory">

--- a/src/pages/strategy/tabs/shipquests/shipquests.js
+++ b/src/pages/strategy/tabs/shipquests/shipquests.js
@@ -1,235 +1,73 @@
 (function(){
 	"use strict";
 
-	KC3StrategyTabs.shipquests = new KC3StrategyTab("shipquests");
-
-	KC3StrategyTabs.shipquests.definition = {
-		tabSelf: KC3StrategyTabs.shipquests,
-
-		shipCache:[],
-		shipQuests:[],
-
-		// default sorting method to Level
-		currentSorters: [{name:"lv", reverse:false}],
-
-		// all sorters
-		sorters: {},
+	class KC3ShipQuestsDefinition extends KC3ShipListGrid {
+		constructor() {
+			super("shipquests");
+		}
 
 		/* INIT
 		Prepares initial static data needed.
 		---------------------------------*/
-		init :function(){
-			// Load ships quests data
-			var questsData = $.ajax('../../data/ship_quests.json', { async: false }).responseText;
-			this.shipQuests = JSON.parse(questsData);
-
-			this.prepareSorters();
-		},
+		init() {
+			this.shipQuests = {};
+			// Load relationship data of ships and quests
+			try {
+				const questsData = $.ajax('../../data/ship_quests.json', { async: false }).responseText;
+				this.shipQuests = JSON.parse(questsData);
+			} catch(e) {
+				console.error("Loading ship quests data failed", e);
+			}
+			this.showListRowCallback = this.showShipQuests;
+			this.defaultSorterDefinitions();
+		}
 
 		/* RELOAD
 		Loads latest player or game data if needed.
 		---------------------------------*/
-		reload :function(){
+		reload() {
 			KC3ShipManager.load();
-			KC3QuestManager.load();
-
-			// Cache ship info
-			this.shipCache = [];
-			for(let ctr in KC3ShipManager.list){
-				let thisShip = KC3ShipManager.list[ctr];
-				let shipData = this.prepareShipData(thisShip);
-				this.shipCache.push(shipData);
-			}
-		},
-
-		// Get ship quests
-		getShipQuests: function(shipId) {
-			var entry = this.shipQuests[shipId];
-			return entry ? entry : [];
-		},
-
-		// Prepares necessary info
-		prepareShipData: function(ship) {
-			var ThisShip = ship;
-			var MasterShip = ThisShip.master();
-			var BaseRemodelForm = RemodelDb.originOf(ThisShip.masterId);
-			var Quests = this.getShipQuests(BaseRemodelForm);
-
-			var cached = {
-				id: ThisShip.rosterId,
-				masterId: ThisShip.masterId,
-				stype: MasterShip.api_stype,
-				sortno: MasterShip.api_sortno,
-				name: ThisShip.name(),
-				level: ThisShip.level,
-				levelClass: ThisShip.levelClass(),
-				quests: Quests,
-			};
-
-			return cached;
-		},
-
-		getLastCurrentSorter: function() {
-			return this.currentSorters[this.currentSorters.length-1];
-		},
-
-		reverseLastCurrentSorter: function() {
-			var sorter = this.getLastCurrentSorter();
-			sorter.reverse = ! sorter.reverse;
-		},
-
-		setCurrentSorter: function(name) {
-			var sorter = this.sorters[name];
-			console.assert(sorter, "sorter should have been registered");
-			this.currentSorters = [ {name: sorter.name, reverse:false} ];
-		},
-
-		defineSorter: function(name,desc,comparator) {
-			this.sorters[name] = {
-				name: name,
-				desc: desc,
-				comparator: comparator
-			};
-		},
-
-		defineSimpleSorter: function(name,desc,getter) {
-			var self = this;
-			this.defineSorter(
-				name,desc,
-				function(a,b) {
-					var va = getter.call(self,a);
-					var vb = getter.call(self,b);
-					return typeof va === "string" ? va.localeCompare(vb) : va - vb;
-				});
-		},
-
-		prepareSorters: function() {
-			var define = this.defineSimpleSorter.bind(this);
-
-			define("id", "Id", function(x) { return x.id; });
-			define("name", "Name", function(x) { return x.name; });
-			define("type", "Type", function(x) { return x.stype; });
-			define("lv", "Level", function(x) { return -x.level; });
-			define("sortno", "BookNo", function(x) { return x.sortno; });
-		},
-
-		// create comparator based on current list sorters
-		makeComparator: function() {
-			function reversed(comparator) {
-				return (l, r) => -comparator(l, r);
-			}
-			function compose(prevComparator, nextComparator) {
-				return (l, r) => prevComparator(l, r) || nextComparator(l, r);
-			}
-			var mergedSorters = this.currentSorters.concat([{
-				name: "sortno",
-				reverse: false
-			}]);
-			if(this.currentSorters.every(si => si.name !== "id")){
-				mergedSorters.push({
-					name: "id",
-					reverse: false
-				});
-			}
-			return mergedSorters
-				.map( sorterInfo => {
-					var sorter = this.sorters[sorterInfo.name];
-					return sorterInfo.reverse
-						? reversed(sorter.comparator)
-						: sorter.comparator;
-				})
-				.reduce( compose );
-		},
+			this.prepareShipList(true, this.mapShipQuests);
+		}
 
 		/* EXECUTE
 		Places data onto the interface from scratch.
 		---------------------------------*/
-		execute :function(){
-			var self = this;
+		execute() {
+			this.shipListDiv = $(".tab_shipquests .ship_list");
+			this.shipRowTemplateDiv = $(".tab_shipquests .factory .ship_item");
+			this.registerShipListHeaderEvent(
+				$(".tab_shipquests .ship_header .ship_field.hover")
+			);
+			this.showListGrid();
+		}
 
-			// Column header sorting
-			$(".tab_shipquests .ship_header .ship_field.hover").on("click", function(){
-				var sorter = self.getLastCurrentSorter();
-				var sorterName = $(this).data("type");
-				if (sorterName === sorter.name) {
-					self.reverseLastCurrentSorter();
-				} else {
-					self.setCurrentSorter( sorterName  );
-				}
-				self.showList();
-			});
+		getShipQuests(baseFormMasterId) {
+			var entry = this.shipQuests[baseFormMasterId];
+			return entry ? entry : [];
+		}
 
-			this.shipList = $(".tab_shipquests .ship_list");
-			this.showList();
-		},
+		mapShipQuests(shipObj) {
+			const mappedObj = this.defaultShipDataMapping(shipObj);
+			const baseRemodelForm = RemodelDb.originOf(shipObj.masterId);
+			mappedObj.quests = this.getShipQuests(baseRemodelForm);
+			return mappedObj;
+		}
 
-		/* SHOW SHIP LIST
-		Pagination not support yet.
-		---------------------------------*/
-		showList :function(){
-			var self = this;
+		showShipQuests(ship, shipRow) {
+			for(let questId of ship.quests) {
+				const questMeta = KC3Meta.quest(questId);
+				const questDiv = $("<div />")
+					.addClass("ship_field ship_stat questIcon")
+					.addClass("type" + String(questId).substr(0, 1));
+				questDiv.text(questMeta.code);
+				questDiv.attr("title", this.buildQuestTooltip(questId, questMeta));
+				$(".ship_quests", shipRow).append(questDiv);
+			}
+		}
 
-			this.startTime = Date.now();
-
-			// Clear list
-			this.shipList.empty().hide();
-
-			// Wait until execute
-			setTimeout(function(){
-				var shipCtr, cElm, qElm, cShip, shipLevel, questCtr;
-
-				// Sorting
-				self.shipCache.sort( self.makeComparator() );
-
-				// Fill up list
-				Object.keys(self.shipCache).forEach(function(shipCtr){
-					cShip = self.shipCache[shipCtr];
-					shipLevel = cShip.level;
-
-					cElm = $(".tab_shipquests .factory .ship_item").clone().appendTo(self.shipList);
-					if(shipCtr%2 === 0){ cElm.addClass("even"); }else{ cElm.addClass("odd"); }
-
-					$(".ship_id", cElm).text( cShip.id );
-					$(".ship_img .ship_icon", cElm).attr("src", KC3Meta.shipIcon(cShip.masterId));
-					$(".ship_img .ship_icon", cElm).attr("alt", cShip.masterId);
-					$(".ship_img .ship_icon", this).click(self.shipClickFunc);
-					$(".ship_name", cElm).text( cShip.name );
-					if(shipLevel >= 100) {
-						$(".ship_name", cElm).addClass("ship_kekkon-color");
-					}
-					$(".ship_type", cElm).text( KC3Meta.stype(cShip.stype) );
-					$(".ship_lv .value", cElm).text( shipLevel )
-						.addClass( cShip.levelClass );
-
-					Object.keys(cShip.quests).forEach(function(questCtr){
-						var questId = cShip.quests[questCtr];
-						var thisQuest = KC3Meta.quest(questId);
-
-						var divTag = $("<div />").addClass("ship_field");
-						divTag.addClass("ship_stat");
-						divTag.addClass("questIcon");
-						divTag.addClass("type"+(String(questId).substring(0,1)));
-						divTag.text(thisQuest.code);
-						divTag.attr("title", self.buildQuestTooltip(questId, thisQuest));
-
-						$(".ship_quests", cElm).append(divTag);
-
-					});
-
-				});
-
-				self.shipList.show();
-				self.shipList.createChildrenTooltips();
-				console.debug("Showing ship quests took", (Date.now() - self.startTime)-100 , "milliseconds");
-			}, 100);
-		},
-
-		shipClickFunc: function(e){
-			KC3StrategyTabs.gotoTab("mstship", $(this).attr("alt"));
-		},
-
-		buildQuestTooltip :function(questId, questMeta){
-			var title = "[{0:id}] {1:code} {2:name}".format(
+		buildQuestTooltip(questId, questMeta) {
+			let title = "[{0:id}] {1:code} {2:name}".format(
 				questId, questMeta.code || "N/A",
 				questMeta.name || KC3Meta.term("UntranslatedQuest"));
 			title += $("<p></p>").css("font-size", "11px")
@@ -256,7 +94,9 @@
 			}
 			return title;
 		}
+	}
 
-	};
+	KC3StrategyTabs.shipquests = new KC3StrategyTab("shipquests");
+	KC3StrategyTabs.shipquests.definition = new KC3ShipQuestsDefinition();
 
 })();

--- a/src/pages/strategy/tabs/ships/ships.js
+++ b/src/pages/strategy/tabs/ships/ships.js
@@ -786,7 +786,7 @@
 				   function(x) { return x.ctype; });
 			define("bid", "ShipId",
 				   function(x) { return x.bid; });
-			define("sortno", "BookNo",
+			define("sortno", "SortOrder",
 				   function(x) { return x.sortno; });
 		},
 


### PR DESCRIPTION
Just wanna reuse more codes for those `ship list` liked pages, current: `docking`, `shipquests`.
Should no feature changed. More similar pages will be easier to be created.
(will merge into `update-cumulative` branch, to test grunt package)