### PR TITLE
Add export to kancepts and kanmusu list buttons to ship list, adds #2196

### DIFF
--- a/src/pages/strategy/tabs/ships/ships.css
+++ b/src/pages/strategy/tabs/ships/ships.css
@@ -97,6 +97,7 @@
 	float:left;
 	margin:0px 0px 2px 0px;
 	line-height:18px;
+	width:220px;
 }
 .tab_ships .ship_count div {
 	float:left;
@@ -105,6 +106,21 @@
 .tab_ships .ship_count .count_label {
 	font-weight:bold;
 	padding-right:5px;
+}
+
+.tab_ships .ship_export {
+	float:left;
+	font-weight:bold;
+	margin:0px 0px 2px 0px;
+	line-height:18px;
+}
+.tab_ships .ship_export div {
+	float:left;
+	font-size:12px;
+}
+.tab_ships .ship_export .hover {
+	font-weight:normal;
+	margin:0px 0px 0px 1em;
 }
 
 .tab_ships .control_buttons {

--- a/src/pages/strategy/tabs/ships/ships.html
+++ b/src/pages/strategy/tabs/ships/ships.html
@@ -148,6 +148,11 @@
 		<div class="count_label">Listed ships:</div>
 		<div class="count_value"></div>
 	</div>
+	<div class="ship_export">
+		<div class="count_label">Export to:</div>
+		<div class="export_to_kanmusu_list hover">kanmusu list</div>
+		<div class="export_to_kancepts hover">kancepts</div>
+	</div>
 	<div class="control_buttons">
 		<div class="reset_default hover">Reset All</div>
 	</div>

--- a/src/pages/strategy/themes/dark.css
+++ b/src/pages/strategy/themes/dark.css
@@ -505,7 +505,7 @@ button, input, select, textarea {
 .tab_ships .filters .fold_button {
 	background:#cccccc;
 }
-.tab_ships .massSelect .hover {
+.tab_ships .hover {
 	color:#ffffff
 }
 .tab_ships .massSelect .hover.on {

--- a/src/pages/strategy/themes/legacy.css
+++ b/src/pages/strategy/themes/legacy.css
@@ -371,7 +371,7 @@ body {
 .tab_ships .filters .fold_button {
 	background:#333;
 }
-.tab_ships .massSelect .hover {
+.tab_ships .hover {
 	border-radius: 4px;
 	color:#00f;
 }


### PR DESCRIPTION
Adds button to export to [kancepts](https://javran.github.io/kancepts/) (#2196) and [kanmusu list
](http://kancolle-calc.net/kanmusu_list.html)

Export to kancepts exports all locked ships.
Export to kanmusu list exports all currently visible (filtered) ships.