### PR TITLE
Air raid defense shotdown prelim calculation

### DIFF
--- a/src/library/objects/LandBase.js
+++ b/src/library/objects/LandBase.js
@@ -122,5 +122,43 @@
 		}
 		return returnObj;
 	};
+
+	// Prelim air defense formula from https://kancolle.wikia.com/wiki/Land_Base_Aerial_Support#Enemy_Raid_2
+	KC3LandBase.prototype.shotdownRatio = function(dispSeiku = 2){
+		const airStateMod = [6, 10, 8, 4, 1][dispSeiku];
+		let minSlotShotdown = [],
+			maxSlotShotdown = [],
+			formattedShotdown = [];
+
+		// Slot-based matching
+		$.each(this.planes, function(i, p) {
+			let minShotdown = 0,
+				maxShotdown = 0;
+			
+			if(p.api_slotid > 0 && p.api_state === 1){
+				const interceptStat = KC3GearManager.get(p.api_slotid).master().api_houk || 0;
+				const abStat = KC3GearManager.get(p.api_slotid).master().api_houm || 0;
+				minShotdown = 6.5 * airStateMod + 3.5 * (abStat + airStateMod * Math.min(interceptStat, 1));
+				// Exclusive to the upper bound
+				maxShotdown = minShotdown + 3.5 * (airStateMod + abStat - 1);
+			}
+
+			// If there is no plane, then shotdown depends on air state
+			// Same formula still applies
+			else {
+				minShotdown = 6.5 * airStateMod;
+				maxShotdown = minShotdown + 3.5 * (airStateMod - 1);
+			}
+			minSlotShotdown.push(minShotdown/100);
+			maxSlotShotdown.push(maxShotdown/100);
+			formattedShotdown.push(minShotdown + "% ~ " + maxShotdown + "%");
+		});
+
+		return {
+			minSlotShotdown: minSlotShotdown,
+			maxSlotShotdown: maxSlotShotdown,
+			formattedShotdown: formattedShotdown,
+		};
+	};
 	
 })();

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -1936,6 +1936,11 @@
 					(lb1, lb2) => lb2.map - lb1.map || lb1.rid - lb2.rid
 				);
 				$.each(sortedBases, function(i, baseInfo){
+					let slotShotdown = [];
+					if (baseInfo.action === 2){
+						const slotDefense = baseInfo.shotdownRatio();
+						slotShotdown = slotDefense.formattedShotdown;
+					}	
 					if (baseInfo.rid != -1) {
 						console.debug("LandBase", i, baseInfo);
 						const baseBox = $("#factory .airbase").clone();
@@ -1948,7 +1953,8 @@
 							KC3Meta.term("LandBaseActionDefend"),
 							KC3Meta.term("LandBaseActionRetreat"),
 							KC3Meta.term("LandBaseActionRest")
-						][baseInfo.action]);
+						][baseInfo.action]).attr("title", KC3Meta.term(baseInfo.action === 2 ? "LandBaseDefenseShotdown" : "").format(slotShotdown))
+						.lazyInitTooltip();
 						
 						const shipObj = new KC3Ship();
 						// simulate 1 land-base as a carrier, ensure it's not a dummy ship


### PR DESCRIPTION
Added preliminary calculation for land base defense in air raid from https://kancolle.wikia.com/wiki/Land_Base_Aerial_Support#Enemy_Raid_2
Added mouseover tooltip to display slot shotdown numbers when land base is set to defense
![image](https://user-images.githubusercontent.com/26541502/42917002-42cb7b9e-8b3a-11e8-93a2-bdafacdb3c9e.png)

AS is used rather than AS+ since most event situation is either AS or AP for perfect defense
"LandBaseDefenseShotdown" : "Shotdown under AS\nSlot 1: {0}\nSlot 2: {1}\nSlot 3: {2}\nSlot 4: {3}",
