### PR TITLE
Fix LBAS indicator visble on NB nodes

### DIFF
--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -635,6 +635,10 @@ Used by SortieManager
 		this.eformation = (nightData.api_formation || [])[1] || this.eformation;
 		this.eKyouka = nightData.api_eKyouka || [-1,-1,-1,-1,-1,-1];
 
+		if (this.startsFromNight) {
+			this.lbasFlag = false;
+		}
+
 		if (nightData.api_n_support_flag > 0) {
 			this.nightSupportFlag = true;
 			this.nightSupportInfo = nightData.api_n_support_info;


### PR DESCRIPTION
LBAS indicator was incorrectly visible on night-battle nodes; both in the Strategy Room and on the devtools panel

Fixes: #2364