### PR TITLE
Improve night-to-day node support

### DIFF
--- a/src/library/modules/BattlePrediction.js
+++ b/src/library/modules/BattlePrediction.js
@@ -270,7 +270,7 @@
 
     switch (role) {
       case Role.MAIN_FLEET:
-        return damecons.slice(0, 6);
+        return damecons;
       case Role.ESCORT_FLEET:
         return damecons.slice(6, 12);
       default:
@@ -599,14 +599,19 @@
       const { create } = KC3BattlePrediction.battle.engagement.parserFactory;
 
       return {
-        kouku: create('kouku', parseKouku),
-        openingTaisen: create('openingTaisen', bind(parseHougeki, battleType)),
-        openingAtack: create('openingAtack', bind(parseRaigeki, battleType)),
-        support: create('support', parseCombinedSupport),
         nSupport: create('nSupport', parseCombinedSupport),
         nHougeki1: create('nHougeki1', bind(parseHougeki, battleType)),
         nHougeki2: create('nHougeki2', bind(parseHougeki, battleType)),
+        airBaseInjection: create('airBaseInjection', parseKouku),
+        injectionKouku: create('injectionKouku', parseKouku),
+        airBaseAttack: create('airBaseAttack', parseKouku),
+        kouku: create('kouku', parseKouku),
+        support: create('support', parseCombinedSupport),
+        openingTaisen: create('openingTaisen', bind(parseHougeki, battleType)),
+        openingAtack: create('openingAtack', bind(parseRaigeki, battleType)),
         hougeki1: create('hougeki1', bind(parseHougeki, battleType)),
+        hougeki2: create('hougeki2', bind(parseHougeki, battleType)),
+        raigeki: create('raigeki', bind(parseRaigeki, battleType)),
       };
     },
     [toKey(Player.SINGLE, Enemy.SINGLE, Time.NIGHT_TO_DAY)](battleType) {
@@ -620,69 +625,98 @@
       const { create } = KC3BattlePrediction.battle.engagement.parserFactory;
 
       return {
-        kouku: create('kouku', parseKouku),
-        openingTaisen: create('openingTaisen', bind(parseHougeki, battleType)),
-        openingAtack: create('openingAtack', bind(parseRaigeki, battleType)),
-        support: create('support', parseSupport),
         nSupport: create('nSupport', parseSupport),
         nHougeki1: create('nHougeki1', bind(parseHougeki, battleType)),
         nHougeki2: create('nHougeki2', bind(parseHougeki, battleType)),
+        airBaseInjection: create('airBaseInjection', parseKouku),
+        injectionKouku: create('injectionKouku', parseKouku),
+        airBaseAttack: create('airBaseAttack', parseKouku),
+        kouku: create('kouku', parseKouku),
+        support: create('support', parseSupport),
+        openingTaisen: create('openingTaisen', bind(parseHougeki, battleType)),
+        openingAtack: create('openingAtack', bind(parseRaigeki, battleType)),
         hougeki1: create('hougeki1', bind(parseHougeki, battleType)),
+        hougeki2: create('hougeki2', bind(parseHougeki, battleType)),
+        raigeki: create('raigeki', bind(parseRaigeki, battleType)),
       };
     },
 
     /* -------------------[ NIGHT BATTLE ]------------------- */
     [toKey(Player.SINGLE, Enemy.SINGLE, Time.NIGHT)](battleType) {
       const { bind } = KC3BattlePrediction;
-      const { parseYasen } = KC3BattlePrediction.battle.phases.yasen;
+      const {
+        support: { parseSupport },
+        yasen: { parseYasen },
+      } = KC3BattlePrediction.battle.phases;
       const { create } = KC3BattlePrediction.battle.engagement.parserFactory;
 
       return {
+        nSupport: create('nSupport', parseSupport),
         hougeki: create('midnight', bind(parseYasen, battleType)),
       };
     },
     [toKey(Player.CTF, Enemy.SINGLE, Time.NIGHT)](battleType) {
       const { bind } = KC3BattlePrediction;
-      const { parseYasen } = KC3BattlePrediction.battle.phases.yasen;
+      const {
+        support: { parseSupport },
+        yasen: { parseYasen },
+      } = KC3BattlePrediction.battle.phases;
       const { create } = KC3BattlePrediction.battle.engagement.parserFactory;
 
       return {
+        nSupport: create('nSupport', parseSupport),
         hougeki: create('midnight', bind(parseYasen, battleType)),
       };
     },
     [toKey(Player.STF, Enemy.SINGLE, Time.NIGHT)](battleType) {
       const { bind } = KC3BattlePrediction;
-      const { parseYasen } = KC3BattlePrediction.battle.phases.yasen;
+      const {
+        support: { parseSupport },
+        yasen: { parseYasen },
+      } = KC3BattlePrediction.battle.phases;
       const { create } = KC3BattlePrediction.battle.engagement.parserFactory;
 
       return {
+        nSupport: create('nSupport', parseSupport),
         hougeki: create('midnight', bind(parseYasen, battleType)),
       };
     },
     [toKey(Player.SINGLE, Enemy.COMBINED, Time.NIGHT)](battleType) {
       const { bind } = KC3BattlePrediction;
-      const { parseYasen } = KC3BattlePrediction.battle.phases.yasen;
+      const {
+        support: { parseCombinedSupport },
+        yasen: { parseYasen },
+      } = KC3BattlePrediction.battle.phases;
       const { create } = KC3BattlePrediction.battle.engagement.parserFactory;
 
       return {
+        nSupport: create('nSupport', parseCombinedSupport),
         hougeki: create('midnight', bind(parseYasen, battleType)),
       };
     },
     [toKey(Player.CTF, Enemy.COMBINED, Time.NIGHT)](battleType) {
       const { bind } = KC3BattlePrediction;
-      const { parseYasen } = KC3BattlePrediction.battle.phases.yasen;
+      const {
+        support: { parseCombinedSupport },
+        yasen: { parseYasen },
+      } = KC3BattlePrediction.battle.phases;
       const { create } = KC3BattlePrediction.battle.engagement.parserFactory;
 
       return {
+        nSupport: create('nSupport', parseCombinedSupport),
         hougeki: create('midnight', bind(parseYasen, battleType)),
       };
     },
     [toKey(Player.STF, Enemy.COMBINED, Time.NIGHT)](battleType) {
       const { bind } = KC3BattlePrediction;
-      const { parseYasen } = KC3BattlePrediction.battle.phases.yasen;
+      const {
+        support: { parseCombinedSupport },
+        yasen: { parseYasen },
+      } = KC3BattlePrediction.battle.phases;
       const { create } = KC3BattlePrediction.battle.engagement.parserFactory;
 
       return {
+        nSupport: create('nSupport', parseCombinedSupport),
         hougeki: create('midnight', bind(parseYasen, battleType)),
       };
     },

--- a/src/library/modules/BattlePrediction/Fleets.js
+++ b/src/library/modules/BattlePrediction/Fleets.js
@@ -89,7 +89,7 @@
 
     switch (role) {
       case Role.MAIN_FLEET:
-        return damecons.slice(0, 6);
+        return damecons;
       case Role.ESCORT_FLEET:
         return damecons.slice(6, 12);
       default:

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -345,14 +345,14 @@ Used by SortieManager
 		
 		// Air phases
 		var
-			planePhase  = battleData.api_kouku.api_stage1 || {
+			planePhase  = battleData.api_kouku && battleData.api_kouku.api_stage1 || {
 				api_touch_plane:[-1,-1],
 				api_f_count    :0,
 				api_f_lostcount:0,
 				api_e_count    :0,
 				api_e_lostcount:0,
 			},
-			attackPhase = battleData.api_kouku.api_stage2;
+			attackPhase = battleData.api_kouku ? battleData.api_kouku.api_stage2 : null;
 		this.fcontactId = planePhase.api_touch_plane[0];
 		this.fcontact = this.fcontactId > 0 ? KC3Meta.term("BattleContactYes") : KC3Meta.term("BattleContactNo");
 		this.econtactId = planePhase.api_touch_plane[1];

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -21,7 +21,7 @@ Used by SortieManager
 	};
 
 	function isNightToDayNode(battleData) {
-		return !!battleData.api_day_flag;
+		return typeof battleData.api_day_flag !== 'undefined';
 	}
 	
 	// set true to test HP, rank and MVP predicting easier via SRoom Maps History

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -1456,10 +1456,13 @@ Used by SortieManager
 	};
 	
 	KC3Node.prototype.isBoss = function(){
-		// Normal BOSS node starts from day battle
-		return (this.eventKind === 1 && this.eventId === 5)
-		// Combined BOSS node, see advanceNode()@SortieManager.js
-			|| (this.eventKind === 5 && this.eventId === 5);
+		// see advanceNode() (SortieManager.js) for api details
+		return (
+			// boss battle
+			this.eventId === 5 &&
+			// enemy single || enemy combined || night-to-day
+			(this.eventKind === 1 || this.eventKind === 5 || this.eventKind === 7)
+		);
 	};
 	
 	KC3Node.prototype.isMvpPredictionCapable = function(){

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -19,6 +19,10 @@ Used by SortieManager
 			map || KC3SortieManager.map_num, this.id);
 		this.nodeData = raw || {};
 	};
+
+	function isNightToDayNode(battleData) {
+		return !!battleData.api_day_flag;
+	}
 	
 	// set true to test HP, rank and MVP predicting easier via SRoom Maps History
 	KC3Node.debugPrediction = function() { return false; };
@@ -461,7 +465,7 @@ Used by SortieManager
 				}
 			})();
 			const enemy = isEnemyCombined ? KC3BattlePrediction.Enemy.COMBINED : KC3BattlePrediction.Enemy.SINGLE;
-			const time = battleData.api_name && battleData.api_name.indexOf('night_to_day') !== -1
+			const time = isNightToDayNode(battleData)
 				? KC3BattlePrediction.Time.NIGHT_TO_DAY
 				: KC3BattlePrediction.Time.DAY;
 

--- a/tests/library/modules/BattlePrediction/Fleets.js
+++ b/tests/library/modules/BattlePrediction/Fleets.js
@@ -132,7 +132,7 @@ QUnit.module('modules > BattlePrediction > Fleets', function () {
 
       const result = this.subject(Role.MAIN_FLEET, damecons);
 
-      assert.deepEqual(result, [1, 2, 3, 4, 5, 6]);
+      assert.deepEqual(result, damecons);
     });
 
     QUnit.test('escort fleet', function (assert) {


### PR DESCRIPTION
- [x] Use `api_day_flag` instead of `api_name` to detect night-to-day node
- [ ] Fix error when no day phase (needs testing)
- [x] Confirm whether battle prediction is accounting for all phases.
- [x] Fix damecon not detected for last slot of 7 ship fleet.