### PR TITLE
Release 32.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "KC3Kai",
-  "version": "32.7.4",
+  "version": "32.8.0",
   "description": "Kantai Collection Game Viewer and Tools",
   "repository": {
     "type": "git",

--- a/src/data/developers.json
+++ b/src/data/developers.json
@@ -583,6 +583,15 @@
 				"links" : {
 					"gh": "https://github.com/TrickLin"
 				}
+			},
+			{
+				"name": "RandomGuyB5",
+				"avatar" : "https://avatars1.githubusercontent.com/u/40309140?s=460&v=4",
+				"desc" : "Deutsch",
+				"active": 1,
+				"links" : {
+					"gh" :"https://github.com/RandomGuyB5"
+				}
 			}
 		],
 		"AboutForkContributors": [
@@ -696,15 +705,6 @@
 				"active": 1,
 				"links" : {
 					"gh": "https://github.com/flixwito"
-				}
-			},
-			{
-				"name": "RandomGuyB5",
-				"avatar" : "https://avatars1.githubusercontent.com/u/40309140?s=460&v=4",
-				"desc" : "Deutsch",
-				"active": 1,
-				"links" : {
-					"gh" :"https://github.com/RandomGuyB5"
 				}
 			},
 			{

--- a/src/library/modules/BattlePrediction.js
+++ b/src/library/modules/BattlePrediction.js
@@ -71,6 +71,18 @@
     );
   };
 
+  BP.predictRankAndDamageGauge = (apiName, battleData, battleResult) => {
+    const { parseStartJson, normalizeFleets, getRankPredictor, getDamageGauge } = KC3BattlePrediction.rank;
+
+    const initialFleets = normalizeFleets(parseStartJson(battleData), battleData),
+      resultFleets = normalizeFleets(battleResult, battleData);
+
+    return [
+      getRankPredictor(apiName).predict(initialFleets, resultFleets),
+      getDamageGauge(initialFleets, resultFleets)
+    ];
+  };
+
   BP.predictMvp = (dayResult, nightResult) => {
     const { combineResults, getHighestDamage } = KC3BattlePrediction.mvp;
 

--- a/src/library/modules/BattlePrediction/BattlePrediction.js
+++ b/src/library/modules/BattlePrediction/BattlePrediction.js
@@ -71,6 +71,18 @@
     );
   };
 
+  BP.predictRankAndDamageGauge = (apiName, battleData, battleResult) => {
+    const { parseStartJson, normalizeFleets, getRankPredictor, getDamageGauge } = KC3BattlePrediction.rank;
+
+    const initialFleets = normalizeFleets(parseStartJson(battleData), battleData),
+      resultFleets = normalizeFleets(battleResult, battleData);
+
+    return [
+      getRankPredictor(apiName).predict(initialFleets, resultFleets),
+      getDamageGauge(initialFleets, resultFleets)
+    ];
+  };
+
   BP.predictMvp = (dayResult, nightResult) => {
     const { combineResults, getHighestDamage } = KC3BattlePrediction.mvp;
 

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -551,9 +551,11 @@ Used by SortieManager
 			}
 
 			if (ConfigManager.info_btrank) {
-				this.predictedRank = KC3BattlePrediction.predictRank(battleData.api_name, this.battleNight || battleData, this.predictedFleetsDay);
+				[this.predictedRank, this.predictedDamageGauge] = KC3BattlePrediction.predictRankAndDamageGauge(
+					battleData.api_name, this.battleNight || battleData, this.predictedFleetsDay
+				);
 				if (KC3Node.debugPrediction()) {
-					console.debug(`Node ${this.letter} predicted rank`, this.predictedRank, this.sortie);
+					console.debug(`Node ${this.letter} predicted rank`, this.predictedRank, this.predictedDamageGauge, this.sortie);
 				}
 				
 				const mvpResult = KC3BattlePrediction.predictMvp(this.predictedFleetsDay, this.predictedFleetsNight);
@@ -813,9 +815,11 @@ Used by SortieManager
 			}
 
 			if (ConfigManager.info_btrank) {
-				this.predictedRankNight = KC3BattlePrediction.predictRank(nightData.api_name, this.battleDay || nightData, this.predictedFleetsNight);
+				[this.predictedRankNight, this.predictedDamageGaugeNight] = KC3BattlePrediction.predictRankAndDamageGauge(
+					nightData.api_name, this.battleDay || nightData, this.predictedFleetsNight
+				);
 				if (KC3Node.debugPrediction()) {
-					console.debug(`Node ${this.letter} predicted yasen rank`, this.predictedRankNight);
+					console.debug(`Node ${this.letter} predicted yasen rank`, this.predictedRankNight, this.predictedDamageGaugeNight);
 				}
 				
 				const mvpResult = KC3BattlePrediction.predictMvp(this.predictedFleetsDay, this.predictedFleetsNight);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
 	"name": "KC3改 Development",
 	"short_name": "KC3改",
 	"description": "Kantai Collection Game Viewer and Helper",
-	"version": "32.7.4",
+	"version": "32.8.0",
 	"devtools_page": "pages/devtools/init.html",
 	"options_page": "pages/settings/settings.html",
 	"icons": {

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -2741,11 +2741,12 @@
 				$(".module.activity .battle_rating img").css("opacity", 0.5)
 					.attr("src", `/assets/img/client/ratings/${rankLetter}.png`);
 				const dmgGauge = thisNode.predictedDamageGauge || thisNode.predictedDamageGaugeNight || {};
-				$(".module.activity .battle_rating").attr("title", "{0}\n{1}%{3}{2}%".format(
+				$(".module.activity .battle_rating").attr("title", "{0}\n{1}".format(
 					KC3Meta.term("BattleRating"),
-					dmgGauge.enemy  === undefined ? "?" : dmgGauge.enemy,
-					dmgGauge.player === undefined ? "?" : dmgGauge.player,
-					KC3Meta.term("BattleContactVs")
+					KC3Meta.term("BattleDamageGauges").format(
+						dmgGauge.enemy  === undefined ? "?" : dmgGauge.enemy,
+						dmgGauge.player === undefined ? "?" : dmgGauge.player
+					)
 				)).lazyInitTooltip();
 			}
 
@@ -2830,11 +2831,12 @@
 				$(".module.activity .battle_rating img").css("opacity", 0.5)
 					.attr("src", `/assets/img/client/ratings/${thisNode.predictedRankNight}.png`);
 				const dmgGauge = thisNode.predictedDamageGaugeNight || {};
-				$(".module.activity .battle_rating").attr("title", "{0}\n{1}%{3}{2}%".format(
+				$(".module.activity .battle_rating").attr("title", "{0}\n{1}".format(
 					KC3Meta.term("BattleRating"),
-					dmgGauge.enemy  === undefined ? "?" : dmgGauge.enemy,
-					dmgGauge.player === undefined ? "?" : dmgGauge.player,
-					KC3Meta.term("BattleContactVs")
+					KC3Meta.term("BattleDamageGauges").format(
+						dmgGauge.enemy  === undefined ? "?" : dmgGauge.enemy,
+						dmgGauge.player === undefined ? "?" : dmgGauge.player
+					)
 				)).lazyInitTooltip();
 			}
 
@@ -3267,11 +3269,12 @@
 				$(".module.activity .battle_rating img").css("opacity", 0.5)
 					.attr("src", `/assets/img/client/ratings/${thisPvP.predictedRank}.png`);
 				const dmgGauge = thisPvP.predictedDamageGauge || {};
-				$(".module.activity .battle_rating").attr("title", "{0}\n{1}%{3:vs}{2}%".format(
+				$(".module.activity .battle_rating").attr("title", "{0}\n{1}".format(
 					KC3Meta.term("BattleRating"),
-					dmgGauge.enemy  === undefined ? "?" : dmgGauge.enemy,
-					dmgGauge.player === undefined ? "?" : dmgGauge.player,
-					KC3Meta.term("BattleContactVs")
+					KC3Meta.term("BattleDamageGauges").format(
+						dmgGauge.enemy  === undefined ? "?" : dmgGauge.enemy,
+						dmgGauge.player === undefined ? "?" : dmgGauge.player
+					)
 				)).lazyInitTooltip();
 			}
 

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -925,7 +925,7 @@
 		$(".module.activity .battle_night img").attr("src", "../../../../assets/img/ui/dark_yasen.png");
 		$(".module.activity .battle_night").attr("title", KC3Meta.term("BattleNightNeeded")).lazyInitTooltip();
 		$(".module.activity .battle_rating img").attr("src", "../../../../assets/img/ui/dark_rating.png").css("opacity", "");
-		$(".module.activity .battle_rating").lazyInitTooltip();
+		$(".module.activity .battle_rating").attr("title", KC3Meta.term("BattleRating")).lazyInitTooltip();
 		$(".module.activity .battle_drop img").attr("src", "../../../../assets/img/ui/dark_shipdrop.png");
 		$(".module.activity .battle_drop").removeData("masterId").off("dblclick").removeClass("new_ship");
 		$(".module.activity .battle_drop").attr("title", "").lazyInitTooltip();
@@ -2737,9 +2737,16 @@
 
 			// Show predicted battle rank
 			if(thisNode.predictedRank || thisNode.predictedRankNight){
-				$(".module.activity .battle_rating img").attr("src",
-				"../../../../assets/img/client/ratings/"+(thisNode.predictedRank||thisNode.predictedRankNight)+".png")
-				.css("opacity", 0.5);
+				const rankLetter = thisNode.predictedRank || thisNode.predictedRankNight;
+				$(".module.activity .battle_rating img").css("opacity", 0.5)
+					.attr("src", `/assets/img/client/ratings/${rankLetter}.png`);
+				const dmgGauge = thisNode.predictedDamageGauge || thisNode.predictedDamageGaugeNight || {};
+				$(".module.activity .battle_rating").attr("title", "{0}\n{1}%{3}{2}%".format(
+					KC3Meta.term("BattleRating"),
+					dmgGauge.enemy  === undefined ? "?" : dmgGauge.enemy,
+					dmgGauge.player === undefined ? "?" : dmgGauge.player,
+					KC3Meta.term("BattleContactVs")
+				)).lazyInitTooltip();
 			}
 
 			// Show battle activity if `info_compass` enabled, `info_battle` only affects enemy HP prediction
@@ -2820,9 +2827,15 @@
 			}
 
 			if(thisNode.predictedRankNight){
-				$(".module.activity .battle_rating img").attr("src",
-				"../../../../assets/img/client/ratings/"+thisNode.predictedRankNight+".png")
-				.css("opacity", 0.5);
+				$(".module.activity .battle_rating img").css("opacity", 0.5)
+					.attr("src", `/assets/img/client/ratings/${thisNode.predictedRankNight}.png`);
+				const dmgGauge = thisNode.predictedDamageGaugeNight || {};
+				$(".module.activity .battle_rating").attr("title", "{0}\n{1}%{3}{2}%".format(
+					KC3Meta.term("BattleRating"),
+					dmgGauge.enemy  === undefined ? "?" : dmgGauge.enemy,
+					dmgGauge.player === undefined ? "?" : dmgGauge.player,
+					KC3Meta.term("BattleContactVs")
+				)).lazyInitTooltip();
 			}
 
 			this.Fleet();
@@ -3251,9 +3264,15 @@
 
 			// Show predicted battle rank
 			if(thisPvP.predictedRank){
-				$(".module.activity .battle_rating img").attr("src",
-				"../../../../assets/img/client/ratings/"+thisPvP.predictedRank+".png")
-				.css("opacity", 0.5);
+				$(".module.activity .battle_rating img").css("opacity", 0.5)
+					.attr("src", `/assets/img/client/ratings/${thisPvP.predictedRank}.png`);
+				const dmgGauge = thisPvP.predictedDamageGauge || {};
+				$(".module.activity .battle_rating").attr("title", "{0}\n{1}%{3:vs}{2}%".format(
+					KC3Meta.term("BattleRating"),
+					dmgGauge.enemy  === undefined ? "?" : dmgGauge.enemy,
+					dmgGauge.player === undefined ? "?" : dmgGauge.player,
+					KC3Meta.term("BattleContactVs")
+				)).lazyInitTooltip();
 			}
 
 			// Battle conditions
@@ -3359,7 +3378,7 @@
 		PvPEnd: function(data){
 			var thisPvP = KC3SortieManager.currentNode();
 			$(".module.activity .battle_rating img")
-				.attr("src", "../../../../assets/img/client/ratings/"+thisPvP.rating+".png")
+				.attr("src", `/assets/img/client/ratings/${thisPvP.rating}.png`)
 				.css("opacity", 1);
 			updateHQEXPGained($(".admiral_lvnext"), KC3SortieManager.hqExpGained);
 			this.Fleet();

--- a/update
+++ b/update
@@ -1,7 +1,7 @@
 {
-	"version" : "32.7.4",
+	"version" : "32.8.0",
 	"pr" : "https://github.com/KC3Kai/KC3Kai/pulls?q=label%3Atype%3Arelease%20",
-	"time" : "Sun, 12 August 2018 19:00:00 +0900",
+	"time" : "Tue, 14 August 2018 11:55:00 +0900",
 	"maintenance_start": "Wed, 15 August 2018 11:55:00 +0900",
 	"maintenance_end": "Fri, 17 August 2018 18:00:00 +0900"
 }


### PR DESCRIPTION
### ⚓️ Important Announcement 

* Please be advised that KanColle will be Shut Down for 2 Days for the KanColle Phase 2 (HTML5) [Block-1] Maintenance & Updates from Wednesday, August 15th from 11:55 AM JST and is expected to end on Friday, August 17th at 18:00 JST
* KC3改 will most likely be broken after this update, however, we will work as quickly as we can to get it working again after the maintenance, we request you have patience
* Also don't forget to send your long expeditions before the start of the Maintenance

### ⚓️ Fixes & Adjustments

* Mousing over the battle prediction rank result on the panel will now show combined damage gauges

### ⚓️ Translations 

* `de` items
* `de` quests
* `de` terms
* `en` quests
* `en` terms
* `jp` quests
* `jp` quotes
* `jp` terms
* `scn` terms
