### PR TITLE
 Add anti-installation (and imps) additive/multiplicative bonus calculation

### DIFF
--- a/src/library/managers/GearManager.js
+++ b/src/library/managers/GearManager.js
@@ -40,6 +40,26 @@ Saves and loads list to and from localStorage
 		jetBomberSteelCostRatioPerSlot: 0.2,
 		// steel_consumption = floor(api_cost * current_slot * 0.2)
 
+		// Anti-installation land damage per type and improvement
+		// Array format is [t2Bonus,t89Bonus,normalBonus]
+		landingModifiers : {
+			// Pillbox
+			0: {
+				modifier: [2.4,2.15,1.8],
+				improvement: [0.08,0.043,0.0036],
+			},
+			// Isolated Island Princess
+			1: {
+				modifier: [2.4,2.15,1.8],
+				improvement: [0.08,0.043,0.0036],
+			},
+			// Supply Depot Princess (no info on Daihatsu improvement)
+			2: {
+				modifier: [1.7,1.3,1],
+				improvement: [0.051,0.026,0],
+			},
+		},
+
 		// Get a specific item by ID
 		// NOTE: if you want to write test-cases, avoid setting KC3GearManager.list["x0"]
 		// because it'll never be retrieved by "get(0)"

--- a/src/library/managers/GearManager.js
+++ b/src/library/managers/GearManager.js
@@ -41,22 +41,27 @@ Saves and loads list to and from localStorage
 		// steel_consumption = floor(api_cost * current_slot * 0.2)
 
 		// Anti-installation land damage per type and improvement
-		// Array format is [t2Bonus,t89Bonus,normalBonus]
+		// Array format is [t2Bonus,t89Bonus,normalBonus,shikonBonus]
 		landingModifiers : {
 			// Pillbox
 			0: {
-				modifier: [2.4,2.15,1.8],
-				improvement: [0.08,0.043,0.0036],
+				modifier: [2.4,2.15,1.8,2.2],
+				improvement: [0.08,0.043,0.0036,0],
 			},
 			// Isolated Island Princess
 			1: {
-				modifier: [2.4,2.15,1.8],
-				improvement: [0.08,0.043,0.0036],
+				modifier: [2.4,2.15,1.8,2.2],
+				improvement: [0.08,0.043,0.0036,0],
+			},
+			// Harbour Summer Princess Damaged Form (no info on 11th interaction)
+			2: {
+				modifier: [2.8,3.7,1.8,1],
+				improvement: [0,0,0,0],
 			},
 			// Supply Depot Princess (no info on Daihatsu improvement)
-			2: {
-				modifier: [1.7,1.3,1],
-				improvement: [0.051,0.026,0],
+			3: {
+				modifier: [1.7,1.3,1,3.52],
+				improvement: [0.051,0.026,0,0],
 			},
 		},
 

--- a/src/library/objects/Ship.js
+++ b/src/library/objects/Ship.js
@@ -2124,7 +2124,7 @@ KC3改 Ship Object
 	 * Special attacks are not taken into consideration
 	 */
 	KC3Ship.prototype.shipPossibleLandingDamage = function(){
-		if(this.isDummy()) { return {}; }
+		if(this.isDummy()) { return []; }
 		let possibleTypes = [];
 		const hasWG42 = this.hasEquipment(126);
 		const hasT3Shell = this.hasEquipment(35);
@@ -2143,7 +2143,7 @@ KC3改 Ship Object
 			possibleTypes = [2,3,4,5];
 		}
 		// Return empty if no anti-installation found
-		else { return {}; }
+		else { return []; }
 
 		const dummyEnemyList = [1573,1665,1668,1702,1653];
 		const basicPower = this.shellingFirePower();
@@ -2161,7 +2161,6 @@ KC3改 Ship Object
 			({power} = shipObj.applyPostcapModifiers(power, "Shelling",
 			[], 0, false, false, 0, false, dummyEnemy));
 			
-
 			landingObj.enemy = dummyEnemy;
 			landingObj.dayPower = Math.floor(power);
 

--- a/src/library/objects/Ship.js
+++ b/src/library/objects/Ship.js
@@ -1992,8 +1992,7 @@ KC3改 Ship Object
 		const isSubmarine = targetShip && this.isSubmarine(targetShip.api_stype);
 		// regular surface vessel by default
 		const isSurface = !isLand && !isSubmarine;
-		const name = targetShip.api_name;
-		const isPTImp = (typeof name != 'undefined' ? name : [] ).includes("PT");
+		const isPTImp = [1637,1638,1639,1640].includes(targetShipMasterId);
 		return {
 			isSubmarine,
 			isLand,

--- a/src/library/objects/Ship.js
+++ b/src/library/objects/Ship.js
@@ -2113,7 +2113,7 @@ KC3改 Ship Object
 
 		else { return 1; }
 	};
-		/**
+	/**
 	 * Get anti-installation power against all possible types of installations
 	 * Choose types based on current equip
 	 * @see getInstallationEnemyType for kc3-unique types
@@ -2152,10 +2152,11 @@ KC3改 Ship Object
 
 		// Fill damage lists for each enemy type
 		possibleTypes.forEach(function(installationType){
-			const landingObj = {}
+			const landingObj = {};
 			const dummyEnemy = dummyEnemyList[installationType-1];
 			let { power } = shipObj.applyPrecapModifiers(basicPower, "Shelling",
 			1, ConfigManager.aaFormation, [], false, false, dummyEnemy);
+			const precap = power;
 			({power} = shipObj.applyPowerCap(power, "Day", "Shelling"));
 			({power} = shipObj.applyPostcapModifiers(power, "Shelling",
 			[], 0, false, false, 0, false, dummyEnemy));
@@ -2164,8 +2165,7 @@ KC3改 Ship Object
 			landingObj.enemy = dummyEnemy;
 			landingObj.dayPower = Math.floor(power);
 
-			({ power } = shipObj.applyPrecapModifiers(basicPower, "Shelling",
-			1, ConfigManager.aaFormation, [], false, false, dummyEnemy));
+			power = precap;
 			({power} = shipObj.applyPowerCap(power, "Night", "Shelling"));
 			({power} = shipObj.applyPostcapModifiers(power, "Shelling",
 			[], 0, false, false, 0, false, dummyEnemy));
@@ -2863,8 +2863,8 @@ KC3改 Ship Object
 		const aswDiff = newEquipAsw - oldEquipAsw;
 		const oaswPower = this.canDoOASW(aswDiff) ? this.antiSubWarfarePower(aswDiff) : false;
 		isShow = isShow || (oaswPower !== false);
-		const antiLandDamage = this.shipPossibleLandingDamage();
-		isShow = isShow || antiLandDamage.length > 0 ;
+		const antiLandPower = this.shipPossibleLandingDamage();
+		isShow = isShow || antiLandPower.length > 0 ;
 		// Possible TODO:
 		// can opening torpedo
 		// can cut-in (fire / air)
@@ -2877,7 +2877,7 @@ KC3改 Ship Object
 			gunFit,
 			shipAacis,
 			oaswPower,
-			antiLandDamage,
+			antiLandPower,
 		};
 	};
 

--- a/src/library/objects/Ship.js
+++ b/src/library/objects/Ship.js
@@ -1272,8 +1272,8 @@ KC3改 Ship Object
 	 * @see http://wikiwiki.jp/kancolle/?%C0%EF%C6%AE%A4%CB%A4%C4%A4%A4%A4%C6#antiground
 	 * @return {number} multiplier of landing craft, unfloored for calculations
 	 */
-	KC3Ship.prototype.calcLandingBonus = function(installationType=0){
-		if(this.isDummy() || ![2,3,4].includes(installationType)) { return 0; }
+	KC3Ship.prototype.calcLandingBonus = function(installationType = 0){
+		if(this.isDummy() || ![2,3,4,5].includes(installationType)) { return 0; }
 
 		const t2Count = this.countEquipment(167); // Special Type 2 Amphibious Tank
 		const t89Count = this.countEquipment(166); // Daihatsu Landing Craft (Type 89 Medium Tank & Landing Force)
@@ -1299,34 +1299,34 @@ KC3改 Ship Object
 		 */
 
 		// Arrange equipment in terms of priority
-		const landingArray = [t2Count,t89Count,normalCount,shikonCount].forEach(function(element,idx){
+		[t2Count,t89Count,normalCount,shikonCount].forEach(function(element,idx){
 			let improvement = 0;
 			shipObj.equipment().forEach((gear, idx) => {
 				if(gear.exists())  {
-					if (gearArr[idx] === gear.masterId){
+					if(gearArr[idx] === gear.masterId){
 						improvement += gear.stars;
 					}
 				}
 			});
 			// Two (or more) Type 2 Tank bonus (Currently only for Supply Depot and Pillbox)
-			if (element > 1 && idx === 0 && [2,5].includes(installationType)){
+			if(element > 1 && idx === 0 && [2,5].includes(installationType)){
 				tankBonus = installationType === 2 ? 3.2 : 2.5;
 				tankBonus *= (1 + improvement / element / 30);
 			}
 
 			// Type 2 Tank bonus
-			else if (element > 0 && idx === 0){
+			else if(element > 0 && idx === 0){
 				tankBonus = landingModifiers.modifier[idx] + landingModifiers.improvement[idx] * improvement / element;
 			}
 			
 			// Bonus for two Type 89 Tank (Pillbox, Supply Depot and Isolated Island)
-			else if (element > 1 && idx === 1 && [2,3,5].includes(installationType)){
+			else if(element > 1 && idx === 1 && [2,3,5].includes(installationType)){
 				landingBonus.push(installationType === 5 ? 2.08 : 3 );
 				landingImprovementBonus.push((installationType === 5 ? 0.0416 : 0.06) * improvement / element);
 			}
 
 			// Otherwise, match modifier and improvement
-			else if (element > 0){
+			else if(element > 0){
 				landingBonus.push(landingModifiers.modifier[idx]);
 				landingImprovementBonus.push(landingModifiers.improvement[idx] * improvement / element);
 			}
@@ -1347,7 +1347,7 @@ KC3改 Ship Object
  	 */
 	KC3Ship.prototype.antiLandWarfarePower = function(targetShipMasterId = 0, precap = true){
 		if(this.isDummy()) { return [0,1]; }
-		if (this.estimateTargetShipType(targetShipMasterId).isLand === false) {return [0,1];} 
+		if(this.estimateTargetShipType(targetShipMasterId).isLand === false) { return [0,1]; } 
 
 		const installationType = this.getInstallationEnemyType(targetShipMasterId,precap);
 		const wg42Count = this.countEquipment(126); 
@@ -1364,9 +1364,9 @@ KC3改 Ship Object
 		Type 5: Supply Depot Princess (NEET Hime), postcap
 		*/
 		
-		if (precap){
+		if(precap){
 			// [0,70,110,140,160] additive for each WG42,
-			const wg42Additive = wg42Count === 0 ? 0 : 20 + 55*wg42Count - 5*Math.pow(wg42Count,2);
+			const wg42Additive = wg42Count === 0 ? 0 : 20 + 55 * wg42Count - 5 * Math.pow(wg42Count,2);
 			
 			switch(installationType){
 				case 1: 
@@ -1384,7 +1384,7 @@ KC3改 Ship Object
 					});
 					const apShellBonus = this.hasEquipmentType(2,19) ? 1.85 : 1;
 					
-					// [0,70,110,140,160] addition for each WG42, multiply multiplicative modifiers
+					// Set WG42 additive modifier, multiply multiplicative modifiers
 					return [wg42Additive, seaplaneBonus * lightShipBonus * wg42Bonus
 						* apShellBonus * landingBonus];
 				
@@ -1395,7 +1395,7 @@ KC3改 Ship Object
 						if (index === wg42Count) { return element; }
 						else if (wg42Count > 2) { return 2.1; }
 					});
-					// [0,70,110,140,160] addition for each WG42, multiply multiplicative modifiers
+					// Set WG42 additive modifier, multiply multiplicative modifiers
 					return [wg42Additive, wg42Bonus * t3Bonus * landingBonus];
 
 				case 4:
@@ -1405,7 +1405,9 @@ KC3改 Ship Object
 						else if (wg42Count > 2) { return 2.1; }
 					});
 					t3Bonus = hasT3Shell ? 1.8 : 1;
+
 					// Missing: AP Shell modifier, SPB/SPF modifier
+					// No additive WG42 bonus
 					return [0, wg42Bonus * t3Bonus * landingBonus];					
 				default: return [0,1];
 			}
@@ -1585,7 +1587,7 @@ KC3改 Ship Object
 			landingModifier = landingBonus[1];
 		}
 		
-		// Apply modifiers, flooring unknown
+		// Apply modifiers, flooring unknown, multiply and add land modifiers first
 		let result = (basicPower * landingModifier + landingAdditive) * engagementModifier * formationModifier * damageModifier * nightCutinModifier;
 		
 		// Light Cruiser fit gun bonus, should not applied before modifiers

--- a/src/library/objects/Ship.js
+++ b/src/library/objects/Ship.js
@@ -1297,7 +1297,8 @@ KC3改 Ship Object
 			
 			// Bonus for two Type 89 Tank
 			if (element > 1 && idx === 1){
-				return 3 + 0.06*improvement/element;
+				return installationType === 4 ? 2.08+0.0416*improvement/element
+				 : 3 + 0.06*improvement/element;
 			}
 
 			// Match modifier and improvement

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -2014,6 +2014,48 @@ ABYSS FLEET
 .module.activity .activity_gunfit .aaci .aaciPattern.triggerable {
 	background:#777;
 }
+.module.activity .activity_gunfit .landing {
+	width:176px;
+	height:82px;
+	margin:0px 0px 2px 0px;
+	overflow:hidden;
+	overflow-y:auto;
+}
+.module.activity .activity_gunfit .landing .landingInfo {
+	width:170px;
+	height:20px;
+	margin:0px 0px 1px 0px;
+	border-radius:6px;
+	font-size:12px;
+	color:#ccc;
+}
+.module.activity .activity_gunfit .landing .shipIcon {
+	width:18px;
+	height:20px;
+	margin:0px 1px 0px 0px;
+	padding:1px 2px;
+	float:left;
+}
+.module.activity .activity_gunfit .landing .shipIcon img {
+	width:18px;
+	height:18px;
+	margin-top:-2px;
+	margin-left:-2px;
+}
+.module.activity .activity_gunfit .landing .dayPower {
+	width:60px;
+	height:20px;
+	margin:0px 2px 0px 0px;
+	padding:1px 2px;
+	float:left;
+}
+.module.activity .activity_gunfit .landing .nightPower {
+	width:60px;
+	height:20px;
+	margin:0px 2px 0px 0px;
+	padding:1px 1px;
+	float:left;
+}
 /*------- ACTIVITY: PvP Info -------*/
 .module.activity .activity_pvp {
 	padding: 5px 10px;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.html
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.html
@@ -801,6 +801,10 @@
 							<div class="aaciList"></div>
 							<div class="clear"></div>
 						</div>
+						<div class="landing">
+							<div class="landingList"></div>
+							<div class="clear"></div>
+						</div>
 					</div>
 					<!-- PvP Enemy List and Fleet Info -->
 					<div class="activity_box activity_pvp">
@@ -1216,6 +1220,13 @@
 				<div class="equipIcons"></div>
 				<div class="fixed"></div>
 				<div class="modifier"></div>
+			</div>
+
+			<!-- Clonable: Gunfit / Landing damage -->
+			<div class="landingInfo">
+				<div class="shipIcon"><img/></div>
+				<div class="dayPower"></div>
+				<div class="nightPower"></div>
 			</div>
 			
 			<!-- Clonable: PvP enemy list -->

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -4094,9 +4094,9 @@
 			}
 
 			// Show anti-installation modifier
-			if (data.antiLandDamage.length > 0 ) {
+			if (data.antiLandPower.length > 0 ) {
 				$(".activity_gunfit .landingList").empty();
-				$.each(data.antiLandDamage, function(idx, landingObj) {
+				$.each(data.antiLandPower, function(idx, landingObj) {
 					const landingBox = $("#factory .landingInfo").clone();
 					if(landingObj.enemy > 0) {
 						$(".shipIcon img", landingBox)

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -4092,6 +4092,29 @@
 			} else {
 				$(".activity_gunfit .aaci").hide();
 			}
+
+			// Show anti-installation modifier
+			if (data.antiLandDamage.length > 0 ) {
+				$(".activity_gunfit .landingList").empty();
+				$.each(data.antiLandDamage, function(idx, landingObj) {
+					const landingBox = $("#factory .landingInfo").clone();
+					if(landingObj.enemy > 0) {
+						$(".shipIcon img", landingBox)
+							.attr("src", KC3Meta.shipIcon(landingObj.enemy) )
+							.lazyInitTooltip();
+					} else {
+						$(".shipIcon img", landingBox).hide();
+					}
+					$(".dayPower", landingBox).text("Day:{0}".format(landingObj.dayPower));
+					$(".nightPower", landingBox).text("Night:{0}".format(landingObj.nightPower));
+					
+					landingBox.appendTo(".activity_gunfit .landingList");
+				});
+				$(".activity_gunfit .landing").show();
+			} else {
+				$(".activity_gunfit .landing").hide();
+			}
+			
 			
 			$(".module.activity .activity_tab").removeClass("active");
 			$("#atab_activity").addClass("active");


### PR DESCRIPTION
Split enemies into currently known installation types and assign bonus based on type

1. normal enemy
2. Soft-skinned installation
3. Pillbox
4. Isolated Island Princess
5. Harbour Summer Princess Damaged
6. Supply Depot Princess
7. PT Imp (not included with anti-installation modifiers)

~~Add bonus for Northernmost Landing Princess~~ (Should be the same as normal ritou anyway)
- [x] Add bonus for Harbour Summer Princess 
- [x] Add two Ka-Mi tank interaction
- [x] Add Toku Daihatsu + 11th Tank Regiment interaction
- [x] Precap/Postcap attack power integration

Some of these bonus interactions (like average improvement levels) are speculative, also, lacking info on certain equipment like 11th Tank Regiment.

Will probably be used to sim damage for future abnormal damage checker