### PR TITLE
Update stats icons of ship & equipment

### DIFF
--- a/src/library/objects/Gear.js
+++ b/src/library/objects/Gear.js
@@ -1534,17 +1534,17 @@ KC3改 Equipment Object
 		// Some stats only shown at Equipment Library, omitted here.
 		const planeStats = ["or", "kk"];
 		$.each([
-			["hp", "taik"],
-			["fp", "houg"],
-			["ar", "souk"],
-			["tp", "raig"],
-			["dv", "baku"],
-			["aa", "tyku"],
-			["as", "tais"],
-			["ht", "houm"],
-			["ev", "houk"],
-			["ls", "saku"],
-			["rn", "leng"],
+			["hp_p2", "taik"],
+			["fp_p2", "houg"],
+			["ar_p2", "souk"],
+			["tp_p2", "raig"],
+			["dv_p2", "baku"],
+			["aa_p2", "tyku"],
+			["as_p2", "tais"],
+			["ht_p2", "houm"],
+			["ev_p2", "houk"],
+			["ls_p2", "saku"],
+			["rn_p2", "leng"],
 			["or", "distance"]
 		], function(index, sdata) {
 			const statBox = $('<div><img class="icon stats_icon_img"/> <span class="value"></span>&nbsp;</div>');
@@ -1556,8 +1556,8 @@ KC3改 Equipment Object
 				)
 			) { // Path of image should be inputted, maybe
 				$(".icon", statBox).attr("src", "/assets/img/stats/" + sdata[0] + ".png");
-				$(".icon", statBox).width(13).height(13).css("margin-top", "-3px");
-				if(sdata[0] === "rn") {
+				$(".icon", statBox).width(15).height(13).css("margin-top", "-3px");
+				if(sdata[0] === "rn_p2") {
 					$(".value", statBox).text(["?","S","M","L","VL","XL"][gearData["api_" + sdata[1]]] || "?");
 				} else {
 					$(".value", statBox).text(gearData["api_" + sdata[1]]);
@@ -1577,7 +1577,7 @@ KC3改 Equipment Object
 		const airBox = $('<div><img class="icon stats_icon_img"/> <span class="value"></span></div>');
 		airBox.css("font-size", "11px");
 		$(".icon", airBox).attr("src", "/assets/img/stats/if.png");
-		$(".icon", airBox).width(13).height(13).css("margin-top", "-3px");
+		$(".icon", airBox).width(15).height(13).css("margin-top", "-3px");
 		let pattern, value;
 		switch(ConfigManager.air_formula) {
 			case 2:
@@ -1597,7 +1597,7 @@ KC3改 Equipment Object
 		if(shipOrLb instanceof KC3LandBase) {
 			const interceptSpan = $('<div><img class="icon stats_icon_img"/> <span class="value"></span></div>');
 			$(".icon", interceptSpan).attr("src", "/assets/img/stats/ib.png");
-			$(".icon", interceptSpan).width(13).height(13).css("margin-top", "-3px");
+			$(".icon", interceptSpan).width(15).height(13).css("margin-top", "-3px");
 			$(".value", interceptSpan).text(gearObj.interceptionPower(slotSize));
 			airBox.append("&emsp;").append(interceptSpan.html());
 		}
@@ -1639,7 +1639,7 @@ KC3改 Equipment Object
 			const powBox = $('<div><img class="icon stats_icon_img"/> <span class="value"></span></div>');
 			powBox.css("font-size", "11px");
 			$(".icon", powBox).attr("src", "/assets/img/stats/" + (isLbaa ? "rk" : "kk") + ".png");
-			$(".icon", powBox).width(13).height(13).css("margin-top", "-3px");
+			$(".icon", powBox).width(15).height(13).css("margin-top", "-3px");
 			$(".value", powBox).text("{0}({1})".format(onNormal, onCritical));
 			tooltipTitle.append("<br/>").append(powBox.html());
 		} else if(shipOrLb instanceof KC3Ship) {
@@ -1662,7 +1662,7 @@ KC3改 Equipment Object
 			const powBox = $('<div><img class="icon stats_icon_img"/> <span class="value"></span></div>');
 			powBox.css("font-size", "11px");
 			$(".icon", powBox).attr("src", "/assets/img/stats/" + (isRange ? "rk" : "kk") + ".png");
-			$(".icon", powBox).width(13).height(13).css("margin-top", "-3px");
+			$(".icon", powBox).width(15).height(13).css("margin-top", "-3px");
 			let valueBox = $('<div><span class="vl"></span>(<span class="vlc"></span>)</div>');
 			$(".vl", valueBox).text(onNormal[0]);
 			if(isOverCap[0]) $(".vl", valueBox).addClass("power_capped");

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -1459,16 +1459,16 @@ Used by SortieManager
 					"{0} /{1}".format(currentHp === 0 || currentHp ? currentHp : "?", maxHp || "?")
 			);
 			if(Array.isArray(eParam)){
-				tooltip += $("<img />").attr("src", "/assets/img/client/mod_fp.png")
+				tooltip += $("<img />").attr("src", "/assets/img/client/mod_fp_p2.png")
 					.css(iconStyles).prop("outerHTML");
 				tooltip += "{0}: {1}\n".format(KC3Meta.term("ShipFire"), eParam[0]);
-				tooltip += $("<img />").attr("src", "/assets/img/client/mod_tp.png")
+				tooltip += $("<img />").attr("src", "/assets/img/client/mod_tp_p2.png")
 					.css(iconStyles).prop("outerHTML");
 				tooltip += "{0}: {1}\n".format(KC3Meta.term("ShipTorpedo"), eParam[1]);
-				tooltip += $("<img />").attr("src", "/assets/img/client/mod_aa.png")
+				tooltip += $("<img />").attr("src", "/assets/img/client/mod_aa_p2.png")
 					.css(iconStyles).prop("outerHTML");
 				tooltip += "{0}: {1}\n".format(KC3Meta.term("ShipAntiAir"), eParam[2]);
-				tooltip += $("<img />").attr("src", "/assets/img/client/mod_ar.png")
+				tooltip += $("<img />").attr("src", "/assets/img/client/mod_ar_p2.png")
 					.css(iconStyles).prop("outerHTML");
 				tooltip += "{0}: {1}".format(KC3Meta.term("ShipArmor"), eParam[3]);
 			}

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -1234,18 +1234,18 @@ ABYSS FLEET
 	float:left;
 }
 .module.activity .activity_crafting .equipStatIcon {
-	width:20px;
+	width:22px;
 	height:20px;
 	float:left;
-	margin:0px 5px 0px 0px;
+	margin:0px 3px 0px 0px;
 	background:#fff;
 	border-radius:10px;
-
+	text-align:center;
 }
 .module.activity .activity_crafting .equipStatIcon img {
-	width:16px;
+	width:18px;
 	height:16px;
-	margin:2px;
+	margin:2px 2px;
 	vertical-align:top;
 }
 .module.activity .activity_crafting .equipStatText {
@@ -4186,8 +4186,8 @@ ABYSS FLEET
 	border-bottom-color:#fcfcfc;
 }
 .ui-tooltip-content .ship_face_tooltip .stat_icon img {
-	width:15px;
-	height:15px;
+	width:19px;
+	height:16px;
 	margin-top:-2px;
 }
 .ui-tooltip-content .ship_face_tooltip .stat_name {

--- a/src/pages/devtools/themes/natsuiro/natsuiro.html
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.html
@@ -683,28 +683,28 @@
 						</div>
 						<div class="mod_result_stats">
 							<div class="mod_result_stat mod_result_fp">
-								<div class="mod_result_icon"><img src="/assets/img/client/mod_fp.png"/></div>
+								<div class="mod_result_icon"><img src="/assets/img/client/mod_fp_p2.png"/></div>
 								<div class="mod_result_old"></div>
 								<div class="mod_result_plus">+<span class="value"></span></div>
 								<div class="mod_result_left"><span class="value"></span></div>
 								<div class="clear"></div>
 							</div>
 							<div class="mod_result_stat mod_result_tp">
-								<div class="mod_result_icon"><img src="/assets/img/client/mod_tp.png"/></div>
+								<div class="mod_result_icon"><img src="/assets/img/client/mod_tp_p2.png"/></div>
 								<div class="mod_result_old"></div>
 								<div class="mod_result_plus">+<span class="value"></span></div>
 								<div class="mod_result_left"><span class="value"></span></div>
 								<div class="clear"></div>
 							</div>
 							<div class="mod_result_stat mod_result_aa">
-								<div class="mod_result_icon"><img src="/assets/img/client/mod_aa.png"/></div>
+								<div class="mod_result_icon"><img src="/assets/img/client/mod_aa_p2.png"/></div>
 								<div class="mod_result_old"></div>
 								<div class="mod_result_plus">+<span class="value"></span></div>
 								<div class="mod_result_left"><span class="value"></span></div>
 								<div class="clear"></div>
 							</div>
 							<div class="mod_result_stat mod_result_ar">
-								<div class="mod_result_icon"><img src="/assets/img/client/mod_ar.png"/></div>
+								<div class="mod_result_icon"><img src="/assets/img/client/mod_ar_p2.png"/></div>
 								<div class="mod_result_old"></div>
 								<div class="mod_result_plus">+<span class="value"></span></div>
 								<div class="mod_result_left"><span class="value"></span></div>
@@ -1374,31 +1374,31 @@
 						<div class="ship_hp"><span class="hp"></span> /<span class="mhp"></span></div>
 					</div>
 					<div class="ship_stats_col">
-						<div class="stat_icon"><img src="../../../../assets/img/stats/hp.png"/><span class="stat_name i18n">ShipHp</span></div>
+						<div class="stat_icon"><img src="../../../../assets/img/stats/hp_p2.png"/><span class="stat_name i18n">ShipHp</span></div>
 						<div class="stat_value stat_hp"><span class="current"></span><span class="mod"></span></div>
-						<div class="stat_icon"><img src="../../../../assets/img/stats/ar.png"/><span class="stat_name i18n">ShipArmor</span></div>
+						<div class="stat_icon"><img src="../../../../assets/img/stats/ar_p2.png"/><span class="stat_name i18n">ShipArmor</span></div>
 						<div class="stat_value stat_ar"><span class="equip"></span><span class="current"></span><span class="mod"></span></div>
-						<div class="stat_icon"><img src="../../../../assets/img/stats/ev.png"/><span class="stat_name i18n">ShipEvasion</span></div>
+						<div class="stat_icon"><img src="../../../../assets/img/stats/ev_p2.png"/><span class="stat_name i18n">ShipEvasion</span></div>
 						<div class="stat_value stat_ev"><span class="equip"></span><span class="current"></span><span class="level"></span></div>
-						<div class="stat_icon"><img src="../../../../assets/img/stats/ac.png"/><span class="stat_name i18n">ShipCarry</span></div>
+						<div class="stat_icon"><img src="../../../../assets/img/stats/ac_p2.png"/><span class="stat_name i18n">ShipCarry</span></div>
 						<div class="stat_value stat_ac"><span class="current"></span></div>
-						<div class="stat_icon"><img src="../../../../assets/img/stats/sp.png"/><span class="stat_name i18n">ShipSpeed</span></div>
+						<div class="stat_icon"><img src="../../../../assets/img/stats/sp_p2.png"/><span class="stat_name i18n">ShipSpeed</span></div>
 						<div class="stat_value stat_sp text_center"></div>
-						<div class="stat_icon"><img src="../../../../assets/img/stats/rn.png"/><span class="stat_name i18n">ShipLength</span></div>
+						<div class="stat_icon"><img src="../../../../assets/img/stats/rn_p2.png"/><span class="stat_name i18n">ShipLength</span></div>
 						<div class="stat_value stat_rn text_center"></div>
 					</div>
 					<div class="ship_stats_col">
-						<div class="stat_icon"><img src="../../../../assets/img/stats/fp.png"/><span class="stat_name i18n">ShipFire</span></div>
+						<div class="stat_icon"><img src="../../../../assets/img/stats/fp_p2.png"/><span class="stat_name i18n">ShipFire</span></div>
 						<div class="stat_value stat_fp"><span class="equip"></span><span class="current"></span><span class="mod"></span></div>
-						<div class="stat_icon"><img src="../../../../assets/img/stats/tp.png"/><span class="stat_name i18n">ShipTorpedo</span></div>
+						<div class="stat_icon"><img src="../../../../assets/img/stats/tp_p2.png"/><span class="stat_name i18n">ShipTorpedo</span></div>
 						<div class="stat_value stat_tp"><span class="equip"></span><span class="current"></span><span class="mod"></span></div>
-						<div class="stat_icon"><img src="../../../../assets/img/stats/aa.png"/><span class="stat_name i18n">ShipAntiAir</span></div>
+						<div class="stat_icon"><img src="../../../../assets/img/stats/aa_p2.png"/><span class="stat_name i18n">ShipAntiAir</span></div>
 						<div class="stat_value stat_aa"><span class="equip"></span><span class="current"></span><span class="mod"></span></div>
-						<div class="stat_icon"><img src="../../../../assets/img/stats/as.png"/><span class="stat_name i18n">ShipAsw</span></div>
+						<div class="stat_icon"><img src="../../../../assets/img/stats/as_p2.png"/><span class="stat_name i18n">ShipAsw</span></div>
 						<div class="stat_value stat_as"><span class="equip"></span><span class="current"></span><span class="level"></span><span class="mod"></span></div>
-						<div class="stat_icon"><img src="../../../../assets/img/stats/ls.png"/><span class="stat_name i18n">ShipLos</span></div>
+						<div class="stat_icon"><img src="../../../../assets/img/stats/ls_p2.png"/><span class="stat_name i18n">ShipLos</span></div>
 						<div class="stat_value stat_ls"><span class="equip"></span><span class="current"></span><span class="level"></span></div>
-						<div class="stat_icon"><img src="../../../../assets/img/stats/lk.png"/><span class="stat_name i18n">ShipLuck</span></div>
+						<div class="stat_icon"><img src="../../../../assets/img/stats/lk_p2.png"/><span class="stat_name i18n">ShipLuck</span></div>
 						<div class="stat_value stat_lk"><span class="equip"></span><span class="current"></span><span class="luck"></span></div>
 					</div>
 					<div class="ship_stats_row"><div class="stat_value stat_wide text_left">

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -2973,6 +2973,14 @@
 					$(".activity_crafting .equipNote").html( KC3Meta.term("CraftEquipNoteExists").format(countExisting) );
 				}
 
+				const CraftGearStats = (itemMst, statProperty, code) => {
+					if(parseInt(itemMst["api_"+statProperty], 10) !== 0){
+						const thisStatBox = $("#factory .equipStat").clone()
+							.appendTo(".module.activity .activity_crafting .equipStats");
+						$("img", thisStatBox).attr("src", `/assets/img/stats/${code}_p2.png`);
+						$(".equipStatText", thisStatBox).text( itemMst["api_"+statProperty] );
+					}
+				};
 				$(".activity_crafting .equipStats").empty();
 				CraftGearStats(MasterItem, "souk", "ar");
 				CraftGearStats(MasterItem, "houg", "fp");
@@ -4368,15 +4376,6 @@
 					return "";
 			}()))
 			.text( KC3Meta.formatNumber(PlayerManager.hq.exp[hqDt]) );
-	}
-
-	function CraftGearStats(MasterItem, StatProperty, Code){
-		if(parseInt(MasterItem["api_"+StatProperty], 10) !== 0){
-			var thisStatBox = $("#factory .equipStat").clone().appendTo(".module.activity .activity_crafting .equipStats");
-
-			$("img", thisStatBox).attr("src", "../../../../assets/img/stats/"+Code+".png");
-			$(".equipStatText", thisStatBox).text( MasterItem["api_"+StatProperty] );
-		}
 	}
 
 	function buildContactPlaneSpan(fcontactId, fcontact, econtactId, econtact) {

--- a/src/pages/strategy/tabs/aircraft/aircraft.css
+++ b/src/pages/strategy/tabs/aircraft/aircraft.css
@@ -73,7 +73,7 @@
 	font-size:12px;
 }
 .tab_aircraft .slotitem .info .item_stat img {
-	width:16px;
+	max-width:19px;
 	height:16px;
 	margin:0px 2px 0px 0px;
 }

--- a/src/pages/strategy/tabs/aircraft/aircraft.html
+++ b/src/pages/strategy/tabs/aircraft/aircraft.html
@@ -59,16 +59,16 @@
 			<div class="clear"></div>
 			<div class="japanese jp_fonts"></div>
 			<div class="stats">
-				<div class="item_stat item_fp i18n_title" title="ShipFire"><img src="/assets/img/stats/fp.png"><span></span></div>
-				<div class="item_stat item_tp i18n_title" title="ShipTorpedo"><img src="/assets/img/stats/tp.png"><span></span></div>
-				<div class="item_stat item_aa i18n_title" title="ShipAntiAir"><img src="/assets/img/stats/aa.png"><span></span></div>
-				<div class="item_stat item_ar i18n_title" title="ShipArmor"><img src="/assets/img/stats/ar.png"><span></span></div>
-				<div class="item_stat item_as i18n_title" title="ShipAsw"><img src="/assets/img/stats/as.png"><span></span></div>
-				<div class="item_stat item_ev i18n_title" title="ShipEvasion"><img src="/assets/img/stats/ev.png"><span></span></div>
-				<div class="item_stat item_ls i18n_title" title="ShipLos"><img src="/assets/img/stats/ls.png"><span></span></div>
-				<div class="item_stat item_dv i18n_title" title="ShipBombing"><img src="/assets/img/stats/dv.png"><span></span></div>
-				<div class="item_stat item_ht i18n_title" title="ShipAccuracy"><img src="/assets/img/stats/ht.png"><span></span></div>
-				<div class="item_stat item_rn i18n_title" title="ShipLength"><img src="/assets/img/stats/rn.png"><span></span></div>
+				<div class="item_stat item_fp i18n_title" title="ShipFire"><img src="/assets/img/stats/fp_p2.png"><span></span></div>
+				<div class="item_stat item_tp i18n_title" title="ShipTorpedo"><img src="/assets/img/stats/tp_p2.png"><span></span></div>
+				<div class="item_stat item_aa i18n_title" title="ShipAntiAir"><img src="/assets/img/stats/aa_p2.png"><span></span></div>
+				<div class="item_stat item_ar i18n_title" title="ShipArmor"><img src="/assets/img/stats/ar_p2.png"><span></span></div>
+				<div class="item_stat item_as i18n_title" title="ShipAsw"><img src="/assets/img/stats/as_p2.png"><span></span></div>
+				<div class="item_stat item_ev i18n_title" title="ShipEvasion"><img src="/assets/img/stats/ev_p2.png"><span></span></div>
+				<div class="item_stat item_ls i18n_title" title="ShipLos"><img src="/assets/img/stats/ls_p2.png"><span></span></div>
+				<div class="item_stat item_dv i18n_title" title="ShipBombing"><img src="/assets/img/stats/dv_p2.png"><span></span></div>
+				<div class="item_stat item_ht i18n_title" title="ShipAccuracy"><img src="/assets/img/stats/ht_p2.png"><span></span></div>
+				<div class="item_stat item_rn i18n_title" title="ShipLength"><img src="/assets/img/stats/rn_p2.png"><span></span></div>
 				<div class="item_stat item_or i18n_title" title="ShipRadius"><img src="/assets/img/stats/or.png"><span></span></div>
 				<div class="clear"></div>
 			</div>

--- a/src/pages/strategy/tabs/compare/compare.css
+++ b/src/pages/strategy/tabs/compare/compare.css
@@ -9,7 +9,7 @@
 	margin:10px 0px 20px 0px;
 	display: none;
 }
-.tab_compare .compare_add_col  {
+.tab_compare .compare_add_col {
 	height:24px;
 	line-height:24px;
 	float:left;
@@ -89,11 +89,12 @@
 	line-height:24px;
 	margin:0px 5px 0px 0px;
 	border-radius:12px;
+	text-align:center;
 }
 .tab_compare .compare_ship_stat img {
-	width:16px;
+	max-width:19px;
 	height:16px;
-	margin:4px;
+	margin:4px 2px;
 	vertical-align:top;
 }
 .tab_compare .compare_remove {
@@ -149,9 +150,10 @@
 	height:30px;
 	float:left;
 	margin:0px 5px 0px 0px;
+	text-align:center;
 }
 .tab_compare .compare_select_stat img {
-	width:16px;
+	max-width:19px;
 	height:16px;
-	margin:7px 6px;
+	margin:7px 4px;
 }

--- a/src/pages/strategy/tabs/compare/compare.html
+++ b/src/pages/strategy/tabs/compare/compare.html
@@ -29,19 +29,19 @@
 	<!-- GRAPH SELECTION -->
 	<div class="compare_selector">
 		<div class="compare_select_back hover">FULL VIEW</div>
-		<div class="compare_select_stat hover mono" data-stat="0"><img src="../../assets/img/stats/hp.png" /></div>
-		<div class="compare_select_stat hover mono" data-stat="1"><img src="../../assets/img/stats/fp.png" /></div>
-		<div class="compare_select_stat hover mono" data-stat="2"><img src="../../assets/img/stats/tp.png" /></div>
-		<div class="compare_select_stat hover mono" data-stat="3"><img src="../../assets/img/stats/aa.png" /></div>
-		<div class="compare_select_stat hover mono" data-stat="4"><img src="../../assets/img/stats/ar.png" /></div>
-		<div class="compare_select_stat hover mono" data-stat="5"><img src="../../assets/img/stats/as.png" /></div>
-		<div class="compare_select_stat hover mono" data-stat="6"><img src="../../assets/img/stats/ev.png" /></div>
-		<div class="compare_select_stat hover mono" data-stat="7"><img src="../../assets/img/stats/ls.png" /></div>
-		<div class="compare_select_stat hover mono" data-stat="8"><img src="../../assets/img/stats/lk.png" /></div>
+		<div class="compare_select_stat hover mono" data-stat="0"><img src="../../assets/img/stats/hp_p2.png" /></div>
+		<div class="compare_select_stat hover mono" data-stat="1"><img src="../../assets/img/stats/fp_p2.png" /></div>
+		<div class="compare_select_stat hover mono" data-stat="2"><img src="../../assets/img/stats/tp_p2.png" /></div>
+		<div class="compare_select_stat hover mono" data-stat="3"><img src="../../assets/img/stats/aa_p2.png" /></div>
+		<div class="compare_select_stat hover mono" data-stat="4"><img src="../../assets/img/stats/ar_p2.png" /></div>
+		<div class="compare_select_stat hover mono" data-stat="5"><img src="../../assets/img/stats/as_p2.png" /></div>
+		<div class="compare_select_stat hover mono" data-stat="6"><img src="../../assets/img/stats/ev_p2.png" /></div>
+		<div class="compare_select_stat hover mono" data-stat="7"><img src="../../assets/img/stats/ls_p2.png" /></div>
+		<div class="compare_select_stat hover mono" data-stat="8"><img src="../../assets/img/stats/lk_p2.png" /></div>
 		<div class="compare_select_stat hover mono" data-stat="9"><img src="../../assets/img/stats/yasen.png" /></div>
-		<div class="compare_select_stat hover mono" data-stat="10"><img src="../../assets/img/stats/ac.png" /></div>
-		<div class="compare_select_stat hover mono" data-stat="11"><img src="../../assets/img/stats/sp.png" /></div>
-		<div class="compare_select_stat hover mono" data-stat="12"><img src="../../assets/img/stats/rn.png" /></div>
+		<div class="compare_select_stat hover mono" data-stat="10"><img src="../../assets/img/stats/ac_p2.png" /></div>
+		<div class="compare_select_stat hover mono" data-stat="11"><img src="../../assets/img/stats/sp_p2.png" /></div>
+		<div class="compare_select_stat hover mono" data-stat="12"><img src="../../assets/img/stats/rn_p2.png" /></div>
 		<div class="compare_select_stat hover" data-stat="13"><img src="../../assets/img/client/ammo.png" /></div>
 		<div class="compare_select_stat hover" data-stat="14"><img src="../../assets/img/client/fuel.png" /></div>
 		<div class="compare_select_stat hover mono" data-stat="15"><img src="../../assets/img/client/gear.png" /></div>
@@ -63,19 +63,19 @@
 		<div class="compare_ship_col compare_ship_icon"><img/></div>
 		<div class="compare_ship_col compare_ship_name"></div>
 		<!-- Stats -->
-		<div class="compare_ship_col compare_ship_stat compare_ship_hp mono"><img src="../../assets/img/stats/hp.png" /></div>
-		<div class="compare_ship_col compare_ship_stat compare_ship_fp mono"><img src="../../assets/img/stats/fp.png" /></div>
-		<div class="compare_ship_col compare_ship_stat compare_ship_tp mono"><img src="../../assets/img/stats/tp.png" /></div>
-		<div class="compare_ship_col compare_ship_stat compare_ship_aa mono"><img src="../../assets/img/stats/aa.png" /></div>
-		<div class="compare_ship_col compare_ship_stat compare_ship_ar mono"><img src="../../assets/img/stats/ar.png" /></div>
-		<div class="compare_ship_col compare_ship_stat compare_ship_as mono"><img src="../../assets/img/stats/as.png" /></div>
-		<div class="compare_ship_col compare_ship_stat compare_ship_ev mono"><img src="../../assets/img/stats/ev.png" /></div>
-		<div class="compare_ship_col compare_ship_stat compare_ship_ls mono"><img src="../../assets/img/stats/ls.png" /></div>
-		<div class="compare_ship_col compare_ship_stat compare_ship_lk mono"><img src="../../assets/img/stats/lk.png" /></div>
+		<div class="compare_ship_col compare_ship_stat compare_ship_hp mono"><img src="../../assets/img/stats/hp_p2.png" /></div>
+		<div class="compare_ship_col compare_ship_stat compare_ship_fp mono"><img src="../../assets/img/stats/fp_p2.png" /></div>
+		<div class="compare_ship_col compare_ship_stat compare_ship_tp mono"><img src="../../assets/img/stats/tp_p2.png" /></div>
+		<div class="compare_ship_col compare_ship_stat compare_ship_aa mono"><img src="../../assets/img/stats/aa_p2.png" /></div>
+		<div class="compare_ship_col compare_ship_stat compare_ship_ar mono"><img src="../../assets/img/stats/ar_p2.png" /></div>
+		<div class="compare_ship_col compare_ship_stat compare_ship_as mono"><img src="../../assets/img/stats/as_p2.png" /></div>
+		<div class="compare_ship_col compare_ship_stat compare_ship_ev mono"><img src="../../assets/img/stats/ev_p2.png" /></div>
+		<div class="compare_ship_col compare_ship_stat compare_ship_ls mono"><img src="../../assets/img/stats/ls_p2.png" /></div>
+		<div class="compare_ship_col compare_ship_stat compare_ship_lk mono"><img src="../../assets/img/stats/lk_p2.png" /></div>
 		<div class="compare_ship_col compare_ship_stat compare_ship_ys mono"><img src="../../assets/img/stats/yasen.png" /></div>
-		<div class="compare_ship_col compare_ship_stat compare_ship_ac mono"><img src="../../assets/img/stats/ac.png" /></div>
-		<div class="compare_ship_col compare_ship_stat compare_ship_sp mono"><img src="../../assets/img/stats/sp.png" /></div>
-		<div class="compare_ship_col compare_ship_stat compare_ship_rn mono"><img src="../../assets/img/stats/rn.png" /></div>
+		<div class="compare_ship_col compare_ship_stat compare_ship_ac mono"><img src="../../assets/img/stats/ac_p2.png" /></div>
+		<div class="compare_ship_col compare_ship_stat compare_ship_sp mono"><img src="../../assets/img/stats/sp_p2.png" /></div>
+		<div class="compare_ship_col compare_ship_stat compare_ship_rn mono"><img src="../../assets/img/stats/rn_p2.png" /></div>
 		<div class="compare_ship_col compare_ship_stat compare_ship_am"><img src="../../assets/img/client/ammo.png" /></div>
 		<div class="compare_ship_col compare_ship_stat compare_ship_fl"><img src="../../assets/img/client/fuel.png" /></div>
 		<div class="compare_ship_col compare_ship_stat compare_ship_sl mono"><img src="../../assets/img/client/gear.png" /></div>

--- a/src/pages/strategy/tabs/fleet/fleet.html
+++ b/src/pages/strategy/tabs/fleet/fleet.html
@@ -202,31 +202,31 @@
 				<div class="ship_hp"><span class="hp"></span> /<span class="mhp"></span></div>
 			</div>
 			<div class="ship_stats_col">
-				<div class="stat_icon"><img src="/assets/img/stats/hp.png"/><span class="stat_name i18n">ShipHp</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/hp_p2.png"/><span class="stat_name i18n">ShipHp</span></div>
 				<div class="stat_value stat_hp"><span class="current"></span><span class="mod"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/ar.png"/><span class="stat_name i18n">ShipArmor</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/ar_p2.png"/><span class="stat_name i18n">ShipArmor</span></div>
 				<div class="stat_value stat_ar"><span class="equip"></span><span class="current"></span><span class="mod"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/ev.png"/><span class="stat_name i18n">ShipEvasion</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/ev_p2.png"/><span class="stat_name i18n">ShipEvasion</span></div>
 				<div class="stat_value stat_ev"><span class="equip"></span><span class="current"></span><span class="level"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/ac.png"/><span class="stat_name i18n">ShipCarry</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/ac_p2.png"/><span class="stat_name i18n">ShipCarry</span></div>
 				<div class="stat_value stat_ac"><span class="current"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/sp.png"/><span class="stat_name i18n">ShipSpeed</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/sp_p2.png"/><span class="stat_name i18n">ShipSpeed</span></div>
 				<div class="stat_value stat_sp text_center"></div>
-				<div class="stat_icon"><img src="/assets/img/stats/rn.png"/><span class="stat_name i18n">ShipLength</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/rn_p2.png"/><span class="stat_name i18n">ShipLength</span></div>
 				<div class="stat_value stat_rn text_center"></div>
 			</div>
 			<div class="ship_stats_col">
-				<div class="stat_icon"><img src="/assets/img/stats/fp.png"/><span class="stat_name i18n">ShipFire</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/fp_p2.png"/><span class="stat_name i18n">ShipFire</span></div>
 				<div class="stat_value stat_fp"><span class="equip"></span><span class="current"></span><span class="mod"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/tp.png"/><span class="stat_name i18n">ShipTorpedo</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/tp_p2.png"/><span class="stat_name i18n">ShipTorpedo</span></div>
 				<div class="stat_value stat_tp"><span class="equip"></span><span class="current"></span><span class="mod"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/aa.png"/><span class="stat_name i18n">ShipAntiAir</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/aa_p2.png"/><span class="stat_name i18n">ShipAntiAir</span></div>
 				<div class="stat_value stat_aa"><span class="equip"></span><span class="current"></span><span class="mod"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/as.png"/><span class="stat_name i18n">ShipAsw</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/as_p2.png"/><span class="stat_name i18n">ShipAsw</span></div>
 				<div class="stat_value stat_as"><span class="equip"></span><span class="current"></span><span class="level"></span><span class="mod"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/ls.png"/><span class="stat_name i18n">ShipLos</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/ls_p2.png"/><span class="stat_name i18n">ShipLos</span></div>
 				<div class="stat_value stat_ls"><span class="equip"></span><span class="current"></span><span class="level"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/lk.png"/><span class="stat_name i18n">ShipLuck</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/lk_p2.png"/><span class="stat_name i18n">ShipLuck</span></div>
 				<div class="stat_value stat_lk"><span class="equip"></span><span class="current"></span><span class="luck"></span></div>
 			</div>
 			<div class="ship_stats_row"><div class="stat_value stat_wide text_left">

--- a/src/pages/strategy/tabs/gears/gears.css
+++ b/src/pages/strategy/tabs/gears/gears.css
@@ -77,7 +77,7 @@
 	font-size:12px;
 }
 .tab_gears .slotitem .info .item_stat img {
-	width:16px;
+	max-width:19px;
 	height:16px;
 	margin:0px 2px 0px 0px;
 }
@@ -261,4 +261,6 @@
 }
 .tab_gears .itemSorters .sortControl img {
 	margin-top:-3px;
+	max-width: 22px;
+	height: 18px
 }

--- a/src/pages/strategy/tabs/gears/gears.html
+++ b/src/pages/strategy/tabs/gears/gears.html
@@ -72,34 +72,34 @@
 <div class="page_panel itemSorters bscolor4">
 	<div class="sorterLabel">Sort by:</div>
         <div class="sortControl hover fp i18n_title" title="ShipFire">
-          <img src="../../assets/img/stats/fp.png"><span></span>
+          <img src="../../assets/img/stats/fp_p2.png"><span></span>
         </div>
         <div class="sortControl hover tp i18n_title" title="ShipTorpedo">
-          <img src="../../assets/img/stats/tp.png"><span></span>
+          <img src="../../assets/img/stats/tp_p2.png"><span></span>
         </div>
         <div class="sortControl hover aa i18n_title" title="ShipAntiAir">
-          <img src="../../assets/img/stats/aa.png"><span></span>
+          <img src="../../assets/img/stats/aa_p2.png"><span></span>
         </div>
         <div class="sortControl hover ar i18n_title" title="ShipArmor">
-          <img src="../../assets/img/stats/ar.png"><span></span>
+          <img src="../../assets/img/stats/ar_p2.png"><span></span>
         </div>
         <div class="sortControl hover as i18n_title" title="ShipAsw">
-          <img src="../../assets/img/stats/as.png"><span></span>
+          <img src="../../assets/img/stats/as_p2.png"><span></span>
         </div>
         <div class="sortControl hover ev i18n_title" title="ShipEvasion">
-          <img src="../../assets/img/stats/ev.png"><span></span>
+          <img src="../../assets/img/stats/ev_p2.png"><span></span>
         </div>
         <div class="sortControl hover ls i18n_title" title="ShipLos">
-          <img src="../../assets/img/stats/ls.png"><span></span>
+          <img src="../../assets/img/stats/ls_p2.png"><span></span>
         </div>
         <div class="sortControl hover dv i18n_title" title="ShipBombing">
-          <img src="../../assets/img/stats/dv.png"><span></span>
+          <img src="../../assets/img/stats/dv_p2.png"><span></span>
         </div>
         <div class="sortControl hover ht i18n_title" title="ShipAccuracy">
-          <img src="../../assets/img/stats/ht.png"><span></span>
+          <img src="../../assets/img/stats/ht_p2.png"><span></span>
         </div>
         <div class="sortControl hover rn i18n_title" title="ShipLength">
-          <img src="../../assets/img/stats/rn.png"><span></span>
+          <img src="../../assets/img/stats/rn_p2.png"><span></span>
         </div>
         <div class="sortControl hover or i18n_title" title="ShipRadius">
           <img src="../../assets/img/stats/or.png"><span></span>
@@ -137,16 +137,16 @@
 			<div class="clear"></div>
 			<div class="japanese jp_fonts"></div>
 			<div class="stats">
-				<div class="item_stat item_fp i18n_title" title="ShipFire"><img src="../../assets/img/stats/fp.png"><span></span></div>
-				<div class="item_stat item_tp i18n_title" title="ShipTorpedo"><img src="../../assets/img/stats/tp.png"><span></span></div>
-				<div class="item_stat item_aa i18n_title" title="ShipAntiAir"><img src="../../assets/img/stats/aa.png"><span></span></div>
-				<div class="item_stat item_ar i18n_title" title="ShipArmor"><img src="../../assets/img/stats/ar.png"><span></span></div>
-				<div class="item_stat item_as i18n_title" title="ShipAsw"><img src="../../assets/img/stats/as.png"><span></span></div>
-				<div class="item_stat item_ev i18n_title" title="ShipEvasion"><img src="../../assets/img/stats/ev.png"><span></span></div>
-				<div class="item_stat item_ls i18n_title" title="ShipLos"><img src="../../assets/img/stats/ls.png"><span></span></div>
-				<div class="item_stat item_dv i18n_title" title="ShipBombing"><img src="../../assets/img/stats/dv.png"><span></span></div>
-				<div class="item_stat item_ht i18n_title" title="ShipAccuracy"><img src="../../assets/img/stats/ht.png"><span></span></div>
-				<div class="item_stat item_rn i18n_title" title="ShipLength"><img src="../../assets/img/stats/rn.png"><span></span></div>
+				<div class="item_stat item_fp i18n_title" title="ShipFire"><img src="../../assets/img/stats/fp_p2.png"><span></span></div>
+				<div class="item_stat item_tp i18n_title" title="ShipTorpedo"><img src="../../assets/img/stats/tp_p2.png"><span></span></div>
+				<div class="item_stat item_aa i18n_title" title="ShipAntiAir"><img src="../../assets/img/stats/aa_p2.png"><span></span></div>
+				<div class="item_stat item_ar i18n_title" title="ShipArmor"><img src="../../assets/img/stats/ar_p2.png"><span></span></div>
+				<div class="item_stat item_as i18n_title" title="ShipAsw"><img src="../../assets/img/stats/as_p2.png"><span></span></div>
+				<div class="item_stat item_ev i18n_title" title="ShipEvasion"><img src="../../assets/img/stats/ev_p2.png"><span></span></div>
+				<div class="item_stat item_ls i18n_title" title="ShipLos"><img src="../../assets/img/stats/ls_p2.png"><span></span></div>
+				<div class="item_stat item_dv i18n_title" title="ShipBombing"><img src="../../assets/img/stats/dv_p2.png"><span></span></div>
+				<div class="item_stat item_ht i18n_title" title="ShipAccuracy"><img src="../../assets/img/stats/ht_p2.png"><span></span></div>
+				<div class="item_stat item_rn i18n_title" title="ShipLength"><img src="../../assets/img/stats/rn_p2.png"><span></span></div>
 				<div class="item_stat item_or i18n_title" title="ShipRadius"><img src="../../assets/img/stats/or.png"><span></span></div>
 				<div class="clear"></div>
 			</div>

--- a/src/pages/strategy/tabs/mstgear/mstgear.css
+++ b/src/pages/strategy/tabs/mstgear/mstgear.css
@@ -135,11 +135,12 @@
 	height:20px;
 	float:left;
 	line-height:18px;
+	text-align:right;
 }
 .tab_mstgear .gearInfo .stat_icon img {
-	width:18px;
+	max-width:20px;
 	height:18px;
-	margin:1px;
+	margin:1px 0px;
 }
 .tab_mstgear .gearInfo .stat_value {
 	width:36px;

--- a/src/pages/strategy/tabs/mstgear/mstgear.js
+++ b/src/pages/strategy/tabs/mstgear/mstgear.js
@@ -138,18 +138,18 @@
 			var statBox;
 			$(".tab_mstgear .gearInfo .stats").empty();
 			$.each([
-				["hp", "taik", "ShipHp"],
-				["fp", "houg", "ShipFire"],
-				["ar", "souk", "ShipArmor"],
-				["tp", "raig", "ShipTorpedo"],
-				["sp", "soku", "ShipSpeed"],
-				["dv", "baku", "ShipBombing"],
-				["aa", "tyku", "ShipAntiAir"],
-				["as", "tais", "ShipAsw"],
-				["ht", "houm", "ShipAccuracy", "ShipAccAntiBomber"],
-				["ev", "houk", "ShipEvasion", "ShipEvaInterception"],
-				["ls", "saku", "ShipLos"],
-				["rn", "leng", "ShipLength"],
+				["hp_p2", "taik", "ShipHp"],
+				["fp_p2", "houg", "ShipFire"],
+				["ar_p2", "souk", "ShipArmor"],
+				["tp_p2", "raig", "ShipTorpedo"],
+				["sp_p2", "soku", "ShipSpeed"],
+				["dv_p2", "baku", "ShipBombing"],
+				["aa_p2", "tyku", "ShipAntiAir"],
+				["as_p2", "tais", "ShipAsw"],
+				["ht_p2", "houm", "ShipAccuracy", "ShipAccAntiBomber"],
+				["ev_p2", "houk", "ShipEvasion", "ShipEvaInterception"],
+				["ls_p2", "saku", "ShipLos"],
+				["rn_p2", "leng", "ShipLength"],
 				["or", "distance", "ShipRadius"],
 				["kk", "cost", "ShipDeployCost"],
 			], function(index, sdata){
@@ -160,15 +160,18 @@
 				){
 					statBox = $(".tab_mstgear .factory .stat").clone();
 					$("img", statBox)
-						.attr("src", "../../../../assets/img/stats/"+sdata[0]+".png")
+						.attr("src", `/assets/img/stats/${sdata[0]}.png`)
 						.attr("title", KC3Meta.term(
 							sdata[sdata.length > 3 && gearData.api_type[2] === 48 ? 3 : 2]) || "")
 						.lazyInitTooltip();
-					if(sdata[0]==="rn"){ // For range length
+					if(sdata[0]==="ev_p2" && gearData.api_type[2] === 48){ // For interception
+						$("img", statBox).attr("src", "/assets/img/stats/ev2_p2.png");
+						$(".stat_value", statBox).text( gearData["api_"+sdata[1]] );
+					}else if(sdata[0]==="rn_p2"){ // For range length
 						$(".stat_value", statBox).text( [
 							"?", "S", "M", "L", "VL", "XL"
 						][gearData["api_"+sdata[1]]] || "?" );
-					}else if(sdata[0]==="sp"){ // For speed, but not found in gears
+					}else if(sdata[0]==="sp_p2"){ // For speed, but not found in gears
 						$(".stat_value", statBox).text( ({
 							"0":"L", "5":"S", "10":"F", "15":"F+", "20":"F++"
 						})[gearData["api_"+sdata[1]]] || "?");

--- a/src/pages/strategy/tabs/mstship/mstship.css
+++ b/src/pages/strategy/tabs/mstship/mstship.css
@@ -184,9 +184,9 @@
 	line-height:16px;
 }
 .tab_mstship .shipInfo .ship_stat_icon img {
-	width:16px;
+	width:19px;
 	height:16px;
-	margin:2px;
+	margin:2px 1px 2px 0px;
 }
 .tab_mstship .shipInfo .ship_stat_name {
 	width:45px;
@@ -352,9 +352,9 @@
 	float:left;
 }
 .tab_mstship .shipInfo .more .rsc_icon img {
-	width:16px;
+	width:18px;
 	height:16px;
-	margin:2px;
+	margin:2px 1px;
 }
 .tab_mstship .shipInfo .more .rsc_value {
 	width:50px;

--- a/src/pages/strategy/tabs/mstship/mstship.html
+++ b/src/pages/strategy/tabs/mstship/mstship.html
@@ -161,22 +161,22 @@
 				<div class="modfods moreinfo_box">
 					<div class="ship_label">Modernization</div>
 					<div class="rsc">
-						<div class="rsc_icon"><img src="../../../../assets/img/client/mod_fp.png" /></div>
+						<div class="rsc_icon"><img src="../../../../assets/img/client/mod_fp_p2.png" /></div>
 						<div class="rsc_value"></div>
 						<div class="clear"></div>
 					</div>
 					<div class="rsc">
-						<div class="rsc_icon"><img src="../../../../assets/img/client/mod_tp.png" /></div>
+						<div class="rsc_icon"><img src="../../../../assets/img/client/mod_tp_p2.png" /></div>
 						<div class="rsc_value"></div>
 						<div class="clear"></div>
 					</div>
 					<div class="rsc">
-						<div class="rsc_icon"><img src="../../../../assets/img/client/mod_aa.png" /></div>
+						<div class="rsc_icon"><img src="../../../../assets/img/client/mod_aa_p2.png" /></div>
 						<div class="rsc_value"></div>
 						<div class="clear"></div>
 					</div>
 					<div class="rsc">
-						<div class="rsc_icon"><img src="../../../../assets/img/client/mod_ar.png" /></div>
+						<div class="rsc_icon"><img src="../../../../assets/img/client/mod_ar_p2.png" /></div>
 						<div class="rsc_value"></div>
 						<div class="clear"></div>
 					</div>
@@ -203,17 +203,17 @@
 					<div class="level-val"></div>
 					<div class="stat-detail">
 						<div class="rsc">
-							<div class="rsc_icon i18n_title" title="ShipAsw"><img src="../../../../assets/img/stats/as.png" /></div>
+							<div class="rsc_icon i18n_title" title="ShipAsw"><img src="../../../../assets/img/stats/as_p2.png" /></div>
 							<div class="rsc_value asw"></div>
 							<div class="clear"></div>
 						</div>
 						<div class="rsc">
-							<div class="rsc_icon i18n_title" title="ShipLos"><img src="../../../../assets/img/stats/ls.png" /></div>
+							<div class="rsc_icon i18n_title" title="ShipLos"><img src="../../../../assets/img/stats/ls_p2.png" /></div>
 							<div class="rsc_value los"></div>
 							<div class="clear"></div>
 						</div>
 						<div class="rsc">
-							<div class="rsc_icon i18n_title" title="ShipEvasion"><img src="../../../../assets/img/stats/ev.png" /></div>
+							<div class="rsc_icon i18n_title" title="ShipEvasion"><img src="../../../../assets/img/stats/ev_p2.png" /></div>
 							<div class="rsc_value evs"></div>
 							<div class="clear"></div>
 						</div>

--- a/src/pages/strategy/tabs/mstship/mstship.js
+++ b/src/pages/strategy/tabs/mstship/mstship.js
@@ -469,7 +469,7 @@
 					["lk", "luck", "ShipLuck"],
 				], function(index, stat){
 					statBox = $(".tab_mstship .factory .ship_stat").clone();
-					$("img", statBox).attr("src", "../../../../assets/img/stats/"+stat[0]+".png");
+					$("img", statBox).attr("src", `/assets/img/stats/${stat[0]}_p2.png`);
 					$(".ship_stat_name", statBox).text(stat[1])
 						.attr("title", KC3Meta.term(stat[2]) || "")
 						.lazyInitTooltip();

--- a/src/pages/strategy/tabs/ships/ships.html
+++ b/src/pages/strategy/tabs/ships/ships.html
@@ -278,31 +278,31 @@
 				<div class="ship_hp"><span class="hp"></span> /<span class="mhp"></span></div>
 			</div>
 			<div class="ship_stats_col">
-				<div class="stat_icon"><img src="/assets/img/stats/hp.png"/><span class="stat_name i18n">ShipHp</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/hp_p2.png"/><span class="stat_name i18n">ShipHp</span></div>
 				<div class="stat_value stat_hp"><span class="current"></span><span class="mod"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/ar.png"/><span class="stat_name i18n">ShipArmor</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/ar_p2.png"/><span class="stat_name i18n">ShipArmor</span></div>
 				<div class="stat_value stat_ar"><span class="equip"></span><span class="current"></span><span class="mod"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/ev.png"/><span class="stat_name i18n">ShipEvasion</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/ev_p2.png"/><span class="stat_name i18n">ShipEvasion</span></div>
 				<div class="stat_value stat_ev"><span class="equip"></span><span class="current"></span><span class="level"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/ac.png"/><span class="stat_name i18n">ShipCarry</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/ac_p2.png"/><span class="stat_name i18n">ShipCarry</span></div>
 				<div class="stat_value stat_ac"><span class="current"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/sp.png"/><span class="stat_name i18n">ShipSpeed</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/sp_p2.png"/><span class="stat_name i18n">ShipSpeed</span></div>
 				<div class="stat_value stat_sp text_center"></div>
-				<div class="stat_icon"><img src="/assets/img/stats/rn.png"/><span class="stat_name i18n">ShipLength</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/rn_p2.png"/><span class="stat_name i18n">ShipLength</span></div>
 				<div class="stat_value stat_rn text_center"></div>
 			</div>
 			<div class="ship_stats_col">
-				<div class="stat_icon"><img src="/assets/img/stats/fp.png"/><span class="stat_name i18n">ShipFire</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/fp_p2.png"/><span class="stat_name i18n">ShipFire</span></div>
 				<div class="stat_value stat_fp"><span class="equip"></span><span class="current"></span><span class="mod"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/tp.png"/><span class="stat_name i18n">ShipTorpedo</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/tp_p2.png"/><span class="stat_name i18n">ShipTorpedo</span></div>
 				<div class="stat_value stat_tp"><span class="equip"></span><span class="current"></span><span class="mod"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/aa.png"/><span class="stat_name i18n">ShipAntiAir</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/aa_p2.png"/><span class="stat_name i18n">ShipAntiAir</span></div>
 				<div class="stat_value stat_aa"><span class="equip"></span><span class="current"></span><span class="mod"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/as.png"/><span class="stat_name i18n">ShipAsw</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/as_p2.png"/><span class="stat_name i18n">ShipAsw</span></div>
 				<div class="stat_value stat_as"><span class="equip"></span><span class="current"></span><span class="level"></span><span class="mod"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/ls.png"/><span class="stat_name i18n">ShipLos</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/ls_p2.png"/><span class="stat_name i18n">ShipLos</span></div>
 				<div class="stat_value stat_ls"><span class="equip"></span><span class="current"></span><span class="level"></span></div>
-				<div class="stat_icon"><img src="/assets/img/stats/lk.png"/><span class="stat_name i18n">ShipLuck</span></div>
+				<div class="stat_icon"><img src="/assets/img/stats/lk_p2.png"/><span class="stat_name i18n">ShipLuck</span></div>
 				<div class="stat_value stat_lk"><span class="equip"></span><span class="current"></span><span class="luck"></span></div>
 			</div>
 			<div class="ship_stats_row"><div class="stat_value stat_wide text_left">

--- a/src/pages/strategy/themes/dark.css
+++ b/src/pages/strategy/themes/dark.css
@@ -183,8 +183,8 @@ button, input, select, textarea {
 	border-bottom-color:#fcfcfc;
 }
 .ui-tooltip-content .ship_tooltip .stat_icon img {
-	width:15px;
-	height:15px;
+	width:19px;
+	height:16px;
 	margin-top:-2px;
 }
 .ui-tooltip-content .ship_tooltip .stat_name {

--- a/src/pages/strategy/themes/legacy.css
+++ b/src/pages/strategy/themes/legacy.css
@@ -171,8 +171,8 @@ body {
 	border-bottom-color:#fcfcfc;
 }
 .ui-tooltip-content .ship_tooltip .stat_icon img {
-	width:15px;
-	height:15px;
+	width:19px;
+	height:16px;
 	margin-top:-2px;
 }
 .ui-tooltip-content .ship_tooltip .stat_name {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/160240/44592035-f12cc480-a7f1-11e8-85d1-260e79220a6d.png)

* Replaced stats icons of almost all pages with phase 2 version
  * Ship List grid caption not replaced (perhaps there are still some pages forgotten?)
  * Icons originally crafted by us not replaced (who make some new?)
* New 'HD' icons are not only larger size, but also different aspect ratio
  * Have to adjust their css sizes by hands... so they look not so good after zoomed out, maybe not suit for current 'compact' theme. 🤔 

Plz try and check if they are good to go, imo do not like them anyway 😂  