### PR TITLE
Fix LBAS raid damage calculation

### DIFF
--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -1474,9 +1474,9 @@ Used by SortieManager
 			this.planeBombers.abyssal[0] = attackPhase.api_e_count;
 			this.planeBombers.abyssal[1] = attackPhase.api_e_lostcount;
 		}
-		this.baseDamage = bomberPhase && bomberPhase.api_fdam ? Math.floor(
-			bomberPhase.api_fdam.slice(1).reduce(function(a,b){return a+b;},0)
-		) : 0;
+		this.baseDamage = bomberPhase && bomberPhase.api_fdam
+			? sumSupportDamageArray(bomberPhase.api_fdam)
+			: 0;
 	};
 	
 	KC3Node.prototype.isBoss = function(){

--- a/src/pages/strategy/sortielogs.js
+++ b/src/pages/strategy/sortielogs.js
@@ -489,13 +489,17 @@
 				KC3StrategyTabs.gotoTab("fleet", "history", $(this).data("id"));
 			};
 			var parseAirRaidFunc = function(airRaid){
+				const damageArray =
+				  airRaid &&
+				  airRaid.api_air_base_attack &&
+				  airRaid.api_air_base_attack.api_stage3 &&
+				  airRaid.api_air_base_attack.api_stage3.api_fdam || [];
 				return {
 					airRaidLostKind: (airRaid || {}).api_lost_kind || 0,
-					baseTotalDamage: airRaid && airRaid.api_air_base_attack
-						&& airRaid.api_air_base_attack.api_stage3
-						&& airRaid.api_air_base_attack.api_stage3.api_fdam ?
-						Math.floor(airRaid.api_air_base_attack.api_stage3.api_fdam.slice(1)
-							.reduce((a, b) => a + b, 0)) : 0
+					baseTotalDamage: damageArray.reduce(
+							(sum, n) => sum + Math.max(0, Math.floor(n)),
+							0
+						),
 				};
 			};
 			$.each(sortieList, function(id, sortie){


### PR DESCRIPTION
Shift to 0-based arrays in the kcsapi meant that damage to the first
land base was being ignored.