### PR TITLE
Change FCM to fish counter during fish events + split mamiya & irako in tooltip.

### DIFF
--- a/src/pages/devtools/themes/natsuiro/natsuiro.html
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.html
@@ -236,7 +236,7 @@
 							</div>
 							<div class="consumable page3">
 								<div class="consumable_icon"><img src="../../../../assets/img/useitems/61.png" /></div>
-								<div class="consumable_ltext count_1classMedals">99</div>
+								<div class="consumable_ltext count_1classMedals_or_mackerel">99</div>
 								<div class="clear"></div>
 							</div>
 							<div class="consumable page3">

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -1069,8 +1069,9 @@
 					.lazyInitTooltip();
 			}
 			// More pages could be added, see `api_get_member/useitem` in Kcsapi.js
-			$(".count_1classMedals").text( PlayerManager.consumables.firstClassMedals || 0 )
-				.prev().attr("title", KC3Meta.useItemName(61) );
+			$(".count_1classMedals_or_mackerel").text( PlayerManager.consumables.mackerel || PlayerManager.consumables.firstClassMedals || 0 )
+				.prev().attr("title", KC3Meta.useItemName(PlayerManager.consumables.mackerel ? 68 : 61) )
+				.children("img").attr("src", "/assets/img/useitems/" + (PlayerManager.consumables.mackerel ? 68 : 61) + ".png");
 			$(".count_medals").text( PlayerManager.consumables.medals || 0 )
 				.prev().attr("title", KC3Meta.useItemName(57) );
 			$(".count_reinforcement").text( PlayerManager.consumables.reinforceExpansion || 0 )
@@ -1081,8 +1082,9 @@
 				.prev().attr("title", KC3Meta.useItemName(52) );
 			$(".count_morale").text( (PlayerManager.consumables.mamiya || 0)
 				+ (PlayerManager.consumables.irako || 0) )
-				.prev().attr("title", "{0} + {1}"
-					.format(KC3Meta.useItemName(54), KC3Meta.useItemName(59)) );
+				.prev().attr("title", "{0}x {1} + {2}x {3}"
+					.format(PlayerManager.consumables.mamiya || 0, KC3Meta.useItemName(54), 
+						PlayerManager.consumables.irako || 0, KC3Meta.useItemName(59)) );
 			$(".consumables .consumable").hide();
 			$(".consumables .consumable.page{0}".format(ConfigManager.hqInfoPage||1)).show();
 		},


### PR DESCRIPTION
When player has at least 1 mackerel: show mackerel counter
When player has 0 mackerel (eg, outside of events): show FCM counter

Also split up mamiya and irako counter in hover

![image](https://i.imgur.com/bOQvrBm.png)
