### PR TITLE
Added ship level filter to strategy room ship list

### DIFF
--- a/src/pages/strategy/tabs/ships/ships.css
+++ b/src/pages/strategy/tabs/ships/ships.css
@@ -100,6 +100,49 @@
 	color: #f00;
 }
 
+.tab_ships .ship_level_filter {
+    float: right;
+    height: 18px;
+    margin: 0px 0px 2px 0px;
+}
+.tab_ships .ship_level_filter .level_start_label {
+    float: left;
+    font-weight: bold;
+    font-size: 12px;
+    padding-right: 5px;
+    line-height: 18px;
+}
+.tab_ships .ship_level_filter .level_end_label {
+    float: left;
+    font-weight: bold;
+    font-size: 12px;
+    padding-right: 5px;
+    line-height: 18px;
+    margin: 0 0 0 6px;
+}
+.tab_ships .ship_level_filter .level_start_input {
+    float: left;
+    font-size: 12px;
+    width: 40px;
+    height: 18px;
+    padding: 1px 3px;
+    line-height: 18px;
+}
+.tab_ships .ship_level_filter .level_start_input.error {
+    color: #f00;
+}
+.tab_ships .ship_level_filter .level_end_input {
+    float: left;
+    font-size: 12px;
+    width: 40px;
+    height: 18px;
+    padding: 1px 3px;
+    line-height: 18px;
+}
+.tab_ships .ship_level_filter .level_end_input.error {
+    color: #f00;
+}
+
 .tab_ships .advanced_sorter {
 	margin:0px 0px 2px 0px;
 }

--- a/src/pages/strategy/tabs/ships/ships.css
+++ b/src/pages/strategy/tabs/ships/ships.css
@@ -78,6 +78,7 @@
 }
 
 .tab_ships .show_name_filter {
+	float: left;
 	height: 18px;
 	margin: 0px 0px 2px 0px;
 }

--- a/src/pages/strategy/tabs/ships/ships.html
+++ b/src/pages/strategy/tabs/ships/ships.html
@@ -152,6 +152,12 @@
 		<div class="name_label">Show by Name:</div>
 		<input type="text" class="name_criteria" />
 	</div>
+    <div class="ship_level_filter">
+        <div class="level_start_label">Start Level:</div>
+        <input type="text" class="level_start_input" />
+        <div class="level_end_label">End Level:</div>
+        <input type="text" class="level_end_input" />
+    </div>
 	<div class="clear"></div>
 
 	<div class="ship_count">

--- a/src/pages/strategy/tabs/ships/ships.js
+++ b/src/pages/strategy/tabs/ships/ships.js
@@ -275,21 +275,39 @@
 
 			// Ship show name quick filter
 			$(".show_name_filter .name_criteria").on("keyup", () => {
-				this.refreshShowNameFilter();
+				this.refreshInputFilter();
 			}).on("focus", () => {
 				$(".show_name_filter .name_criteria").select();
 			}).val(this.showNameFilter);
 
-            // Ship show start/end level quick filter
-            $(".ship_level_filter .level_start_input").on("keyup", () => {
-                this.refreshFilter();
+			// Ship show start/end level quick filter
+			const lvStartInput = $(".ship_level_filter .level_start_input");
+			const lvEndInput = $(".ship_level_filter .level_end_input");
+            lvStartInput.on("keyup", () => {
+				const lvStartVal = parseInt(lvStartInput.val() == "" ? 0 : lvStartInput.val());
+				const lvEndVal = parseInt(lvEndInput.val() == "" ? 0 : lvEndInput.val());
+				if (lvStartVal <= lvEndVal){
+					lvStartInput.removeClass("error");
+					lvEndInput.removeClass("error");
+					this.refreshInputFilter();
+				} else {
+					lvStartInput.addClass("error");
+				}
             }).on("focus", () => {
-                $(".ship_level_filter .level_start_input").select();
+                lvStartInput.select();
             }).val(this.shipLevelFilterStart);
-            $(".ship_level_filter .level_end_input").on("keyup", () => {
-                this.refreshFilter();
+            lvEndInput.on("keyup", () => {
+				const lvStartVal = parseInt(lvStartInput.val() == "" ? 0 : lvStartInput.val());
+				const lvEndVal = parseInt(lvEndInput.val() == "" ? 0 : lvEndInput.val());
+				if (lvStartVal <= lvEndVal){
+					lvStartInput.removeClass("error");
+					lvEndInput.removeClass("error");
+					this.refreshInputFilter();
+				} else {
+					lvEndInput.addClass("error");
+				}
             }).on("focus", () => {
-                $(".ship_level_filter .level_end_input").select();
+                lvEndInput.select();
             }).val(this.shipLevelFilterEnd);
 		},
 

--- a/src/pages/strategy/themes/dark.css
+++ b/src/pages/strategy/themes/dark.css
@@ -856,7 +856,8 @@ button, input, select, textarea {
 .tab_ships .control_buttons .reset_default:hover {
 	background:#555555;
 }
-.tab_ships .show_name_filter .name_criteria {
+.tab_ships .show_name_filter .name_criteria,
+.tab_ships .ship_level_filter input {
 	border:1px solid #888888;
 }
 .tab_ships .ship_count {

--- a/src/pages/strategy/themes/legacy.css
+++ b/src/pages/strategy/themes/legacy.css
@@ -695,7 +695,8 @@ body {
 .tab_ships .control_buttons .hover:hover {
 	background:#cfc;
 }
-.tab_ships .show_name_filter .name_criteria {
+.tab_ships .show_name_filter .name_criteria,
+.tab_ships .ship_level_filter input {
 	border:1px solid #000;
 }
 .tab_ships .advanced_sorter .filter_box {


### PR DESCRIPTION
Strategy room's ship list now has the feature to filter by ship level on minimum and maximum limits.

1) Added "Start Level" and "End Level" input fields to the right of the existing "Show by Name" input field.
2) "Start Level" input field will dictate the minimum level that a ship must be in order to display in the list. (Level inclusive, so the list will include ships this level and higher.)
3) "End Level" input field will dictate the maximum level that a ship must be in order to display in the list.
(Level inclusive, so the list will include ships this level and lower.)
4) Both fields do not need to be specified - if both are specified then both filters will be applied, if one is specified then only one filter will be applied.
5) If the start level is greater than the end level, then an error will display via turning the level specified red. Entering non numeric value for a level will treat it as level 0 for this check.
6) The ship level filter was added on top of the existing ship name filter, but the function was renamed. This means the ship level filter should work with the other filters as well.