### PR TITLE
Add baseExp for PoiDB

### DIFF
--- a/src/library/modules/PoiDBSubmission.js
+++ b/src/library/modules/PoiDBSubmission.js
@@ -343,6 +343,7 @@
 			dropShipData.enemy = response.api_enemy_info.api_deck_name;
 			dropShipData.mapLv = this.mapInfo[dropShipData.mapId] || 0;
 			dropShipData.rank = response.api_win_rank;
+			dropShipData.baseExp = response.api_get_base_exp;
 			dropShipData.teitokuLv = PlayerManager.hq.level;
 
 			dropShipData.itemId = (typeof response.api_get_useitem === "undefined")


### PR DESCRIPTION
Schema was [updated](https://github.com/poooi/poi-server/blob/97fe091b753d818ac5af01d49fb7ae89598a0f89/models/report/drop-ship.es#L17) to support `api_get_base_exp`.