### PR TITLE
Showcase update: event ship locks

### DIFF
--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -508,8 +508,14 @@
 
     ShowcaseExporter.prototype._drawStat = function (ship, stat, x, y, w, h, color) {
         var MasterShipStat = ship.master()[this._paramToApi[stat]];
-        if(MasterShipStat[0]+ship.mod[this._modToParam.indexOf(stat)]>=MasterShipStat[1]){
-            this.ctx.fillStyle = color;
+        this.ctx.fillStyle = color;
+        if (stat === "lk") {
+            if (MasterShipStat[0] + ship.mod[this._modToParam.indexOf(stat)] >= 50) {
+                this.ctx.fillRect(x, y, w, h);
+            } else if (MasterShipStat[0] + ship.mod[this._modToParam.indexOf(stat)] >= 40) {
+                this.ctx.fillRect(x, y, w, h / 2);
+            }
+        } else if (MasterShipStat[0] + ship.mod[this._modToParam.indexOf(stat)] >= MasterShipStat[1]) {
             this.ctx.fillRect(x, y, w, h);
         }
     };

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -19,6 +19,7 @@
             width: 330,
             height: 35
         };
+        this.lock_plan = null;
         this.colors = {
             odd: "#e0e0e0",
             even: "#f2f2f2",
@@ -38,8 +39,17 @@
             equipCount: "#000",
             equipStars: "#42837f",
             equipInfo: "#000",
-            equipStat: "#000"
+            equipStat: "#000",
+            /* should match lock mods in light theme. see legacy.css */
+            lock_modes: {
+                1: "#029DD5",
+                2: "#64B162",
+                3: "#CCC700",
+                4: "#EB9528",
+                5: "#B1A2C1"
+            }
         };
+
         this.buildSettings = {};
         this.columnCount = 5;
         this.loadingCount = 0;
@@ -291,6 +301,14 @@
             this.rowParams.width = this.rowParams.height*3;
             this.columnCount=this.columnCount*2;
         }
+        if(this.buildSettings.eventLocking === true && typeof localStorage.lock_plan !== "undefined"){
+            this.lock_plan = {};
+            JSON.parse(localStorage.lock_plan).map((ships, lock_num) => {
+                ships.map((shipId) => {
+                    this.lock_plan[shipId] = lock_num + 1;
+                });
+            });
+        }
         if(!this._getShips()){
             return;
         }
@@ -430,13 +448,41 @@
         this.ctx.fillRect(x, y, this.rowParams.width, this.rowParams.height);
         var xOffset = this.rowParams.height / 7;
 
+        if(this.buildSettings.eventLocking === true){
+            if(ship.sally !== 0){
+                this.ctx.fillStyle = this.ctx.strokeStyle = this.colors.lock_modes[ship.sally];
+                if(this.buildSettings.exportMode==="light"){
+                    this.ctx.fillRect(x + this.rowParams.height * 1.2 + xOffset, y, this.rowParams.width - this.rowParams.height * 1.2 - xOffset, this.rowParams.height);
+                } else {
+                    this.ctx.fillRect(x + this.rowParams.height * 2,y,this.rowParams.width - this.rowParams.height * 2, this.rowParams.height);
+                }
+            } else if(this.lock_plan !== null && this.lock_plan[ship.rosterId]){
+                this.ctx.beginPath();
+                this.ctx.fillStyle = this.ctx.strokeStyle = this.colors.lock_modes[this.lock_plan[ship.rosterId]];
+                var circleRadius = 5;
+                this.ctx.strokeStyle = circleRadius;
+                this.ctx.arc(x + this.rowParams.width - circleRadius * 2, y + this.rowParams.height / 2, circleRadius, 0, 2 * Math.PI);
+                this.ctx.fill();
+                this.ctx.stroke();
+            }
+        }
+
         this._drawStat(ship, "fp", x + xOffset, y, this.rowParams.height / 2, this.rowParams.height / 2, this.colors.statFP);
         this._drawStat(ship, "tp", x + xOffset + this.rowParams.height / 2, y, this.rowParams.height / 2, this.rowParams.height / 2, this.colors.statTP);
         this._drawStat(ship, "aa", x + xOffset + this.rowParams.height / 2, y + this.rowParams.height / 2, this.rowParams.height / 2, this.rowParams.height / 2, this.colors.statAA);
         this._drawStat(ship, "ar", x + xOffset, y + this.rowParams.height / 2, this.rowParams.height / 2, this.rowParams.height / 2, this.colors.statAR);
-        this._drawStat(ship, "lk", x + xOffset + this.rowParams.height, y, this.rowParams.height / 5, this.rowParams.height / 2, this.colors.statLK);
+        this._drawStat(ship, "lk", x + xOffset + this.rowParams.height, y, this.rowParams.height / 5, this.rowParams.height, this.colors.statLK);
 
         this._drawIcon(x + xOffset, y, ship.masterId);
+
+        this.ctx.font = generateFontString(400, 24);
+        this.ctx.fillStyle = this.colors.shipInfo;
+        this.ctx.textBaseline = "middle";
+        this.ctx.fillText(
+            ship.level,
+            x + this.rowParams.width - this.rowParams.height * 0.5 - this.ctx.measureText(ship.level).width,
+            y + this.rowParams.height / 2
+        );
 
         if(this.buildSettings.exportMode !== "light") {
             var fontSize = 24;
@@ -450,15 +496,6 @@
             this.ctx.fillText(ship.name(), x + this.rowParams.height * 2, y + this.rowParams.height / 2);
         }
 
-        this.ctx.font = generateFontString(400, 24);
-        this.ctx.fillStyle = this.colors.shipInfo;
-        this.ctx.textBaseline = "middle";
-        this.ctx.fillText(
-            ship.level,
-            x + this.rowParams.width - this.rowParams.height * 0.5 - this.ctx.measureText(ship.level).width,
-            y + this.rowParams.height / 2
-        );
-
     };
 
     ShowcaseExporter.prototype._drawIcon = function (x, y, shipId) {
@@ -469,7 +506,7 @@
         );
     };
 
-    ShowcaseExporter.prototype._drawStat = function (ship, stat, x, y, w, h, color, background) {
+    ShowcaseExporter.prototype._drawStat = function (ship, stat, x, y, w, h, color) {
         var MasterShipStat = ship.master()[this._paramToApi[stat]];
         if(MasterShipStat[0]+ship.mod[this._modToParam.indexOf(stat)]>=MasterShipStat[1]){
             this.ctx.fillStyle = color;

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -513,7 +513,7 @@
             if (MasterShipStat[0] + ship.mod[this._modToParam.indexOf(stat)] >= 50) {
                 this.ctx.fillRect(x, y, w, h);
             } else if (MasterShipStat[0] + ship.mod[this._modToParam.indexOf(stat)] >= 40) {
-                this.ctx.fillRect(x, y, w, h / 2);
+                this.ctx.fillRect(x, y + h/4, w, h / 2);
             }
         } else if (MasterShipStat[0] + ship.mod[this._modToParam.indexOf(stat)] >= MasterShipStat[1]) {
             this.ctx.fillRect(x, y, w, h);

--- a/src/pages/strategy/tabs/showcase/showcase.html
+++ b/src/pages/strategy/tabs/showcase/showcase.html
@@ -32,6 +32,9 @@
 	<div class="help_q">Exporter is downloading image instead of opening it in new tab or Imgur!</div>
 	<div class="help_a">In case of Imgur error or image data string is being too big for new tab to handle it will be downloaded.</div>
 
+	<div class="help_q">How does export event locking tags work?</div>
+	<div class="help_a">If ship is locked in some operation you will see colored background behind it's name. If you only plan to lock it there you will see colored circle right after ship level. Please note colors on image doesn't necessarily match lock colors in game. You could compare them <a href="#locking">here</a>.</div>
+
 	<div class="help_more">
 		<a href="https://github.com/KC3Kai/KC3Kai/wiki/Strategy-Room%3A-Showcase">Learn more</a>
 	</div>
@@ -58,6 +61,11 @@
 		<div class="option admiral_info">
 			<input type="checkbox" id="exportAddName">
 			<label for="exportAddName">Show my name and level on image</label>
+		</div>
+
+		<div class="option admiral_info">
+			<input type="checkbox" id="exportEventLocking">
+			<label for="exportEventLocking">Add event locking tags (see <a href="#locking">locking</a>)</label>
 		</div>
 	</div>
 	<div class="clear"></div>

--- a/src/pages/strategy/tabs/showcase/showcase.js
+++ b/src/pages/strategy/tabs/showcase/showcase.js
@@ -183,7 +183,8 @@
 			var defSettings = {
 				exportMode: "standard",
 				output: 2, // new tab
-				exportName: false
+				exportName: false,
+				eventLocking: false
 			};
 			var settings;
 			if (typeof localStorage.srShowcase === "undefined") {
@@ -206,6 +207,7 @@
 			$("#exportOutputMode").val(settings.output);
 			$("#exportAddName")[0].checked = settings.exportName;
 			$("#exportMode").val(settings.exportMode);
+			$("#exportEventLocking")[0].checked = settings.eventLocking;
 
 		},
 
@@ -290,6 +292,14 @@
 					return settings;
 				});
 			});
+
+            $("#exportEventLocking").change(function(){
+                var checked = this.checked;
+                self.modifySettings(function(settings){
+                    settings.eventLocking = checked;
+                    return settings;
+                });
+            });
 
 			$("#exportMode").change(function(){
 				var val = this.value;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9434504/29615426-99e4a7fc-8816-11e7-8f42-90e4d3b9cb5f.png)
i guess i should ask someone to validate my engrish :rofl:

so it looks like so
first you either lock your ships in sortie or inside strategy room **Locking** page.
![image](https://user-images.githubusercontent.com/9434504/29615477-bea9499e-8816-11e7-9598-3324201eaa1c.png)
 
Then you click that checkbox above and have something like this
![image](https://user-images.githubusercontent.com/9434504/29615949-651e4f80-8818-11e7-832b-0a58e966cb5e.png)

or in case of Light version this
![image](https://user-images.githubusercontent.com/9434504/29615923-56983606-8818-11e7-9821-76cf01a69569.png)


Colors might be discussed but i rather leave them as is, since Tanaka already trolled us with this two:
![image](https://user-images.githubusercontent.com/9434504/29615634-58c0d164-8817-11e7-8a2e-5911a1cb2f6b.png)

