### PR TITLE
Add Chuuha HP left to hp hover, always show taiha/chuuha HP in tooltip.

### DIFF
--- a/src/pages/devtools/themes/natsuiro/js/Shipbox.js
+++ b/src/pages/devtools/themes/natsuiro/js/Shipbox.js
@@ -213,11 +213,20 @@ KC3改 Ship Box for Natsuiro theme
 		
 		// Left HP to be Taiha
 		var taihaHp = Math.floor(0.25 * this.shipData.hp[1]);
-		if(this.shipData.hp[0] > taihaHp && this.shipData.hp[0] < this.shipData.hp[1]){
-			$(".ship_hp_cur", this.element)
-				.attr("title", KC3Meta.term("PanelTaihaHpLeft").format(taihaHp, this.shipData.hp[0] - taihaHp) )
-				.lazyInitTooltip();
-		}
+		var chuuhaHp = Math.floor(0.50 * this.shipData.hp[1]);
+
+		var hpTooltip = "";
+		if(this.shipData.hp[0] > taihaHp)
+			hpTooltip = KC3Meta.term("PanelTaihaHpLeft").format(taihaHp, this.shipData.hp[0] - taihaHp);
+		else
+			hpTooltip = KC3Meta.term("PanelTaihaHp").format(taihaHp);
+
+		if(this.shipData.hp[0] > chuuhaHp)
+			hpTooltip += "<br>" + KC3Meta.term("PanelChuuhaHpLeft").format(chuuhaHp, this.shipData.hp[0] - chuuhaHp);
+		else
+			hpTooltip += "<br>" + KC3Meta.term("PanelChuuhaHp").format(chuuhaHp);
+		$(".ship_hp_cur", this.element).attr("title", hpTooltip).lazyInitTooltip();
+		
 		
 		// Clear box colors
 		this.element.css("background-color", "transparent");


### PR DESCRIPTION
Adds how much HP left till chuuha in HP tooltip;
![non full hp example](https://user-images.githubusercontent.com/5676386/30775083-bb7230d0-a08d-11e7-911d-547230ded1aa.png)

Also, always show taiha/chuuha HP even when ship is already taiha/chuuha:
![taiha example](https://user-images.githubusercontent.com/5676386/30775081-b75d680c-a08d-11e7-9002-ad2ea32633f1.png)
![chuuha example](https://user-images.githubusercontent.com/5676386/30775082-b926ba9e-a08d-11e7-816d-86ea841d7703.png)

For terms.json:
```json
	"PanelTaihaHpLeft" : "Taiha HP = {0}, {1} left",
	"PanelTaihaHp" : "Taiha HP = {0}",
	"PanelChuuhaHpLeft" : "Chuuha HP = {0}, {1} left",
	"PanelChuuhaHp" : "Chuuha HP = {0}",
```
