### PR TITLE
Fix error thrown by PvP matches

### DIFF
--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -461,7 +461,7 @@ Used by SortieManager
 				}
 			})();
 			const enemy = isEnemyCombined ? KC3BattlePrediction.Enemy.COMBINED : KC3BattlePrediction.Enemy.SINGLE;
-			const time = battleData.api_name.indexOf('night_to_day') !== -1
+			const time = battleData.api_name && battleData.api_name.indexOf('night_to_day') !== -1
 				? KC3BattlePrediction.Time.NIGHT_TO_DAY
 				: KC3BattlePrediction.Time.DAY;
 


### PR DESCRIPTION
Note: night-to-day battle prediction depends on custom prop `api_name` being set, so it may not function depending on how `Node.engage()` is called.