### PR TITLE
Add ability to time subtitles

### DIFF
--- a/src/library/injections/dmm_takeover.js
+++ b/src/library/injections/dmm_takeover.js
@@ -286,7 +286,7 @@
 		/* SUBTITLES OVERLAY
 		Displays subtitles on voice audio file requested
 		--------------------------------------*/
-		subtitleVanishTimer: null,
+		subtitleTimer: null,
 		subtitleVanishBaseMillis: null,
 		subtitleVanishExtraMillisPerChar: null,
 		subtitleHourlyTimer: null,
@@ -340,38 +340,66 @@
 					$(".overlay_subtitles").stop(true, true);
 					$(".overlay_subtitles").hide();
 					// If subtitle removal timer is ongoing, reset
-					if(self.subtitleVanishTimer){
-						clearTimeout(self.subtitleVanishTimer);
+					if(self.subtitleTimer){
+						if(self.subtitleTimer instanceof Array)
+							self.subtitleTimer.forEach(clearTimeout);
+						else
+							clearTimeout(self.subtitleTimer);
 					}
 				};
 				hideSubtitle();
 
 				// Display subtitle and set its removal timer
 				const showSubtitle = (subtitleText, quoteIdentifier) => {
+					if (typeof subtitleText === 'string' || subtitleText instanceof String)  {
+						showSubtitleLine(subtitleText, quoteIdentifier);
+						const millis = self.subtitleVanishBaseMillis +
+							(self.subtitleVanishExtraMillisPerChar * $(".overlay_subtitles").text().length);
+						self.subtitleTimer = setTimeout(phaseSubtitlesOut, millis);
+						return;
+					}
+
+					self.subtitleTimer = [];
+					var maxTime = 0;
+					$.each(subtitleText, function(delay, text) {
+						delay = Number(delay);
+						if(text === "") {
+							maxTime = delay;
+							return;
+						}
+						
+						self.subtitleTimer.push(setTimeout(() => {
+							showSubtitleLine(text, quoteIdentifier);
+						}, delay));
+						maxTime = delay + self.subtitleVanishBaseMillis + (self.subtitleVanishExtraMillisPerChar * text.length);
+					});
+					self.subtitleTimer.push(setTimeout(phaseSubtitlesOut, maxTime));
+				};
+
+				const phaseSubtitlesOut = () => {
+					self.subtitleTimer = false;
+					$(".overlay_subtitles").fadeOut(1000, function(){
+						switch (config.subtitle_display) {
+							case "evade":
+								$(".overlay_subtitles").css("top", "");
+								$(".overlay_subtitles").css("bottom", "5px");
+								self.subtitlePosition = "bottom";
+								break;
+							case "ghost":
+								$(".overlay_subtitles").removeClass("ghost");
+								break;
+							default: break;
+						}
+					});
+				};
+
+				const showSubtitleLine = (subtitleText, quoteIdentifier) => {
 					$(".overlay_subtitles span").html(subtitleText);
-					$(".overlay_subtitles").toggleClass("abyssal", quoteIdentifier === "abyssal");
-					$(".overlay_subtitles").show();
-					const millis = self.subtitleVanishBaseMillis +
-						(self.subtitleVanishExtraMillisPerChar * $(".overlay_subtitles").text().length);
-					self.subtitleVanishTimer = setTimeout(function(){
-						self.subtitleVanishTimer = false;
-						$(".overlay_subtitles").fadeOut(1000, function(){
-							switch (config.subtitle_display) {
-								case "evade":
-									$(".overlay_subtitles").css("top", "");
-									$(".overlay_subtitles").css("bottom", "5px");
-									self.subtitlePosition = "bottom";
-									break;
-								case "ghost":
-									$(".overlay_subtitles").removeClass("ghost");
-									break;
-								default: break;
-							}
-						});
-					}, millis);
 					if(!!quoteSpeaker){
 						$(".overlay_subtitles span").html("{0}: {1}".format(quoteSpeaker, subtitleText));
 					}
+					$(".overlay_subtitles").toggleClass("abyssal", quoteIdentifier === "abyssal");
+					$(".overlay_subtitles").show();
 				};
 
 				const cancelHourlyLine = () => {

--- a/src/library/injections/dmm_takeover.js
+++ b/src/library/injections/dmm_takeover.js
@@ -362,16 +362,15 @@
 					self.subtitleTimer = [];
 					var maxTime = 0;
 					$.each(subtitleText, function(delay, text) {
-						delay = Number(delay);
-						if(text === "") {
-							maxTime = delay;
-							return;
-						}
+						var delayms = Number(delay.split(",")[0]);
 						
 						self.subtitleTimer.push(setTimeout(() => {
 							showSubtitleLine(text, quoteIdentifier);
-						}, delay));
-						maxTime = delay + self.subtitleVanishBaseMillis + (self.subtitleVanishExtraMillisPerChar * text.length);
+						}, delayms));
+						maxTime = delayms + self.subtitleVanishBaseMillis + (self.subtitleVanishExtraMillisPerChar * text.length);
+
+						if(delay.split(",").length > 1)
+							maxTime = Number(delay.split(",")[1]);
 					});
 					self.subtitleTimer.push(setTimeout(phaseSubtitlesOut, maxTime));
 				};

--- a/src/library/modules/Translation.js
+++ b/src/library/modules/Translation.js
@@ -301,7 +301,7 @@
 					if (subId) {
 						// force overwriting regardless of original content
 						// empty content not replaced
-						if (v[subKey] && v[subKey].length) {
+						if (v[subKey]) {
 							v[subId] = v[subKey];
 
 							// temporary hack for scn quotes

--- a/src/library/modules/Translation.js
+++ b/src/library/modules/Translation.js
@@ -53,12 +53,12 @@
 		/*
 		  Recursively changing any non-object value "v" into "{val: v, tag: <tag>}".
 		 */
-		addTags: function(obj, tag) {
-			function track(obj) {
-				if (typeof obj === "object") {
+		addTags: function(obj, tag, maxdepth = 2) {
+			function track(obj, depth) {
+				if (typeof obj === "object" && depth) {
 					$.each( obj, function(k,v) {
 						// should work for both arrays and objects
-						obj[k] = track(v);
+						obj[k] = track(v, depth - 1);
 					});
 				} else {
 					return {val: obj, tag: tag};
@@ -69,7 +69,7 @@
 			console.assert(
 				typeof obj === "object",
 				"addTags should only be applied on objects");
-			return track(obj);
+			return track(obj, maxdepth);
 		},
 
 		/** Clear specified attribute key from specified JSON object. */

--- a/src/pages/game/api.js
+++ b/src/pages/game/api.js
@@ -7,7 +7,7 @@ var waiting = true;
 var trustedExit = false;
 
 // Used to fade out subtitles after calculated duration
-var subtitleVanishTimer = false;
+var subtitleTimer = false;
 var subtitleVanishBaseMillis;
 var subtitleVanishExtraMillisPerChar;
 var subtitleHourlyTimer = false;
@@ -628,39 +628,66 @@ var interactions = {
 			$(".overlay_subtitles").stop(true, true);
 			$(".overlay_subtitles").hide();
 			// If subtitle removal timer is ongoing, reset
-			if(subtitleVanishTimer){
-				clearTimeout(subtitleVanishTimer);
+			if(subtitleTimer){
+				if(subtitleTimer instanceof Array)
+					subtitleTimer.forEach(clearTimeout);
+				else
+					clearTimeout(subtitleTimer);
 			}
 		};
 		hideSubtitle();
 		
 		// Display subtitle and set its removal timer
 		const showSubtitle = (subtitleText, quoteIdentifier) => {
+			if (typeof subtitleText === 'string' || subtitleText instanceof String)  {
+				showSubtitleLine(subtitleText, quoteIdentifier);
+				const millis = subtitleVanishBaseMillis +
+					(subtitleVanishExtraMillisPerChar * $(".overlay_subtitles").text().length);
+				subtitleTimer = setTimeout(phaseSubtitlesOut, millis);
+				return;
+			}
+
+			subtitleTimer = [];
+			var maxTime = 0;
+			$.each(subtitleText, function(delay, text) {
+				delay = Number(delay);
+				if(text === "") {
+					maxTime = delay;
+					return;
+				}
+
+				subtitleTimer.push(setTimeout(() => {
+					showSubtitleLine(text, quoteIdentifier);
+				}, delay));
+				maxTime = delay + subtitleVanishBaseMillis + (subtitleVanishExtraMillisPerChar * text.length);
+			});
+			subtitleTimer.push(setTimeout(phaseSubtitlesOut, maxTime));
+		};
+
+		const phaseSubtitlesOut = () => {
+			subtitleTimer = false;
+			$(".overlay_subtitles").fadeOut(1000, function(){
+				switch (config.subtitle_display) {
+					case "evade":
+						$(".overlay_subtitles").css("top", "");
+						$(".overlay_subtitles").css("bottom", "5px");
+						subtitlePosition = "bottom";
+						break;
+					case "ghost":
+						$(".overlay_subtitles").removeClass("ghost");
+						break;
+					default: break;
+				}
+			});
+		};
+
+		const showSubtitleLine = (subtitleText, quoteIdentifier) => {
 			$(".overlay_subtitles span").html(subtitleText);
-			$(".overlay_subtitles").toggleClass("abyssal", quoteIdentifier === "abyssal");
-			$(".overlay_subtitles").show();
-			const millis = subtitleVanishBaseMillis +
-				(subtitleVanishExtraMillisPerChar * $(".overlay_subtitles").text().length);
-			//console.debug("vanish after", millis, "ms");
-			subtitleVanishTimer = setTimeout(function(){
-				subtitleVanishTimer = false;
-				$(".overlay_subtitles").fadeOut(1000, function(){
-					switch (ConfigManager.subtitle_display) {
-						case "evade":
-							$(".overlay_subtitles").css("top", "");
-							$(".overlay_subtitles").css("bottom", "5px");
-							subtitlePosition = "bottom";
-							break;
-						case "ghost":
-							$(".overlay_subtitles").removeClass("ghost");
-							break;
-						default: break;
-					}
-				});
-			}, millis);
 			if(!!quoteSpeaker){
 				$(".overlay_subtitles span").html("{0}: {1}".format(quoteSpeaker, subtitleText));
 			}
+			$(".overlay_subtitles").toggleClass("abyssal", quoteIdentifier === "abyssal");
+			$(".overlay_subtitles").show();
 		};
 		
 		const cancelHourlyLine = () => {

--- a/src/pages/game/api.js
+++ b/src/pages/game/api.js
@@ -650,16 +650,15 @@ var interactions = {
 			subtitleTimer = [];
 			var maxTime = 0;
 			$.each(subtitleText, function(delay, text) {
-				delay = Number(delay);
-				if(text === "") {
-					maxTime = delay;
-					return;
-				}
-
+				var delayms = Number(delay.split(",")[0]);
+				
 				subtitleTimer.push(setTimeout(() => {
 					showSubtitleLine(text, quoteIdentifier);
-				}, delay));
-				maxTime = delay + subtitleVanishBaseMillis + (subtitleVanishExtraMillisPerChar * text.length);
+				}, delayms));
+				maxTime = delayms + subtitleVanishBaseMillis + (subtitleVanishExtraMillisPerChar * text.length);
+
+				if(delay.split(",").length > 1)
+					maxTime = Number(delay.split(",")[1]);
 			});
 			subtitleTimer.push(setTimeout(phaseSubtitlesOut, maxTime));
 		};
@@ -667,7 +666,7 @@ var interactions = {
 		const phaseSubtitlesOut = () => {
 			subtitleTimer = false;
 			$(".overlay_subtitles").fadeOut(1000, function(){
-				switch (config.subtitle_display) {
+				switch (ConfigManager.subtitle_display) {
 					case "evade":
 						$(".overlay_subtitles").css("top", "");
 						$(".overlay_subtitles").css("bottom", "5px");

--- a/src/pages/game/dmm.js
+++ b/src/pages/game/dmm.js
@@ -636,16 +636,15 @@ var interactions = {
 			subtitleTimer = [];
 			var maxTime = 0;
 			$.each(subtitleText, function(delay, text) {
-				delay = Number(delay);
-				if(text === "") {
-					maxTime = delay;
-					return;
-				}
-
+				var delayms = Number(delay.split(",")[0]);
+				
 				subtitleTimer.push(setTimeout(() => {
 					showSubtitleLine(text, quoteIdentifier);
-				}, delay));
-				maxTime = delay + subtitleVanishBaseMillis + (subtitleVanishExtraMillisPerChar * text.length);
+				}, delayms));
+				maxTime = delayms + subtitleVanishBaseMillis + (subtitleVanishExtraMillisPerChar * text.length);
+
+				if(delay.split(",").length > 1)
+					maxTime = Number(delay.split(",")[1]);
 			});
 			subtitleTimer.push(setTimeout(phaseSubtitlesOut, maxTime));
 		};
@@ -653,7 +652,7 @@ var interactions = {
 		const phaseSubtitlesOut = () => {
 			subtitleTimer = false;
 			$(".overlay_subtitles").fadeOut(1000, function(){
-				switch (config.subtitle_display) {
+				switch (ConfigManager.subtitle_display) {
 					case "evade":
 						$(".overlay_subtitles").css("top", "");
 						$(".overlay_subtitles").css("bottom", "5px");

--- a/src/pages/strategy/tabs/mstship/mstship.js
+++ b/src/pages/strategy/tabs/mstship/mstship.js
@@ -146,10 +146,19 @@
 					var shipGirl = KC3Master.graph_file(self.currentGraph);
 					var voiceLine = KC3Meta.getVoiceLineByFilename(shipGirl, voiceFile);
 					var quote = KC3Meta.quote( shipGirl, voiceLine, voiceSize );
+
 					console.debug("Playing subtitle: shipId, vnum, voiceLine, voiceFile, voiceSize:",
 						shipGirl, vnum, voiceLine, voiceFile, voiceSize);
 					if(quote){
-						$(".tab_mstship .shipInfo .subtitles").html(quote);
+						var quoteText = quote;
+						if (!(typeof quote === 'string' || quote instanceof String)) {
+							quoteText = "";
+							$.each(quote, function (delay, line) {
+								if(line !== "")
+									quoteText += line + "</br>";
+							});
+						}
+						$(".tab_mstship .shipInfo .subtitles").html(quoteText);
 					} else {
 						$(".tab_mstship .shipInfo .subtitles").html(
 							"Quote not found yet for: ship={0}, vnum={1}, vline={2}"

--- a/src/pages/strategy/tabs/mstship/mstship.js
+++ b/src/pages/strategy/tabs/mstship/mstship.js
@@ -154,8 +154,7 @@
 						if (!(typeof quote === 'string' || quote instanceof String)) {
 							quoteText = "";
 							$.each(quote, function (delay, line) {
-								if(line !== "")
-									quoteText += line + "</br>";
+								quoteText += line + "</br>";
 							});
 						}
 						$(".tab_mstship .shipInfo .subtitles").html(quoteText);

--- a/src/pages/strategy/tabs/quotes/quotes.js
+++ b/src/pages/strategy/tabs/quotes/quotes.js
@@ -117,8 +117,19 @@
 					$(".source",elm).addClass("hover").data("sid", src.tag);
 					$(".source",elm).click(toFromFunc);
 				}
-				$(".subtitle",elm).text( (state === "missing") ? "missing"
-										 :src.val );
+				var subtitle = "";
+				if(state === "missing")
+					subtitle = "missing";
+				else if (!(typeof src.val === 'string' || src.val instanceof String)) {
+					var subtitles = [];
+					$.each(src.val, function (delay, line) {
+						subtitles.push(line);
+					});
+					subtitle = subtitles.join("</br>");
+				} else
+					subtitle = src.val;
+
+				$(".subtitle",elm).html(subtitle);
 				$(".division",elm).click(toggleSrcFunc);
 				if(self.enQuotes && self.enQuotes[masterId] && self.enQuotes[masterId][voiceNum]){
 					$(".en_src",elm).text(self.enQuotes[masterId][voiceNum]);


### PR DESCRIPTION
Allows per line timing of subs. Also allows custom fadeout times for slow lines.
Example for Yamagumo:
```json
        "Poke(2)": {"0,2300": "You can't do that~ That's delicate~ The depth charges, they're sensitive~"},
```

Example for quotes.json with one of the new quests; https://www.youtube.com/watch?v=VU8S80Bghqs
```json
        "1187": {
            "0":"Michishio: \"Why did they assign me to this fleet...?\"",
            "3530": "Shigure: \"Oh, Michishio. Nice to see you.\"",
            "7500": "Michishio: \"Shigure?! What are you doing here? Don't tell me we're in the same unit!\"",
            "15720": "Shigure: \"Looks like it... Force C of the First Striking Force...\"",
            "22900": "Michishio: \"What's wrong, Shigure? You don't look so good. Maybe you should lie down for a bit.\"",
            "30540": "Shigure: \"It's okay, I'm fine. It's because of the rain... I guess. Anyway, let's go.\""
        },
```


