### PR TITLE
Release 32.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "KC3Kai",
-  "version": "32.5.5",
+  "version": "32.6.0",
   "description": "Kantai Collection Game Viewer and Tools",
   "repository": {
     "type": "git",

--- a/src/library/managers/ShipManager.js
+++ b/src/library/managers/ShipManager.js
@@ -8,8 +8,7 @@ Saves and loads list to and from localStorage
 	"use strict";
 	
 	/* this variable will keep the kc3-specific variables */
-	var
-		defaults = (new KC3Ship()),
+	const defaults = (new KC3Ship()),
 		devVariables = {
 			capture: ['didFlee','pendingConsumption','lastSortie','repair','akashiMark'],
 			norepl : ['repair']
@@ -19,7 +18,7 @@ Saves and loads list to and from localStorage
 		list: {},
 		max: 100,
 		pendingShipNum: 0,
-
+		
 		// Get a specific ship by ID
 		get :function( rosterId ){
 			// console.log("getting ship", rosterId, this.list["x"+rosterId]);
@@ -46,27 +45,24 @@ Saves and loads list to and from localStorage
 		
 		// Add or replace a ship on the list
 		add :function(data){
-			var
-				self     = this,
-				tempData = {},
-				cky      = "",
-				newData  = false,
-				cShip;
-			if(typeof data.api_id != "undefined"){
+			const self   = this,
+				tempData = {};
+			var cky, cShip, oShip, isNewShip;
+			if(typeof data.api_id !== "undefined") {
 				cky = "x"+data.api_id;
-			}else if(typeof data.rosterId != "undefined"){
+			} else if(typeof data.rosterId !== "undefined") {
 				cky = "x"+data.rosterId;
-			}else{
+			} else {
 				return false;
 			}
 			
-			newData = !self.list[cky];
+			oShip = self.list[cky];
+			isNewShip = !oShip;
 			
 			devVariables.capture.forEach(function(key){
-				var
-					val = (self.list[cky] || defaults)[key];
+				var val = (oShip || defaults)[key];
 				tempData[key] = (typeof val === 'object' &&
-					(val instanceof Array ? [].slice.apply(val) : $.extend({},val))
+					(val instanceof Array ? [].slice.apply(val) : $.extend({}, val))
 				) || val;
 			});
 			
@@ -78,22 +74,22 @@ Saves and loads list to and from localStorage
 			//this.list[cky].didFlee = didFlee;
 			
 			// prevent the fresh data always overwrites the current loaded state
-			if(!newData) {
+			if(!isNewShip) {
 				devVariables.capture.forEach(function(key){
-					if(devVariables.norepl.indexOf(key)<0)
+					if(devVariables.norepl.indexOf(key) < 0)
 						cShip[key] = tempData[key];
 				});
 				
 				// enforce fresh sortie0 placeholder
-				(function(){
-					var szs = 'sortie0';
-					var ls  = cShip.lastSortie;
-					var cnt = 0;
-					var szi;
-					for(szi=0;szi<ls.length;szi++)
-						cnt += ls[szi]==szs;
+				(function() {
+					var szs = 'sortie0',
+						ls  = cShip.lastSortie,
+						cnt = 0,
+						szi;
+					for(szi = 0; szi < ls.length; szi++)
+						cnt += ls[szi] == szs;
 					while(cnt) {
-						for(szi=0;ls[szi]!=szs;szi++){}
+						for(szi = 0; ls[szi] != szs; szi++) {}
 						ls.splice(szi,1);
 						cnt--;
 					}
@@ -120,12 +116,11 @@ Saves and loads list to and from localStorage
 				/* Disabling this --
 					the problem is, pending consumption variable stacks up for expedition, */
 				// Calculate Difference
-				var
-					sp  = cShip,
+				var sp  = cShip,
 					pc  = sp.pendingConsumption,
 					rs  = Array.apply(null,{length:8}).map(function(){return 0;}),
 					df  = tempData.repair.map(function(x,i){return x - sp.repair[i];}),
-					plt = ((cShip.hp[1] - cShip.hp[0]) > 0 ? 0.075 : 0.000 );
+					hpd = sp.hp[0] - (oShip || defaults).hp[0];
 				
 				rs[0] = -df[1];
 				rs[2] = -df[2];
@@ -135,18 +130,15 @@ Saves and loads list to and from localStorage
 					type: 'akashi' + sp.masterId,
 					data: rs
 				});
+				console.log("Akashi repaired", sp.rosterId, sp.name(), hpd, df);
 				// Reduce Consumption Counter
 				// df (delta)      = [0,5,20]
 				df.shift(); df.push(0);
-				console.log("Akashi repaired", cShip.rosterId, cShip.name(),
-					cShip.hp.reduceRight((hi, lo) => hi - lo),
-					df, df.map(rsc => Math.floor(rsc * plt)) );
 				Object.keys(pc).reverse().forEach(function(d){
 					// if the difference is not all-zero, keep going
 					if(df.every(function(x){return !x;}))
 						return;
-					var
-						rp = pc[d][1],
+					var rp = pc[d][1],
 						dt = rp.map(function(x,i){return Math.max(x,-df[i]);});
 					// if the delta is not all-zero, keep going
 					if(dt.every(function(x){return !x;}))
@@ -162,9 +154,11 @@ Saves and loads list to and from localStorage
 			// if there's still pending exped condition on queue
 			// don't remove async wait false, after that, remove port load wait
 			if(!cShip.pendingConsumption.costnull) {
-				cShip.getDefer()[1].resolve(null); // removes async wait
+				// removes async wait
+				cShip.getDefer()[1].resolve(null);
 			}
-			cShip.getDefer()[2].resolve(cShip.fuel,cShip.bull,cShip.slots.reduce(function(x,y){return x+y;})); // mark resolve wait for port
+			// mark resolve wait for port
+			cShip.getDefer()[2].resolve(cShip.fuel, cShip.bull, cShip.slots.reduce(function(x,y){return x+y;}));
 			
 			// update picture book base form info
 			if(PictureBook) {
@@ -174,25 +168,23 @@ Saves and loads list to and from localStorage
 		
 		// Mass set multiple ships
 		// [repl] -> replace flag (replace whole list, replacing clear functionality)
-		set :function(data,repl){
-			var ctr,cky,rem,kid,slf;
-			slf = this;
-			rem = Object.keys(this.list);
+		set :function(data, repl){
+			const self = this;
+			var rem = Object.keys(this.list);
 			// console.log.apply(console,["Current list"].concat(rem.map(function(x){return x.slice(1);})));
-			for(ctr in data){
+			for(const ctr in data){
 				if(!!data[ctr]){
-					cky = 'x' + data[ctr].api_id;
-					kid = rem.indexOf(cky);
+					var cky = 'x' + data[ctr].api_id;
+					var kid = rem.indexOf(cky);
 					this.add(data[ctr]);
-					if(kid>=0)
-						rem.splice(kid,1);
+					if(kid >= 0)
+						rem.splice(kid, 1);
 				}
 			}
-			if(!repl)
-				rem.splice(0);
+			if(!repl) rem.splice(0);
 			// console.log.apply(console,["Removed ship"].concat(rem.map(function(x){return x.slice(1);})));
 			rem.forEach(function(rosterId){
-				slf.remove(parseInt(rosterId.slice(1)));
+				self.remove(parseInt(rosterId.slice(1)));
 			});
 			this.save();
 		},
@@ -259,7 +251,7 @@ Saves and loads list to and from localStorage
 		clear: function(){
 			this.list = {};
 		},
-
+		
 		encoded: function() {
 			return JSON.stringify(this.list);
 		},

--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -2226,6 +2226,7 @@ Previously known as "Reactor"
 			// Other handling on item/materials obtained:
 			switch(obtainFlag){
 				case 1: // supposed to obtain use/slot item
+				case 3: // exchange type 63, obtains materials and 2 irako
 					break;
 				case 2: // supposed to obtain materials
 					break;

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -1930,12 +1930,15 @@ Used by SortieManager
 		// Ignore if not saving to DB is demanded
 		if(!ConfigManager.idbSavePvP) { return; }
 		var p = {
-			fleet: PlayerManager.fleets[KC3SortieManager.fleetSent-1].sortieJson(),
-			enemy: [], // Unused
+			fleet: PlayerManager.fleets[KC3SortieManager.fleetSent - 1].sortieJson(),
+			// Unused, included in following data
+			enemy: [],
 			data: (this.battleDay || {}),
 			yasen: (this.battleNight || {}),
 			rating: this.rating,
 			baseEXP: this.nodalXP,
+			// ID bound to PvP win count + 1, related to ledger type
+			sortie_name: KC3SortieManager.sortieName(2),
 			mvp: this.mvps,
 			time: KC3SortieManager.sortieTime
 		};

--- a/src/library/objects/Ship.js
+++ b/src/library/objects/Ship.js
@@ -660,8 +660,9 @@ KC3改 Ship Object
 		const thisShipClass = this.master().api_ctype;
 		// Explicit stats bonuses from equipment on specific ship are added to API result by server-side,
 		// To correct the 'naked stats' for these cases, have to simulate them all.
-		// A summary table: https://twitter.com/Lambda39/status/990268289866579968
-		// https://gist.github.com/andanteyk/ecd9b81d12403d841aa71e3fd76d3652
+		// Some summary tables:
+		//  * https://twitter.com/Lambda39/status/990268289866579968
+		//  * https://gist.github.com/andanteyk/ecd9b81d12403d841aa71e3fd76d3652
 		// In order to handle some complex cases,
 		// this definition table includes some functions which can not be moved to JSON file.
 		const explicitStatsBonusGears = {
@@ -680,7 +681,7 @@ KC3改 Ship Object
 						multiple: { "houg": 1 },
 					},
 					{
-						// extra aa +1, ev +2 for Haruna K2
+						// extra +1 aa, +2 ev for Haruna K2
 						ids: [151],
 						multiple: { "tyku": 1, "houk": 2 },
 						// synergy with Surface Radar
@@ -691,6 +692,7 @@ KC3改 Ship Object
 				],
 			},
 			// 35.6cm Triple Gun Mount Kai (Dazzle Camouflage)
+			// https://wikiwiki.jp/kancolle/35.6cm%E4%B8%89%E9%80%A3%E8%A3%85%E7%A0%B2%E6%94%B9%28%E3%83%80%E3%82%BA%E3%83%AB%E8%BF%B7%E5%BD%A9%E4%BB%95%E6%A7%98%29
 			"289": {
 				count: 0,
 				byShip: [
@@ -709,18 +711,19 @@ KC3改 Ship Object
 						})[api] || 0 : 0),
 					},
 					{
-						// extra aa +1 for Kongou K2
+						// extra +1 aa for Kongou K2
 						ids: [149],
 						multiple: { "tyku": 1 },
 					},
 					{
-						// extra aa +2, ev +2 for Haruna K2
+						// extra +2 aa, +2 ev for Haruna K2
 						ids: [151],
 						multiple: { "tyku": 2, "houk": 2 },
 					},
 				],
 			},
 			// 41cm Triple Gun Mount Kai Ni
+			// https://wikiwiki.jp/kancolle/41cm%E4%B8%89%E9%80%A3%E8%A3%85%E7%A0%B2%E6%94%B9%E4%BA%8C
 			"290": {
 				count: 0,
 				byClass: {
@@ -756,7 +759,7 @@ KC3改 Ship Object
 				count: 0,
 				starsDist: [],
 				byShip: {
-					// Here goes ship ID white-list:
+					// Here goes ship ID white-list instead of byClass:
 					//  Fubuki K2, Murakumo K2,
 					//  Ayanami K2, Ushio K2
 					//  Akatsuki K2, Bep (Hibiki K2)
@@ -859,13 +862,14 @@ KC3改 Ship Object
 						ids: [566, 567],
 						single: { "houg": 1 },
 					},
+					{
+						// synergy with Surface Radar for Naganami Kai Ni and Shimakaze Kai
+						ids: [543, 229],
+						callback: (api, info) => (hasSurfaceRadar ? ({
+							"houg": 1, "raig": 3, "houk": 2
+						})[api] || 0 : 0),
+					},
 				],
-				synergyCallback: (api, info) => (
-					// Synergy with Surface Radar for Naganami Kai Ni and Shimakaze Kai
-					hasSurfaceRadar && [543, 229].includes(this.masterId) ? ({
-						"houg": 1, "raig": 3, "houk": 2
-					})[api] || 0 : 0
-				),
 			},
 			// Arctic Camouflage
 			// http://wikiwiki.jp/kancolle/?%CB%CC%CA%FD%CC%C2%BA%CC%28%A1%DC%CB%CC%CA%FD%C1%F5%C8%F7%29
@@ -913,7 +917,13 @@ KC3改 Ship Object
 			if(gearInfo.count > 0) {
 				if(gearInfo.byClass) {
 					const byClass = gearInfo.byClass[thisShipClass];
-					if(byClass) addBonusToTotalIfNecessary(byClass, apiName, gearInfo);
+					if(byClass) {
+						if(Array.isArray(byClass)) {
+							byClass.forEach(c => addBonusToTotalIfNecessary(c, apiName, gearInfo));
+						} else {
+							addBonusToTotalIfNecessary(byClass, apiName, gearInfo);
+						}
+					}
 				}
 				if(gearInfo.byShip) {
 					const byShip = gearInfo.byShip;
@@ -922,9 +932,6 @@ KC3改 Ship Object
 					} else {
 						addBonusToTotalIfNecessary(byShip, apiName, gearInfo);
 					}
-				}
-				if(gearInfo.synergyCallback) {
-					total += gearInfo.synergyCallback(apiName, gearInfo);
 				}
 			}
 		});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
 	"name": "KC3改 Development",
 	"short_name": "KC3改",
 	"description": "Kantai Collection Game Viewer and Helper",
-	"version": "32.5.5",
+	"version": "32.6.0",
 	"devtools_page": "pages/devtools/init.html",
 	"options_page": "pages/settings/settings.html",
 	"icons": {

--- a/src/pages/strategy/sortielogs.js
+++ b/src/pages/strategy/sortielogs.js
@@ -505,7 +505,7 @@
 					KC3StrategyTabs.gotoTab("fleet", "history", id);
 				}
 			};
-			const parseAirRaidFunc = function(airRaid){
+			const parseAirRaidFunc = function(airRaid) {
 				if(!airRaid) return {airRaidLostKind: 0};
 				if(airRaid.api_air_base_attack) {
 					//console.debug("LB Air Raid", airRaid);
@@ -567,6 +567,25 @@
 					topAntiBomberSquadNames: topAbSquadsName
 				};
 			};
+			const showSortieLedger = function(sortieId, sortieBox) {
+				// LBAS consumptions not included, because they are bound with world id, not sortie
+				// Akashi repair not included either, belonged to its own type
+				KC3Database.con.navaloverall.where("type").equals("sortie" + sortieId).toArray(arr => {
+					const consumptions = arr.reduce((acc, o) =>
+						acc.map((v, i) => acc[i] + (o.data[i] || 0)), [0,0,0,0,0,0,0,0]);
+					if(arr.length && !consumptions.every(v => !v)) {
+						const tooltip = consumptions.map((v, i) => {
+							const icon = $("<img />").attr("src", "/assets/img/client/" +
+									["fuel.png", "ammo.png", "steel.png", "bauxite.png",
+									"ibuild.png", "bucket.png", "devmat.png", "screws.png"][i]
+								).width(13).height(13).css("margin", "-3px 2px 0 0");
+							return i < 4 || !!v ? $("<div/>").append(icon).append(v).html() : "";
+						}).join(" ");
+						$(".sortie_map", sortieBox).attr("titlealt",
+							"{0}".format(tooltip)).lazyInitTooltip();
+					}
+				});
+			};
 			$.each(sortieList, function(id, sortie){
 				const mapkey = ["m", sortie.world, sortie.mapnum].join(''),
 					mapInfo = self.maps[mapkey] || {};
@@ -589,6 +608,7 @@
 					$(".sortie_date", sortieBox).text( new Date(sortie.time*1000).format("mmm d", false, self.locale) );
 					$(".sortie_date", sortieBox).attr("title", new Date(sortie.time*1000).format("yyyy-mm-dd HH:MM:ss") );
 					$(".sortie_map", sortieBox).text( (sortie.world >= 10 ? "E" : sortie.world) + "-" + sortie.mapnum );
+					showSortieLedger(sortie.id, sortieBox);
 					$(".button_tomanager", sortieBox).data("id", sortie.id)
 						.on("click", viewFleetAtManagerFunc);
 					var edges = [];

--- a/src/pages/strategy/tabs/badge/badge.js
+++ b/src/pages/strategy/tabs/badge/badge.js
@@ -54,7 +54,7 @@
 				if (v === 'shiplist') {
 					mkText("Use data from the current ship list. Please note that ships that you had before but somehow scrapped, modfodded, or sunk in favor of more ship slots will not show up. If you want to show everything that you had so far, even in the past, use the Picture Book option.");
 				} else {
-					mkText("Use data from the in-game picture book / album / kandex / library. This will export ships you had even in the past which had been lost, probably in favor of more ship slots. This however, will require you to visit the MAIN pages on the IN-GAME picture book for us to collect data. You just need to visit the FIVE MAIN pages (not the sub-pages). Also, you DO NOT need to wait for all images to load.");
+					mkText("Use data from the in-game picture book / album / kandex / library. This will export ships you had even in the past which had been lost, probably in favor of more ship slots. This however, will require you to visit the MAIN pages on the IN-GAME picture book for us to collect data. You just need to visit the 6 MAIN pages (not the sub-pages). Also, you DO NOT need to wait for all images to load.");
 
 					mkText("Status:");
 					const pb = PictureBook.load();

--- a/src/pages/strategy/tabs/pvp/pvp.js
+++ b/src/pages/strategy/tabs/pvp/pvp.js
@@ -107,8 +107,25 @@
 		cloneBattleBox :function(pvpBattle){
 			//console.debug("PvP battle record:", pvpBattle);
 			const self = this;
-			
 			const recordBox = $(".tab_pvp .factory .pvp_record").clone();
+			const showPvpLedger = function(sortieName) {
+				KC3Database.con.navaloverall.where("type").equals(sortieName).toArray(arr => {
+					const consumptions = arr.reduce((acc, o) =>
+						acc.map((v, i) => acc[i] + (o.data[i] || 0)), [0,0,0,0,0,0,0,0]);
+					if(arr.length && !consumptions.every(v => !v)) {
+						const tooltip = consumptions.map((v, i) => {
+							const icon = $("<img />").attr("src", "/assets/img/client/" +
+									["fuel.png", "ammo.png", "steel.png", "bauxite.png",
+									"ibuild.png", "bucket.png", "devmat.png", "screws.png"][i]
+								).width(13).height(13).css("margin", "-3px 2px 0 0");
+							return i < 4 || !!v ? $("<div/>").append(icon).append(v).html() : "";
+						}).join(" ");
+						const oldTooltip = $(".pvp_result img", recordBox).attr("title");
+						$(".pvp_result img", recordBox).removeAttr("title").attr("titlealt",
+							"{0}<br/>{1}".format(oldTooltip, tooltip)).lazyInitTooltip();
+					}
+				});
+			};
 			
 			// Basic battle info
 			$(".pvp_id", recordBox).text(pvpBattle.id);
@@ -120,9 +137,10 @@
 				$(".pvp_date", recordBox).text("Unknown");
 			}
 			$(".pvp_result img", recordBox)
-				.attr("src", "../../assets/img/client/ratings/"+pvpBattle.rating+".png")
+				.attr("src", `/assets/img/client/ratings/${pvpBattle.rating}.png`)
 				.attr("title", "Base EXP " + pvpBattle.baseEXP );
 			$(".pvp_dl", recordBox).data("id", pvpBattle.id);
+			if (pvpBattle.sortie_name) showPvpLedger(pvpBattle.sortie_name);
 			
 			// Player fleet
 			$.each(pvpBattle.fleet, function(index, curShip){

--- a/update
+++ b/update
@@ -1,7 +1,7 @@
 {
-	"version" : "32.5.5",
+	"version" : "32.6.0",
 	"pr" : "https://github.com/KC3Kai/KC3Kai/pulls?q=label%3Atype%3Arelease%20",
-	"time" : "Wed, 30 May 2018 12:00:00 +0900",
+	"time" : "Fri, 1 June 2018 19:00:00 +0900",
 	"maintenance_start": "Tue, 15 May 2018 11:00:00 +0900",
 	"maintenance_end": "Tue, 15 May 2018 22:20:00 +0900"
 }


### PR DESCRIPTION
### ⚓️ Features & Enhancements

* Hovering over the Sortie ID in the Sortie History will now show you how many resources were used in that sortie
  * **NOTE:** LBAS consumption and Akashi repairs are not counted
  * Resource amounts are not updated real time but will update when you push the resupply button
  * Resources gained from the sortie is counted towards the final resource total
  * Old sortie records should work just fine however PVP records will only start showing resources used after this update

### ⚓️ Fixes & Adjustments

* Minor back-end changes