### PR TITLE
Release 32.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "KC3Kai",
-  "version": "32.3.0",
+  "version": "32.3.1",
   "description": "Kantai Collection Game Viewer and Tools",
   "repository": {
     "type": "git",

--- a/src/data/developers.json
+++ b/src/data/developers.json
@@ -101,7 +101,7 @@
 				}
 			},
 			{
-				"name": "Simona",
+				"name": "FOG_Yamato",
 				"avatar" : "https://avatars2.githubusercontent.com/u/22725593?v=4&s=460",
 				"desc" : "AboutDeveloper",
 				"active": 1,

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -325,6 +325,7 @@
 						[ 3, "SettingsForDiamond" ],
 						[ 4, "SettingsForEchelon" ],
 						[ 5, "SettingsForLineAbreast" ],
+						[ 6, "SettingsForVanguard" ],
 						[ 11, "SettingsForCombAntiSub" ],
 						[ 12, "SettingsForCombForward" ],
 						[ 13, "SettingsForCombDiamond" ],

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -262,7 +262,7 @@ Retrieves when needed to apply on components
 				if(this.aaFormation < 11) this.aaFormation = 11;
 				if(this.aaFormation > 14) this.aaFormation = 11;
 			} else {
-				if(this.aaFormation > 5) this.aaFormation = 1;
+				if(this.aaFormation > 6) this.aaFormation = 1;
 			}
 			this.save();
 		},

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -176,7 +176,7 @@
 		sendData: function(payload) {
 			//console.debug(JSON.stringify(payload));
 			$.ajax({
-				url: "http://kckai.cybersnets.com/api/routing",
+				url: "https://tsundb.kc3.moe/api/routing",
 				method: "POST",
 				headers: {"content-type": "application/json"},
 				data: JSON.stringify(payload)

--- a/src/library/objects/ShowcaseExporter.js
+++ b/src/library/objects/ShowcaseExporter.js
@@ -628,12 +628,12 @@
 
             if (!sorted[groupId].types[typeId]) {
                 sorted[groupId].types[typeId] = {
-                    typeId: KC3Master.slotitem(equip.masterId).api_type[3],
-                    name: KC3Meta.gearTypeName(2, equipMaster.api_type[2]),
+                    typeId: equipMaster.api_type[3],
+                    name: KC3Meta.gearTypeName(3, equipMaster.api_type[3]),
                     gears: {}
                 };
-                this._equipTypeImages[KC3Master.slotitem(equip.masterId).api_type[3]] = null;
             }
+            this._equipTypeImages[equipMaster.api_type[3]] = null;
 
             if (!sorted[groupId].types[typeId].gears[masterId]) {
                 sorted[groupId].types[typeId].gears[masterId] = {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
 	"name": "KC3改 Development",
 	"short_name": "KC3改",
 	"description": "Kantai Collection Game Viewer and Helper",
-	"version": "32.3.0",
+	"version": "32.3.1",
 	"devtools_page": "pages/devtools/init.html",
 	"options_page": "pages/settings/settings.html",
 	"icons": {

--- a/src/pages/devtools/themes/natsuiro/js/Shipbox.js
+++ b/src/pages/devtools/themes/natsuiro/js/Shipbox.js
@@ -78,7 +78,7 @@ KC3改 Ship Box for Natsuiro theme
 			$(".ex_item", this.element).hide();
 		}
 		$(".ex_item", this.element).toggleClass("item_being_used",
-			ConfigManager.info_battle && (this.dameConConsumed.pos == 4 ||
+			ConfigManager.info_battle && (this.dameConConsumed.pos === 0 ||
 				// Although starshell not equippable at ex-slot for now
 				(this.starShellUsed && myExItem.masterId == 101))
 		);
@@ -439,7 +439,7 @@ KC3改 Ship Box for Natsuiro theme
 				if(ConfigManager.info_battle){
 					$(".ship_gear_"+(slot+1)+" .ship_gear_icon", this.element).toggleClass("item_being_used",
 						// Consumed damecon slot
-						this.dameConConsumed.pos == slot ||
+						this.dameConConsumed.pos === slot+1 ||
 						// Mark all equipped starshell
 						(this.starShellUsed && thisGear.masterId == 101)
 					);

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -398,6 +398,7 @@ html,body {
 	line-height:20px;
 	float:left;
 	color:#ccc;
+	white-space:nowrap;
 }
 .module.activity .consumable_ltext.regenCap {
 	color:#EAF918;
@@ -423,6 +424,10 @@ html,body {
 }
 .module.activity .consumables .consumable.page3 {
 	display:none;
+	width:60px;
+}
+.module.activity .consumables .consumable.page3 .consumable_ltext {
+	width:40px;
 }
 
 /* Expedition */

--- a/src/pages/devtools/themes/natsuiro/natsuiro.html
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.html
@@ -249,7 +249,7 @@
 							</div>
 							<div class="consumable page3">
 								<div class="consumable_icon"><img src="../../../../assets/img/useitems/61.png" /></div>
-								<div class="consumable_ltext count_1classMedals_or_mackerel">99</div>
+								<div class="consumable_ltext count_1classMedalsOrSaury">99</div>
 								<div class="clear"></div>
 							</div>
 							<div class="consumable page3">
@@ -258,13 +258,28 @@
 								<div class="clear"></div>
 							</div>
 							<div class="consumable page3">
-								<div class="consumable_icon"><img src="../../../../assets/img/useitems/64.png" /></div>
-								<div class="consumable_ltext count_reinforcement">99</div>
+								<div class="consumable_icon"><img src="../../../../assets/img/useitems/58.png" /></div>
+								<div class="consumable_ltext count_blueprints">99</div>
 								<div class="clear"></div>
 							</div>
 							<div class="consumable page3">
-								<div class="consumable_icon"><img src="../../../../assets/img/useitems/58.png" /></div>
-								<div class="consumable_ltext count_blueprints">99</div>
+								<div class="consumable_icon"><img src="../../../../assets/img/useitems/75.png" /></div>
+								<div class="consumable_ltext count_newGunMats">99</div>
+								<div class="clear"></div>
+							</div>
+							<div class="consumable page3">
+								<div class="consumable_icon"><img src="../../../../assets/img/useitems/77.png" /></div>
+								<div class="consumable_ltext count_newAvMats">99</div>
+								<div class="clear"></div>
+							</div>
+							<div class="consumable page3">
+								<div class="consumable_icon"><img src="../../../../assets/img/useitems/78.png" /></div>
+								<div class="consumable_ltext count_actionReportOrSkilledCrew">99</div>
+								<div class="clear"></div>
+							</div>
+							<div class="consumable page3">
+								<div class="consumable_icon"><img src="../../../../assets/img/useitems/64.png" /></div>
+								<div class="consumable_ltext count_reinforcement">99</div>
 								<div class="clear"></div>
 							</div>
 							<div class="consumable page3">

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -1033,8 +1033,8 @@
 
 		Consumables: function(data){
 			$(".activity_basic .consumables").hideChildrenTooltips();
-			let getWarnRscCap = max => Math.floor(max * (ConfigManager.alert_rsc_cap / 100)) || Infinity;
-			let fc200 = PlayerManager.consumables.furniture200 || 0,
+			const getWarnRscCap = max => Math.floor(max * (ConfigManager.alert_rsc_cap / 100)) || Infinity;
+			const fc200 = PlayerManager.consumables.furniture200 || 0,
 				fc400 = PlayerManager.consumables.furniture400 || 0,
 				fc700 = PlayerManager.consumables.furniture700 || 0,
 				fcboxestot = fc200 * 200 + fc400 * 400 + fc700 * 700;
@@ -1057,9 +1057,9 @@
 				.toggleClass("hardCap", PlayerManager.consumables.devmats >= getWarnRscCap(PlayerManager.maxConsumable));
 			if(Array.isArray(PlayerManager.hq.lastMaterial)){
 				// Regen for fuel, ammo, steel: +3 every 3 minutes. bauxite +1 / 3mins
-				let roundUpTo3Mins = m => String(60 * (m + (m % 3 ? 3 - m % 3 : 0)));
-				let regenCap = PlayerManager.hq.getRegenCap();
-				let fuel = PlayerManager.hq.lastMaterial[0],
+				const roundUpTo3Mins = m => String(60 * (m + (m % 3 ? 3 - m % 3 : 0)));
+				const regenCap = PlayerManager.hq.getRegenCap();
+				const fuel = PlayerManager.hq.lastMaterial[0],
 					ammo = PlayerManager.hq.lastMaterial[1],
 					steel = PlayerManager.hq.lastMaterial[2],
 					bauxite = PlayerManager.hq.lastMaterial[3];
@@ -1093,24 +1093,35 @@
 					.lazyInitTooltip();
 			}
 			// More pages could be added, see `api_get_member/useitem` in Kcsapi.js
-			$(".count_1classMedals_or_mackerel").text( PlayerManager.consumables.mackerel || PlayerManager.consumables.firstClassMedals || 0 )
+			$(".count_1classMedalsOrSaury").text(
+					PlayerManager.consumables.mackerel || PlayerManager.consumables.firstClassMedals || 0 )
 				.prev().attr("title", KC3Meta.useItemName(PlayerManager.consumables.mackerel ? 68 : 61) )
-				.children("img").attr("src", "/assets/img/useitems/" + (PlayerManager.consumables.mackerel ? 68 : 61) + ".png");
+				.children("img").attr("src", `/assets/img/useitems/${PlayerManager.consumables.mackerel ? 68 : 61}.png`);
 			$(".count_medals").text( PlayerManager.consumables.medals || 0 )
 				.prev().attr("title", KC3Meta.useItemName(57) );
-			$(".count_reinforcement").text( PlayerManager.consumables.reinforceExpansion || 0 )
-				.prev().attr("title", KC3Meta.useItemName(64) );
 			$(".count_blueprints").text( PlayerManager.consumables.blueprints || 0 )
 				.prev().attr("title", KC3Meta.useItemName(58) );
+			$(".count_newGunMats").text( PlayerManager.consumables.newArtilleryMaterial || 0 )
+				.prev().attr("title", KC3Meta.useItemName(75) );
+			$(".count_newAvMats").text( PlayerManager.consumables.newAviationMaterial || 0 )
+				.prev().attr("title", KC3Meta.useItemName(77) );
+			$(".count_actionReportOrSkilledCrew").text(
+					PlayerManager.consumables.actionReport || PlayerManager.consumables.skilledCrew || 0 )
+				.prev().attr("title", KC3Meta.useItemName(PlayerManager.consumables.actionReport ? 78 : 70) )
+				.children("img").attr("src", `/assets/img/useitems/${PlayerManager.consumables.actionReport ? 78 : 70}.png`);
+			$(".count_reinforcement").text( PlayerManager.consumables.reinforceExpansion || 0 )
+				.prev().attr("title", KC3Meta.useItemName(64) );
 			$(".count_fairy").text( PlayerManager.consumables.furnitureFairy || 0 )
 				.prev().attr("title", KC3Meta.useItemName(52) );
 			$(".count_morale").text( (PlayerManager.consumables.mamiya || 0)
-				+ (PlayerManager.consumables.irako || 0) )
-				.prev().attr("title", "{0}x {1} + {2}x {3}"
-					.format(PlayerManager.consumables.mamiya || 0, KC3Meta.useItemName(54), 
-						PlayerManager.consumables.irako || 0, KC3Meta.useItemName(59)) );
+				                   + (PlayerManager.consumables.irako || 0)
+			).prev().attr("title", "{1} x{0} + {3} x{2}"
+				.format(PlayerManager.consumables.mamiya || 0, KC3Meta.useItemName(54), 
+					    PlayerManager.consumables.irako || 0, KC3Meta.useItemName(59)) );
+			$(".consumables").hideChildrenTooltips();
 			$(".consumables .consumable").hide();
-			$(".consumables .consumable.page{0}".format(ConfigManager.hqInfoPage||1)).show();
+			$(`.consumables .consumable.page${ConfigManager.hqInfoPage || 1}`).show();
+			$(".consumables").createChildrenTooltips();
 		},
 
 		ShipSlots: function(data){
@@ -2493,7 +2504,7 @@
 					$(".module.activity .battle_support .support_exped").show();
 				}
 
-				$(".module.activity .battle_support").attr("title",
+				$(".module.activity .battle_support").attr("titlealt",
 					thisNode.buildSupportAttackMessage(undefined, true, true)
 						|| KC3Meta.term("BattleSupportExped")
 				).lazyInitTooltip();

--- a/src/pages/strategy/sortielogs.js
+++ b/src/pages/strategy/sortielogs.js
@@ -604,7 +604,8 @@
 								$(".sortie_ship_"+(index+1)+" img", sortieBox)
 									.attr("src", KC3Meta.shipIcon(ship.mst_id))
 									.attr("alt", ship.mst_id)
-									.click(shipClickFunc);
+									.click(shipClickFunc)
+									.css("visibility", "visible");
 								$(".sortie_ship_"+(index+1), sortieBox)
 									.addClass("hover")
 									.addClass("simg-"+ship.mst_id)
@@ -614,11 +615,13 @@
 								$(".sortie_combined_ship_"+(index+1)+" img", sortieBox)
 									.attr("src", KC3Meta.shipIcon(ship.mst_id))
 									.attr("alt", ship.mst_id)
-									.click(shipClickFunc);
+									.click(shipClickFunc)
+									.css("visibility", "visible");
 								$(".sortie_combined_ship_"+(index+1), sortieBox)
 									.addClass("hover")
 									.addClass("simg-"+ship.mst_id)
 									.show();
+								$(".sortie_ship_"+(index+1), sortieBox).show();
 							}
 							
 							rshipBox = $(".tab_"+tabCode+" .factory .rfleet_ship").clone();

--- a/src/pages/strategy/tabs/aircraft/aircraft.html
+++ b/src/pages/strategy/tabs/aircraft/aircraft.html
@@ -6,10 +6,13 @@
 <!-- HELP TOPICS -->
 <div class="page_help">
 	<div class="help_q">What do the blue text in fighter stats mean?</div>
-	<div class="help_a">They are active squadrons equipped on a ship. They have higher fighter power than usual because plane slot formula is applied.</div>
-	
-	<div class="help_q">Does this already involve veteran fighter power bonus?</div>
-	<div class="help_a">Not yet. We just know that max level adds ~25 fighter power and that's it. No definite formula yet.</div>
+	<div class="help_a">They are active squadrons equipped on a ship (or land-base). They have higher fighter power than usual because plane slot formula is applied.</div>
+
+	<div class="help_q">Does this already involve fighter power proficiency bonus?</div>
+	<div class="help_a">Yes.</div>
+
+	<div class="help_q">Why can not find stats of interception and anti-bomber from Interceptor and Land-base Fighter?</div>
+	<div class="help_a">They are reusing existed stats in game API data, which <img src="/assets/img/stats/ht.png"> represents the Anti-Bomber, <img src="/assets/img/stats/ev.png"> represents the Interception.</div>
 
 	<div class="help_more">
 		<a href="https://github.com/KC3Kai/KC3Kai/wiki/Strategy-Room%3A-Aircraft">Learn more</a>

--- a/src/pages/strategy/tabs/aircraft/aircraft.js
+++ b/src/pages/strategy/tabs/aircraft/aircraft.js
@@ -172,6 +172,9 @@
 		execute :function(){
 			const self = this;
 			
+			$(".tab_aircraft .item_type").each((_, elm) => {
+				$(elm).attr("title", KC3Meta.gearTypeName(3, $(elm).data("type")));
+			});
 			$(".tab_aircraft .item_type").on("click", function(e){
 				KC3StrategyTabs.gotoTab(null, $(this).data("type"));
 			});

--- a/src/pages/strategy/tabs/encounters/encounters.js
+++ b/src/pages/strategy/tabs/encounters/encounters.js
@@ -143,7 +143,6 @@
 			const shipClickFunc = function(e) {
 				KC3StrategyTabs.gotoTab("mstship", $(this).attr("alt"));
 			};
-			const diffStrs = ["", "E", "N", "H"];
 
 			$(".encounter_list").empty().hide();
 			$(".loading").show();
@@ -164,7 +163,7 @@
 						KC3Meta.term("EventRankEasyAbbr"),
 						KC3Meta.term("EventRankNormalAbbr"),
 						KC3Meta.term("EventRankHardAbbr")][
-							((d, w) => w >= 41 ? d : d + 1)(encounter.diff || 0, encounter.world)
+							((d, w) => w < 10 || w >= 41 ? d : d + 1)(encounter.diff || 0, encounter.world)
 						] || "";
 					const mapName = `${encounter.world}-${encounter.map}${diffStr}`;
 					// Check map box

--- a/src/pages/strategy/tabs/event/event.css
+++ b/src/pages/strategy/tabs/event/event.css
@@ -309,6 +309,7 @@
 	width:30px;
 	height:30px;
 	vertical-align:top;
+	visibility:hidden;
 }
 .tab_event .sortie_list .seven_ships .sortie_ship {
 	margin:3px 5px 0px 0px;

--- a/src/pages/strategy/tabs/gears/gears.js
+++ b/src/pages/strategy/tabs/gears/gears.js
@@ -315,6 +315,9 @@
 		execute :function(){
 			const self = this;
 
+			$(".tab_gears .item_type").each((_, elm) => {
+				$(elm).attr("title", KC3Meta.gearTypeName(3, $(elm).data("type")));
+			});
 			$(".tab_gears .item_type").on("click", function(){
 				KC3StrategyTabs.gotoTab(null, $(this).data("type"));
 			});

--- a/update
+++ b/update
@@ -1,7 +1,7 @@
 {
-	"version" : "32.3.0",
+	"version" : "32.3.1",
 	"pr" : "https://github.com/KC3Kai/KC3Kai/pulls?q=label%3Atype%3Arelease%20",
-	"time" : "Fri, 09 March 2018 17:00:00 +0900",
+	"time" : "Fri, 16 March 2018 11:30:00 +0900",
 	"maintenance_start": "Fri, 23 March 2018 11:30:00 +0900",
 	"maintenance_end": "Fri, 23 March 2018 19:00:00 +0900"
 }


### PR DESCRIPTION
### ⚓️ Fixes & Adjustments

* Will now switch to vertical damage summary when applicable for the panel support tooltip
* Show 3 more items on the panel (action reports, gun and aviation parts)
* Update TsunDB submission domain, and traffic now via `HTTPS`
* Show proper equipment type (icon) names at Strategy Room Equipment, Aircraft pages and exported Showcase image
* Other minor fixes

### ⚓️ Translations

* `en` quotes
* `en` terms
* `fr` terms
* `id` terms
* `jp` quotes
* `jp` terms
* `ru` terms
* `scn` terms
* `tcn` quests
* `tcn` terms
* `th` battle
* `th` terms