### PR TITLE
Add support for multi-tracking TL's

### DIFF
--- a/src/library/objects/Quest.js
+++ b/src/library/objects/Quest.js
@@ -57,7 +57,7 @@ known IDs see QuestManager
 	};
 
 	/* OUTPUT SHORT
-	Return tracking text to be shown on Panel
+	Return tracking text to be shown on Panel and Strategy Room
 	------------------------------------------*/
 	KC3Quest.prototype.outputShort = function(showAll){
 		if (typeof showAll == "undefined") {
@@ -69,7 +69,7 @@ known IDs see QuestManager
 			var textToShow = "";
 			for(ctr in this.tracking){
 				textToShow = this.tracking[ctr][0]+"/"+this.tracking[ctr][1];
-				trackingText.push(textToShow);
+				trackingText.push((this.meta().trackTypes ? this.meta().trackTypes[ctr] : "{0}").format(textToShow));
 				if (!showAll && (this.tracking[ctr][0] < this.tracking[ctr][1])) {
 					return textToShow;
 				}
@@ -84,14 +84,14 @@ known IDs see QuestManager
 	};
 
 	/* OUTPUT HTML
-	Return tracking text to be shown on Strategy Room
+	Return tracking text to be shown on in-game quest overlay
 	------------------------------------------*/
 	KC3Quest.prototype.outputHtml = function(){
 		if(this.tracking){
 			var trackingText = [];
 			var ctr;
 			for(ctr in this.tracking){
-				trackingText.push(this.tracking[ctr][0]+"/"+this.tracking[ctr][1]);
+				trackingText.push((this.meta().trackTypes ? this.meta().trackTypes[ctr] : "{0}").format(this.tracking[ctr][0]+"/"+this.tracking[ctr][1]));
 			}
 			return trackingText.join("<br />");
 		}
@@ -168,7 +168,8 @@ known IDs see QuestManager
 					code : questMeta.code,
 					name : questMeta.name,
 					desc : questMeta.desc,
-					memo : questMeta.memo
+					memo : questMeta.memo,
+					trackTypes : questMeta.trackTypes
 				}; };
 				// If tracking is empty and Meta is defined
 				if(this.tracking === false){
@@ -190,6 +191,7 @@ known IDs see QuestManager
 				|| oldMeta.name !== questMeta.name
 				|| oldMeta.desc !== questMeta.desc
 				|| oldMeta.memo !== questMeta.memo
+				|| oldMeta.trackTypes !== questMeta.trackTypes
 				)){
 				// Only update meta text, keep tracking untouched
 				this.meta = function(){ return {
@@ -197,7 +199,8 @@ known IDs see QuestManager
 					code : questMeta.code,
 					name : questMeta.name,
 					desc : questMeta.desc,
-					memo : questMeta.memo
+					memo : questMeta.memo,
+					trackTypes : questMeta.trackTypes
 				}; };
 			}
 		}

--- a/src/library/objects/Quest.js
+++ b/src/library/objects/Quest.js
@@ -69,7 +69,7 @@ known IDs see QuestManager
 			var textToShow = "";
 			for(ctr in this.tracking){
 				textToShow = this.tracking[ctr][0]+"/"+this.tracking[ctr][1];
-				trackingText.push((this.meta().trackTypes ? this.meta().trackTypes[ctr] : "{0}").format(textToShow));
+				trackingText.push((this.meta().trackingDesc ? this.meta().trackingDesc[ctr] : "{0}").format(textToShow));
 				if (!showAll && (this.tracking[ctr][0] < this.tracking[ctr][1])) {
 					return textToShow;
 				}
@@ -91,7 +91,7 @@ known IDs see QuestManager
 			var trackingText = [];
 			var ctr;
 			for(ctr in this.tracking){
-				trackingText.push((this.meta().trackTypes ? this.meta().trackTypes[ctr] : "{0}").format(this.tracking[ctr][0]+"/"+this.tracking[ctr][1]));
+				trackingText.push(this.tracking[ctr][0]+"/"+this.tracking[ctr][1]);
 			}
 			return trackingText.join("<br />");
 		}
@@ -169,7 +169,7 @@ known IDs see QuestManager
 					name : questMeta.name,
 					desc : questMeta.desc,
 					memo : questMeta.memo,
-					trackTypes : questMeta.trackTypes
+					trackingDesc : questMeta.trackingDesc
 				}; };
 				// If tracking is empty and Meta is defined
 				if(this.tracking === false){
@@ -191,7 +191,7 @@ known IDs see QuestManager
 				|| oldMeta.name !== questMeta.name
 				|| oldMeta.desc !== questMeta.desc
 				|| oldMeta.memo !== questMeta.memo
-				|| oldMeta.trackTypes !== questMeta.trackTypes
+				|| oldMeta.trackingDesc !== questMeta.trackingDesc
 				)){
 				// Only update meta text, keep tracking untouched
 				this.meta = function(){ return {
@@ -200,7 +200,7 @@ known IDs see QuestManager
 					name : questMeta.name,
 					desc : questMeta.desc,
 					memo : questMeta.memo,
-					trackTypes : questMeta.trackTypes
+					trackingDesc : questMeta.trackingDesc
 				}; };
 			}
 		}

--- a/src/pages/strategy/tabs/translations/translations.css
+++ b/src/pages/strategy/tabs/translations/translations.css
@@ -66,6 +66,11 @@
 	clear: both;
 }
 
+.tab_translations .tq-trackTypes {
+	font-size: smaller;
+	clear: both;
+}
+
 .tab_translations .tq-json {
 	font-family: monospace;
 	color: gray;

--- a/src/pages/strategy/tabs/translations/translations.css
+++ b/src/pages/strategy/tabs/translations/translations.css
@@ -66,7 +66,7 @@
 	clear: both;
 }
 
-.tab_translations .tq-trackTypes {
+.tab_translations .tq-trackingDesc {
 	font-size: smaller;
 	clear: both;
 }

--- a/src/pages/strategy/tabs/translations/translations.js
+++ b/src/pages/strategy/tabs/translations/translations.js
@@ -78,7 +78,7 @@
 				var questName = v.name.val;
 				var questDesc = v.desc.val;
 				var questMemo = v.memo ? v.memo.val : false;
-				var questTrackTypes = v.trackTypes ? v.trackTypes : false;
+				var questTrackingDesc = v.trackingDesc ? v.trackingDesc : false;
 
 				var questNameL = v.name.tag;
 				var questDescL = v.desc.tag;
@@ -107,11 +107,11 @@
 							"translation_done" : "translation_missing");
 					}
 				}
-				if(questTrackTypes){
-					for(var index = 0; index < questTrackTypes.length; index++){
-						var questTrack = $("<div/>").addClass("tq-trackTypes");
-						questTrack.text("[" + index + "] " + questTrackTypes[index].val).addClass(
-							language === questTrackTypes[index].tag ?
+				if(questTrackingDesc){
+					for(var index = 0; index < questTrackingDesc.length; index++){
+						var questTrack = $("<div/>").addClass("tq-trackingDesc");
+						questTrack.text("[" + index + "] " + questTrackingDesc[index].val).addClass(
+							language === questTrackingDesc[index].tag ?
 								"translation_done" : "translation_missing");
 						questTrack.appendTo(row);
 					}

--- a/src/pages/strategy/tabs/translations/translations.js
+++ b/src/pages/strategy/tabs/translations/translations.js
@@ -78,6 +78,7 @@
 				var questName = v.name.val;
 				var questDesc = v.desc.val;
 				var questMemo = v.memo ? v.memo.val : false;
+				var questTrackTypes = v.trackTypes ? v.trackTypes : false;
 
 				var questNameL = v.name.tag;
 				var questDescL = v.desc.tag;
@@ -98,14 +99,24 @@
 				if(questMemo){
 					if($("#html-rendering").is(":checked")){
 						$(".tq-memo",row).html(questMemo.replace(/\n/g,"<br/>")).addClass(
-							language === v.desc.tag ?
+							language === v.memo.tag ?
 							"translation_done" : "translation_missing");
 					} else {
 						$(".tq-memo",row).text(questMemo.replace(/\n/g,"\\n")).addClass(
-							language === v.desc.tag ?
+							language === v.memo.tag ?
 							"translation_done" : "translation_missing");
 					}
 				}
+				if(questTrackTypes){
+					for(var index = 0; index < questTrackTypes.length; index++){
+						var questTrack = $("<div/>").addClass("tq-trackTypes");
+						questTrack.text("[" + index + "] " + questTrackTypes[index].val).addClass(
+							language === questTrackTypes[index].tag ?
+								"translation_done" : "translation_missing");
+						questTrack.appendTo(row);
+					}
+				}
+
 				$(".tq-json",row).text('{0}:{1},'.format(JSON.stringify(k), JSON.stringify(originalJson[k])));
 
 				row.appendTo( "#tr-container" );

--- a/src/pages/strategy/themes/dark.css
+++ b/src/pages/strategy/themes/dark.css
@@ -1742,7 +1742,7 @@ button, input, select, textarea {
 .tab_translations .tq-item.translation_missing .tq-from,
 .tab_translations .tq-item .tq-name.translation_missing,
 .tab_translations .tq-item .tq-desc.translation_missing,
-.tab_translations .tq-item .tq-trackTypes.translation_missing {
+.tab_translations .tq-item .tq-trackingDesc.translation_missing {
 	color: firebrick;
 }
 .tab_translations .page_content select {

--- a/src/pages/strategy/themes/dark.css
+++ b/src/pages/strategy/themes/dark.css
@@ -1741,7 +1741,8 @@ button, input, select, textarea {
 .tab_translations .tq-item.translation_missing .tq-key,
 .tab_translations .tq-item.translation_missing .tq-from,
 .tab_translations .tq-item .tq-name.translation_missing,
-.tab_translations .tq-item .tq-desc.translation_missing {
+.tab_translations .tq-item .tq-desc.translation_missing,
+.tab_translations .tq-item .tq-trackTypes.translation_missing {
 	color: firebrick;
 }
 .tab_translations .page_content select {


### PR DESCRIPTION
Allows addition of a TL for every tracking line, could be used for weekly 1, quarterly ranking and quarterly expedition.

![Panel](https://user-images.githubusercontent.com/5676386/28227496-7fc9784e-68da-11e7-8f43-72a134116b46.png) 
![Strategy Room](https://user-images.githubusercontent.com/5676386/28227502-85c59bec-68da-11e7-8d8c-acb4038a1a04.png)

## TL examples

```json
    "214": {
        "code": "Bw1",
        "name": "Weekly Sorties",
        "desc": "Sortie 36 times, reach 24 boss nodes, B-Rank+ 12 boss nodes, and obtain 6 S-Ranks.",
        "memo": "\u203bOperation A-Go",
        "unlock": [ 221 ],
        "tracking": [ [0,36], [0,24], [0,12], [0,6] ],
        "trackTypes": [ "Sorties {0}", "Reach bosses {0}", "B+ bosses {0}", "S-ranks {0}"]
    },
...
    "854": {
        "code": "Bq2",
        "name": "Quarterly Ranking Points",
        "desc": "Sortie Fleet 1 to [W2-4], [W6-1] and [W6-3] and A-Rank+ the boss nodes of each. Sortie to [W6-4] and S-Rank the boss node.",
        "memo": "\u203bBattle Results Extension Mission! \"Operation Z\", Preliminary Operation\n\u27a3Rewards 3 Mamiya, 4 Screws and 350 Ranking Points",
        "tracking": [ [0,1], [0,1], [0,1], [0,1] ],
        "trackTypes": [ "A-rank+ 2-4 {0}", "A-rank+ 6-1 {0}", "A-rank+ 6-2 {0}", "S-rank 6-3 {0}" ]
    },
...
    "426": {
        "code": "D24",
        "name": "Quarterly Expeditions",
        "desc": "Complete Expeditions 3, 4, 5 and 10.",
        "memo": "\u2623This quest is still being verified. Report any problems to the KC3 team.\n\u203bPerform Strict Vigilance Over the Maritime Trade Routes!",
        "tracking": [ [0,1], [0,1], [0,1], [0,1] ],
        "trackTypes" : [ "Expedition 3 ({0})", "Expedition 4 ({0})", "Expedition 5 ({0})", "Expedition 10 ({0})" ]
    },
```
## For discussion

- Change 0/1 to ✖ and 1/1 to ✔, putting it between ( ) makes expedition one easier to read, but wouldn't be necessary if it's a checkmark/cross. Will prob look better for Bq2 as well.

- Might need to use shorter text to fit in-game quest overlay or just show old, unformatted X/Y (by reverting `outputHtml` to old style)
![quest screen](https://user-images.githubusercontent.com/5676386/28227739-a4fb920e-68db-11e7-8582-eb924ad20e73.png)
Since I already did the other two quests, I can't check how bad they are in quest menu.

- Bw1 could be changed order, as in `X/36 Sorties` etc.

- Rename `trackTypes` to something else