### PR TITLE
Added enemy air power (including recons) for LB airraid tooltip

### DIFF
--- a/src/pages/strategy/sortielogs.js
+++ b/src/pages/strategy/sortielogs.js
@@ -544,17 +544,19 @@
 				const topAbSquadsName = topAbSquadSlots.map(id =>
 					id > 0 ? KC3Meta.gearName(KC3Master.slotitem(id).api_name) : KC3Meta.term("None")
 				);
+				const eships = Object.getSafePath(airRaid, "api_ship_ke") || [];
 				return {
 					airRaidLostKind: Object.getSafePath(airRaid, "api_lost_kind") || 0,
 					baseTotalDamage: baseTotalDamage,
 					resourceLossAmount: Math.round(baseTotalDamage * 0.9 + 0.1),
-					eships: Object.getSafePath(airRaid, "api_ship_ke") || [],
+					eships: eships,
 					airState: KC3Meta.airbattle(airState)[2] || KC3Meta.airbattle(airState)[0],
 					isTorpedoBombingFound: (bomberPhase.api_frai_flag || []).includes(1),
 					isDiveBombingFound: (bomberPhase.api_fbak_flag || []).includes(1),
 					shotdownPercent: enemyPlaneLost,
 					topAntiBomberSquadSlots: topAbSquadSlots,
 					topAntiBomberSquadNames: topAbSquadsName,
+					ap : KC3Calc.enemyFighterPower(eships, undefined, undefined, true)[0],
 				};
 			};
 			$.each(sortieList, function(id, sortie){
@@ -613,6 +615,7 @@
 											KC3Meta.airraiddamage(airRaid.airRaidLostKind),
 											airRaid.resourceLossAmount,
 											airRaid.airState,
+											airRaid.ap,
 											"{0}%".format(airRaid.shotdownPercent),
 											KC3Meta.term(airRaid.isTorpedoBombingFound ? "BattleContactYes" : "BattleContactNo"),
 											KC3Meta.term(airRaid.isDiveBombingFound ? "BattleContactYes" : "BattleContactNo"),
@@ -838,6 +841,7 @@
 										KC3Meta.airraiddamage(airRaid.airRaidLostKind),
 										airRaid.resourceLossAmount,
 										airRaid.airState,
+										airRaid.ap,
 										"{0}%".format(airRaid.shotdownPercent),
 										KC3Meta.term(airRaid.isTorpedoBombingFound ? "BattleContactYes" : "BattleContactNo"),
 										KC3Meta.term(airRaid.isDiveBombingFound ? "BattleContactYes" : "BattleContactNo"),


### PR DESCRIPTION
Saw that we were adding lbas AP into encounters so decided to add it to airraid tooltip as well
Recons do take part in LB airraids **https://cdn.discordapp.com/attachments/345068113978458113/421001464798773258/2018-3-7T20.48.41.png**
![image](https://user-images.githubusercontent.com/26541502/38992653-fa37512c-4413-11e8-84ec-fe17f484fdb6.png)
Sorry for making the tooltip longer
