### PR TITLE
fix strategy room showing max modernization value of ship stats when …

### DIFF
--- a/src/pages/strategy/tabs/ships/ships.js
+++ b/src/pages/strategy/tabs/ships/ships.js
@@ -1100,7 +1100,7 @@
 		--------------------------------------------*/
 		modernizableStat :function(statAbbr, rowElm, valuesTuple, equipStatIndex = 1, isSup = false){
 			const statElm = $(".ship_" + statAbbr, rowElm);
-			$(".stat_value", statElm).text(valuesTuple[equipStatIndex > 0 ? (this.equipMode ? equipStatIndex : 0) : 0]);
+			$(".stat_value", statElm).text(valuesTuple[equipStatIndex > 0 ? (this.equipMode ? equipStatIndex + 1 : 1) : 0]);
 			if(isSup){
 				if(valuesTuple[0] >= valuesTuple[1]){
 					statElm.addClass("max");


### PR DESCRIPTION
…it should be showing the current stat

![image](https://user-images.githubusercontent.com/10118751/31059055-30725f38-a6cc-11e7-8490-38d64f987e21.png)
Here's an example of what it was like previously. For example, Zuikaku only has a FP value of 0, yet the game displays 39, the maximum stat.

ValuesTuple is stored like so:
`[maxmod value, current stat value, current stat + equips]`

Code used to be:
```javascript
$(".stat_value", statElm).text(valuesTuple[equipStatIndex > 0 ? (this.equipMode ? equipStatIndex : 0) : 0]);
```
which would return either index 0 or 1 (zero if no equips, 1 if show equips is selected). This resulted in displaying of maxmod value if equip stats was off:
![equip stats off](https://user-images.githubusercontent.com/10118751/31059100-030b92d4-a6cd-11e7-8cbe-0ea629f5a5e9.png)
and displaying of base value without equips if equip stats were on.
![equip stats on](https://user-images.githubusercontent.com/10118751/31059108-173d97de-a6cd-11e7-9faf-36d5cc7ac498.png)

The changes in the code aims to fix this by adding 1 to the index. I'm not sure if there's another underlying issue that was the root of this whole problem, but this seems to work:

![image](https://user-images.githubusercontent.com/10118751/31059123-4a1a262c-a6cd-11e7-964f-39eb196fca99.png)

![image](https://user-images.githubusercontent.com/10118751/31059128-5770916c-a6cd-11e7-96b3-b60a052b2d61.png)




