### PR TITLE
Routing database submission

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -28,6 +28,7 @@
 		"KC3Meta": true,
 		"KC3Network": true,
 		"OpenDBSubmission": true,
+		"TsunDBSubmission": true,
 		"KC3Panel": true,
 		"PictureBook": true,
 		"PoiDBSubmission": true,

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -841,12 +841,12 @@
 		]
 	},
 	{
-		"section": "SettingsKC3DBSubmission",
+		"section": "SettingsTsunDBSubmission",
 		"help" : "",
 		"contents" :[
 			{
-				"id" : "KC3DBSubmission_enabled",
-				"name" : "SettingsEnableKC3DBSubmission",
+				"id" : "TsunDBSubmission_enabled",
+				"name" : "SettingsEnableTsunDBSubmission",
 				"type" : "check",
 				"options" : {}
 			}

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -46,8 +46,9 @@ Retrieves when needed to apply on components
 				DBSubmission_enabled : 0,
 				DBSubmission_key     : '',
 				PoiDBSubmission_enabled : false,
-				KC3DBSubmission_enabled : true,
+				KC3DBSubmission_enabled : false,
 				OpenDBSubmission_enabled : false,
+				TsunDBSubmission_enabled : false,
 				PushAlerts_enabled   : 0,
 				PushAlerts_key       : '',
 

--- a/src/library/modules/Network.js
+++ b/src/library/modules/Network.js
@@ -135,6 +135,10 @@ Listens to network history and triggers callback if game events happen
 							if (ConfigManager.OpenDBSubmission_enabled) {
 								KC3Network.asyncSubmit(OpenDBSubmission, thisRequest);
 							}
+							// -- TsunDB Submission
+							if (ConfigManager.TsunDBSubmission_enabled) {
+								KC3Network.asyncSubmit(TsunDBSubmission, thisRequest);
+							}
 							
 							thisRequest.process();
 							

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -1,0 +1,173 @@
+/**
+ * TsunDBSubmission.js
+ *
+ * KC3Kai routing data submission module.
+ */
+(function(){
+	"use strict";
+	
+	window.TsunDBSubmission = {
+		data : {
+			edgeID: [],
+			bossEdge: [],
+			fleetSent: 1
+		},
+		handlers : {},
+		mapInfo : [],
+		
+		init: function () {
+			this.handlers = {
+				/* More detailed info regarding a map.
+					response.api_data:
+					api_map_info : Array of all the maps as objects
+						api_id: Map ID
+						api_cleared : Map is cleared.
+						api_eventmap : If this is an event map...
+							api_now_maphp : Current HP of the map.
+							api_max_maphp : Max HP of the map.
+							api_selected_rank : Difficulty set. 0=Not set, 1=丙, 2=乙, 3=甲
+							api_gauge_type : 2 = HP gauge, 3 = TP gauge
+				*/
+				'api_get_member/mapinfo': this.processMapInfo,
+				
+				/* Triggered when you start a sortie.
+					response.api_data:
+					api_no : Edge ID
+				*/
+				'api_req_map/start': this.processStart,
+				'api_req_map/next': this.processNext
+			};
+		},
+		
+		processMapInfo: function(http) {
+			this.mapInfo = http.response.api_data.api_map_info;
+		},
+		
+		processStart: function(http) {
+			const apiData = http.response.api_data;
+			this.data.edgeID = [];
+			this.data.bossEdge = [apiData.api_bosscell_no];
+			// NOTE: because this is pre-process, when `api_req_map/start` called,
+			// `KC3SortieManager.startSortie` is not executed yet
+			this.data.fleetSent = Number(http.params.api_deck_id);
+			this.processNext(http);
+		},
+		
+		processNext: function(http) {
+			this.clean();
+			const apiData = http.response.api_data;
+			const world = Number(apiData.api_maparea_id);
+			const map = Number(apiData.api_mapinfo_no);
+			const mapId = [world, map].join('');
+			const mapData = this.mapInfo.find(i => i.api_id == mapId) || {};
+			const mapStorage = KC3SortieManager.getCurrentMapData(world, map);
+			
+			if(mapData.api_eventmap) {
+				this.data.currentMapHP = mapData.api_eventmap.api_now_maphp;
+				this.data.maxMapHP = mapData.api_eventmap.api_max_maphp;
+				this.data.difficulty = mapData.api_eventmap.api_selected_rank;
+				this.data.gaugeType = mapData.api_eventmap.api_gauge_type;
+			}
+			
+			this.data.map = [world, map].join('-');
+			this.data.debuffSound = mapStorage.debuffSound;
+			this.data.cleared = mapData.api_cleared;
+			this.data.hqLvl = PlayerManager.hq.level;
+			this.data.fleetType = PlayerManager.combinedFleet;
+			
+			this.data.edgeID.push(apiData.api_no);
+			this.data.bossEdge.push(apiData.api_bosscell_no);
+			this.data.nodeType = apiData.api_color_no;
+			this.data.eventId = apiData.api_event_id;
+			this.data.eventKind = apiData.api_event_kind;
+			this.data.nextRoute = apiData.api_next;
+			
+			this.data.fleet1 = this.handleFleet(PlayerManager.fleets[this.data.fleetSent - 1]);
+			if(this.data.fleetType > 0) {
+				this.data.fleet2 = this.handleFleet(PlayerManager.fleets[1]);
+			}
+			
+			this.sendData(this.data);
+		},
+		
+		handleFleet: function(fleet) {
+			// Update fleet minimal speed
+			fleet.speed();
+			// Slow fleet wins over fast
+			this.data.fleetSpeed = Math.min(this.data.fleetSpeed, fleet.minSpeed);
+			// F33 Cn 1,2,3 & 4
+			[1,2,3,4].forEach(i => { this.data.los[i - 1] += fleet.eLoS4(i); });
+			return fleet.ship().map(ship => (ship.isDummy() || ship.didFlee || ship.hp[0] <= 0) ? -1 : {
+				id: ship.masterId,
+				type: ship.stype(),
+				speed: ship.speed,
+				equip: ship.equipement(false).map(gear => gear.masterId || -1),
+				exslot: ship.exItem().masterId || -1
+			});
+		},
+		
+		/**
+		 * Cleans up the data after each submission for each node.
+		 */
+		clean: function() {
+			// states of fleets might be changed every nodes
+			this.data.los = [0, 0, 0, 0];
+			this.data.fleet1 = [];
+			this.data.fleet2 = [];
+			this.data.fleetSpeed = 20;
+			// optional properties for event only
+			this.data.currentMapHP = 0;
+			this.data.maxMapHP = 0;
+			this.data.difficulty = 0;
+			this.data.gaugeType = 0;
+		},
+		
+		processData: function(requestObj) {
+			try {
+				// get data handler based on URL given
+				// `null` is returned if no handler is found
+				var handler = this.handlers[requestObj.call];
+				if (handler) {
+					handler.call(this, requestObj);
+				}
+			} catch (e) {
+				console.warn("TsunDB submission error", e);
+				// Its not Mongo, but Mango =D
+				var reportParams = $.extend({}, requestObj.params);
+				delete reportParams.api_token;
+				KC3Network.trigger("APIError", {
+					title: KC3Meta.term("APIErrorNoticeTitle"),
+					message: KC3Meta.term("APIErrorNoticeMessage").format("TsunDBSubmission"),
+					stack: e.stack || String(e),
+					request: {
+						url: requestObj.url,
+						headers: requestObj.headers,
+						statusCode: requestObj.statusCode
+					},
+					params: reportParams,
+					response: requestObj.response,
+					serverUtc: Date.safeToUtcTime(requestObj.headers.Date)
+				});
+			}
+		},
+		
+		sendData: function(payload) {
+			var server = "http://kckai.cybersnets.com";
+			var url = server;
+			// console.debug( JSON.stringify( payload ) );
+			$.ajax({
+				url: url,
+				method: "POST",
+				data: {
+					'data': JSON.stringify( payload )
+				},
+			}).done( function() {
+				console.log("Tsun DB Submission done.");
+			}).fail( function(jqXHR, textStatus, errorThrown) {
+				console.warn("Tsun DB Submission " + textStatus, errorThrown);
+			});
+			return;
+		}
+	};
+	window.TsunDBSubmission.init();
+})();

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -8,9 +8,25 @@
 	
 	window.TsunDBSubmission = {
 		data : {
+			map: null,
+			cleared: null,
+			hqLvl: null,
+			fleetType: 0,
 			edgeID: [],
 			bossEdge: [],
-			fleetSent: 1
+			nodeType: null,
+			eventId: null,
+			eventKind: null,
+			nextRoute: null,
+			fleetSent: 1,
+			fleetSpeed: null,
+			fleet1: [],
+			fleet2: [],
+			los: [],
+			currentMapHP: null,
+			maxMapHP: null,
+			difficulty: null,
+			gaugeType: null
 		},
 		handlers : {},
 		mapInfo : [],
@@ -98,8 +114,8 @@
 			// F33 Cn 1,2,3 & 4
 			[1,2,3,4].forEach(i => { this.data.los[i - 1] += fleet.eLoS4(i); });
 			return fleet.ship().map(ship => (ship.isDummy() || ship.didFlee || ship.hp[0] <= 0) ? -1 : {
-				id: ship.masterId,
-				type: ship.stype(),
+				name: ship.master().api_name,
+				type: ship.master().api_stype,
 				speed: ship.speed,
 				equip: ship.equipement(false).map(gear => gear.masterId || -1),
 				exslot: ship.exItem().masterId || -1

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -9,6 +9,7 @@
 	window.TsunDBSubmission = {
 		data : {
 			map: null,
+			mapNodes: [],
 			cleared: null,
 			hqLvl: null,
 			fleetType: 0,
@@ -61,6 +62,7 @@
 		
 		processStart: function(http) {
 			const apiData = http.response.api_data;
+			this.data.mapNodes = apiData.api_cell_data;
 			this.data.edgeID = [];
 			this.data.bossEdge = [apiData.api_bosscell_no];
 			// NOTE: because this is pre-process, when `api_req_map/start` called,

--- a/src/library/objects/Fleet.js
+++ b/src/library/objects/Fleet.js
@@ -8,7 +8,8 @@ Contains summary information about a fleet and its 6 ships
 	
 	window.KC3Fleet = function( data ){
 		this.active = false;
-		this.fastFleet = true;
+		this.fastFleet = false;
+		this.minSpeed = 5;
 		this.fleetId = 0;
 		this.name = "";
 		this.ships = [ -1, -1, -1, -1, -1, -1 ];
@@ -619,15 +620,9 @@ Contains summary information about a fleet and its 6 ships
 	};
 	
 	KC3Fleet.prototype.speed = function(){
-		this.fastFleet = true;
-		var i = 0;
-		while(this.fastFleet && i < 6) {
-			if(this.ships[i] > -1) {
-				this.fastFleet = this.fastFleet && this.ship(i).isFast();
-			}
-			i++;
-		}
-		return (this.fastFleet) ? KC3Meta.term("SpeedFast") : KC3Meta.term("SpeedSlow");
+		this.minSpeed = Math.min(...this.shipsUnescaped().map(ship => ship.getSpeed()));
+		this.fastFleet = this.minSpeed >= 10;
+		return KC3Meta.shipSpeed(this.minSpeed);
 	};
 
 	KC3Fleet.prototype.adjustedAntiAir = function(formationId){

--- a/src/library/objects/Ship.js
+++ b/src/library/objects/Ship.js
@@ -188,6 +188,7 @@ KC3改 Ship Object
 		}
 	};
 	KC3Ship.prototype.isFast = function(){ return (this.speed || this.master().api_soku) >= 10; };
+	KC3Ship.prototype.getSpeed = function(){ return this.speed || this.master().api_soku; };
 	KC3Ship.prototype.exItem = function(){ return this.getGearManager().get(this.ex_item); };
 	KC3Ship.prototype.isStriped = function(){ return (this.hp[1]>0) && (this.hp[0]/this.hp[1] <= 0.5); };
 	KC3Ship.prototype.isTaiha   = function(){ return (this.hp[1]>0) && (this.hp[0]/this.hp[1] <= 0.25) && !this.isRepairing(); };

--- a/src/pages/devtools/themes/natsuiro/natsuiro.html
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.html
@@ -1298,6 +1298,7 @@
 		<script type="text/javascript" src="../../../../library/modules/PoiDBSubmission.js"></script>
 		<script type="text/javascript" src="../../../../library/modules/KC3DBSubmission.js"></script>
 		<script type="text/javascript" src="../../../../library/modules/OpenDBSubmission.js"></script>
+		<script type="text/javascript" src="../../../../library/modules/TsunDBSubmission.js"></script>
 
 		<script type="text/javascript" src="../../../../library/modules/ChromeSync.js"></script>
 		<script type="text/javascript" src="../../../../library/modules/BattlePrediction.js"></script>

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -1394,8 +1394,7 @@
 						MainFleet, EscortFleet,
 						AntiAir.getFormationModifiers(ConfigManager.aaFormation))),
 					speed:
-						(MainFleet.fastFleet && EscortFleet.fastFleet)
-						? KC3Meta.term("SpeedFast") : KC3Meta.term("SpeedSlow"),
+						KC3Meta.shipSpeed(Math.min(MainFleet.minSpeed, EscortFleet.minSpeed)),
 					docking:
 						Math.max(MainRepairs.docking,EscortRepairs.docking),
 					akashi:

--- a/src/pages/devtools/themes/plain/plain.html
+++ b/src/pages/devtools/themes/plain/plain.html
@@ -415,6 +415,7 @@
 		<script type="text/javascript" src="../../../../library/modules/PoiDBSubmission.js"></script>
 		<script type="text/javascript" src="../../../../library/modules/KC3DBSubmission.js"></script>
 		<script type="text/javascript" src="../../../../library/modules/OpenDBSubmission.js"></script>
+		<script type="text/javascript" src="../../../../library/modules/TsunDBSubmission.js"></script>
 
 		<script type="text/javascript" src="../../../../library/modules/ChromeSync.js"></script>
 		<script type="text/javascript" src="../../../../library/modules/BattlePrediction.js"></script>

--- a/src/pages/devtools/themes/plain/plain.js
+++ b/src/pages/devtools/themes/plain/plain.js
@@ -803,8 +803,7 @@
 					elos: Math.qckInt("floor", MainFleet.eLoS()+EscortFleet.eLoS(), 1),
 					air: MainFleet.fighterPowerText(),
 					speed:
-						(MainFleet.fastFleet && EscortFleet.fastFleet)
-						? KC3Meta.term("SpeedFast") : KC3Meta.term("SpeedSlow"),
+						KC3Meta.shipSpeed(Math.min(MainFleet.minSpeed, EscortFleet.minSpeed)),
 					docking:
 						Math.max(MainRepairs.docking,EscortRepairs.docking),
 					akashi:


### PR DESCRIPTION
* Including PRs:
  * https://github.com/Tsubakura/KC3Kai/pull/1
  * https://github.com/Tsubakura/KC3Kai/pull/2
* Replace n/a KC3 data submission setting with new one

To answer sin_sin's questions:

- Preferably, I dont want to use stype() at all, I just need to know the ship type id.
- Wouldnt it take more time to send everything? Is it also necessary? The data already includes anything that is sortie related, excluding LBAS setups.

I prefer that those properties in data are added back in during the initialization, it serves as a summary as to what data is sent over to the server.