### PR TITLE
Fix removal of Lv. 155 ships of leveling tab

### DIFF
--- a/src/pages/strategy/tabs/expcalc/expcalc.js
+++ b/src/pages/strategy/tabs/expcalc/expcalc.js
@@ -661,8 +661,10 @@
 				editingBox.addClass("inactive");
 
 				// the only can when nextLevel === false is when your ship have reached Lv.155
-				if (nextLevel === false)
+				if (nextLevel === false) {
+					editingBox.remove();
 					return;
+				}
 
 				if (nextLevel < 99) {
 					$(".section_expcalc .box_recommend .clear").remove();


### PR DESCRIPTION
Completely remove box of 155 ships after removing them from current goals.

Fixes ![image of bug](https://cdn.discordapp.com/attachments/205766705463427072/327853213070000128/unknown.png)
