### PR TITLE
TsunDB gunfit tests

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -972,7 +972,7 @@
 	},
 	{
 		"section": "SettingsTsunDBSubmission",
-		"help" : "",
+		"help" : "https://github.com/KC3Kai/KC3Kai/wiki/Settings:-Database-Submissions#tsundb-extra-submission",
 		"contents" :[
 			{
 				"id" : "TsunDBSubmission_enabled",

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -979,6 +979,12 @@
 				"name" : "SettingsEnableTsunDBSubmission",
 				"type" : "check",
 				"options" : {}
+			},
+			{
+				"id" : "TsunDBSubmissionExtra_enabled",
+				"name" : "SettingsEnableTsunDBExtraSubmission",
+				"type" : "check",
+				"options" : {}
 			}
 		]
 	},

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -47,6 +47,7 @@ Retrieves when needed to apply on components
 				KC3DBSubmission_enabled : false,
 				OpenDBSubmission_enabled : false,
 				TsunDBSubmission_enabled : false,
+				TsunDBSubmissionExtra_enabled : false,
 				PushAlerts_enabled   : 0,
 				PushAlerts_key       : '',
 

--- a/src/library/managers/SortieManager.js
+++ b/src/library/managers/SortieManager.js
@@ -122,6 +122,17 @@ Stores and manages states and functions during sortie of fleets (including PvP b
 					}
 				});
 			}
+			if (ConfigManager.TsunDBSubmissionExtra_enabled) {
+				this.initialMorale = [];
+				for (let idx = 0; idx < fleet.ships.length; idx++){
+					let morale = 0;
+					const ship = fleet.ship(idx);
+					if (!ship.isDummy()) {
+						morale = ship.morale;
+					}
+					this.initialMorale.push(morale);
+				}
+			}
 		},
 		
 		snapshotFleetState :function(){

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -775,7 +775,7 @@
 							onClick: onClick
 						});
 					}
-					return testId;
+					return parseInt(testId);
 				}
 
 				status = Math.max(status, testStatus);

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -649,13 +649,15 @@
 			const battleData = thisNode.battleDay || thisNode.battleNight;
 			template.formation = battleData.api_formation[0];
 			template.eformation = battleData.api_formation[1];
+			const initialMorale = KC3SortieManager.initialMorale;
+			
 			// Implementing phase tagging to attacks in the future, so this part may need to be updated later
 			for (var idx = 0; idx < fleet.ships.length; idx++) {
 				const ship = fleet.ship(idx);
 				if (ship.isDummy()) { continue; }
 				const testId = this.checkGunFitsRequirements(ship);
 				if (testId >= 0) {
-					const template2 = Object.assign({}, { misc: template, ship: { id:ship.masterId, lv: ship.level, position: idx, morale: ship.morale, luck: ship.lk[0],
+					const template2 = Object.assign({}, { misc: template, ship: { id:ship.masterId, lv: ship.level, position: idx, morale: initialMorale[idx], luck: ship.lk[0],
 						equips: ship.equipment(true).map(g => g.masterId || -1), improvements: ship.equipment(true).map(g => g.stars || -1), }, testId: testId });
 					const formMod = ship.estimateShellingFormationModifier(template2.formation, template2.eformation, 'accuracy');
 					const accVal = ship.shellingAccuracy(formMod, false);

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -668,8 +668,8 @@
 						const attack = shipLog[i];
 						for (var j = 0; j < attack.acc.length; j++) {
 							this.gunfit = Object.assign({}, template2, { api_cl: attack.acc[j], enemy: thisNode.eships[attack.target[j]], 
-								spAttackType: attack.cutin >= 0 ? attack.cutin : attack.ncutin, time : attack.cutin >= 0 ? 'Day' : 'Night' });
-							console.debug(this.gunfit);
+								spAttackType: attack.cutin >= 0 ? attack.cutin : attack.ncutin, time : attack.cutin >= 0 ? 'day' : 'yasen' });
+							this.sendData(this.gunfit, 'fits');
 						}
 					}
 				}

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -666,7 +666,7 @@
 
 					for (var i = 0; i < shipLog.length; i++) {
 						const attack = shipLog[i];
-						for (var j = 0; j < attack.acc; j++) {
+						for (var j = 0; j < attack.acc.length; j++) {
 							this.gunfit = Object.assign({}, template2, { api_cl: attack.acc[j], enemy: thisNode.eships[attack.target[j]], 
 								spAttackType: attack.cutin >= 0 ? attack.cutin : attack.ncutin, time : attack.cutin >= 0 ? 'Day' : 'Night' });
 							console.debug(this.gunfit);

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -156,6 +156,7 @@
 			api_cl: null,
 			enemy: null,
 			spAttackType: null,
+			testName: null,
 			time: null,
 		},
 		development : {
@@ -636,6 +637,10 @@
 			if (!(["1-1","1-2"].includes(this.data.map) && [1,3].includes(thisNode.id) && ConfigManager.TsunDBSubmissionExtra_enabled)) { return; }
 			this.updateGunfitsIfNeeded();
 
+			if(localStorage.tsundb_gunfits == undefined)
+				return;
+			const tests = JSON.parse(localStorage.tsundb_gunfits).tests;
+
 			// Leave it as single-fleet check for now
 			const fleet = PlayerManager.fleets[this.data.sortiedFleet - 1];
 			const battleLog = (thisNode.predictedFleetsNight || thisNode.predictedFleetsDay || {}).playerMain;
@@ -658,7 +663,7 @@
 				const testId = this.checkGunFitsRequirements(ship);
 				if (testId >= 0) {
 					const template2 = Object.assign({}, { misc: template, ship: { id:ship.masterId, lv: ship.level, position: idx, morale: initialMorale[idx], luck: ship.lk[0],
-						equips: ship.equipment(true).map(g => g.masterId || -1), improvements: ship.equipment(true).map(g => g.stars || -1), }, testId: testId });
+						equips: ship.equipment(true).map(g => g.masterId || -1), improvements: ship.equipment(true).map(g => g.stars || -1), }, testName: tests[testId].testName });
 					const formMod = ship.estimateShellingFormationModifier(template2.formation, template2.eformation, 'accuracy');
 					const accVal = ship.shellingAccuracy(formMod, false);
 					template2.accVal = accVal.basicAccuracy;

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -142,6 +142,9 @@
 				kc3version: null,
 				formation: null,
 				eformation: null,
+				starshell: null,
+				searchlight: null,
+				ncontact: null,
 			},
 			ship: {
 				id: null,
@@ -654,6 +657,9 @@
 				map: this.data.map,
 				edge: thisNode.id,
 				kc3version: this.manifest.version + ("update_url" in this.manifest ? "" : "d"),
+				starshell: !!thisNode.flarePos,
+				searchlight: !!fleet.estimateUsableSearchlight(),
+				ncontact:  thisNode.fcontactId === 102,
 			};
 			const battleData = thisNode.battleDay || thisNode.battleNight;
 			template.formation = battleData.api_formation[0];

--- a/src/pages/strategy/strategy.html
+++ b/src/pages/strategy/strategy.html
@@ -107,6 +107,7 @@
 							<li data-id="iconmaker">Icons</li>
 							<li data-id="mapmarkers">Maps</li>
 							<li data-id="playground">Playground</li>
+							<li data-id="gunfits">Gunfits</li>
 						</ul>
 					</div>
 				</div>
@@ -239,6 +240,7 @@
 		<script type="text/javascript" src="tabs/shipdrop/shipdrop.js"></script>
 		<script type="text/javascript" src="tabs/iconmaker/iconmaker.js"></script>
 		<script type="text/javascript" src="tabs/mapmarkers/mapmarkers.js"></script>
+		<script type="text/javascript" src="tabs/gunfits/gunfits.js"></script>
 		<!-- @nonbuildend -->
 
 	</body>

--- a/src/pages/strategy/strategy.html
+++ b/src/pages/strategy/strategy.html
@@ -181,6 +181,7 @@
 		<script type="text/javascript" src="../../library/modules/ImageExport.js"></script>
 		<script type="text/javascript" src="../../library/modules/Master.js"></script>
 		<script type="text/javascript" src="../../library/modules/Translation.js"></script>
+		<script type="text/javascript" src="../../library/modules/TsunDBSubmission.js"></script>
 		<script type="text/javascript" src="../../library/modules/Meta.js"></script>
 		<script type="text/javascript" src="../../library/modules/DataBackup.js"></script>
 		<script type="text/javascript" src="../../library/modules/WhoCallsTheFleetDb.js"></script>

--- a/src/pages/strategy/strategy.html
+++ b/src/pages/strategy/strategy.html
@@ -33,6 +33,7 @@
 							<li data-id="experience">Experience</li>
 							<li data-id="showcase">Showcase</li>
 							<li data-id="overlodger">Ledger</li>
+							<li data-id="gunfits">Gunfits</li>
 							<li data-id="databackup">Data Backup</li>
 						</ul>
 					</div>
@@ -107,7 +108,6 @@
 							<li data-id="iconmaker">Icons</li>
 							<li data-id="mapmarkers">Maps</li>
 							<li data-id="playground">Playground</li>
-							<li data-id="gunfits">Gunfits</li>
 						</ul>
 					</div>
 				</div>

--- a/src/pages/strategy/strategy.html
+++ b/src/pages/strategy/strategy.html
@@ -33,7 +33,6 @@
 							<li data-id="experience">Experience</li>
 							<li data-id="showcase">Showcase</li>
 							<li data-id="overlodger">Ledger</li>
-							<li data-id="gunfits">Gunfits</li>
 							<li data-id="databackup">Data Backup</li>
 						</ul>
 					</div>
@@ -97,6 +96,7 @@
 							<li data-id="mstship">Ships</li>
 							<li data-id="mstgear">Equipment</li>
 							<li data-id="compare">Compare</li>
+							<li data-id="gunfits">Gunfits</li>
 						</ul>
 					</div>
 					<div class="submenu dev-only">

--- a/src/pages/strategy/tabs/gunfits/gunfits.css
+++ b/src/pages/strategy/tabs/gunfits/gunfits.css
@@ -1,0 +1,48 @@
+﻿
+@charset "utf-8";
+.tab_gunfits {
+	width:680px;
+}
+.tab_gunfits .factory {
+	display:none;
+}
+.tab_gunfits .testitem.testingImpossible {
+    opacity: 0.4;
+}
+.tab_gunfits .testitem .shipinfo {
+    width: 130px;
+    float: left;
+    margin-right: 30px;
+}
+.tab_gunfits .testitem .ship_gears {
+    width: 400px;
+    float: left;
+    margin-right: 10px;
+}
+.tab_gunfits .testitem .shipinfo .generalship {
+	display: table;
+}
+.tab_gunfits .testitem .shipinfo .generalship .ship_icon img {
+	width: 50px;
+	float: left;
+}
+.tab_gunfits .testitem .shipinfo .generalship .name {
+	display: table-cell;
+	vertical-align: middle;
+	padding-left: 5px;
+}
+
+.tab_gunfits .testitem .ship_gears .gearsbox {
+	display: table;
+	width: 100%;
+}
+.tab_gunfits .testitem .ship_gears .gearsbox .gear_icon img {
+	width: 25px;
+	float: left;
+}
+.tab_gunfits .testitem .ship_gears .gearsbox .gear_name {
+	padding-left: 5px;
+}
+.tab_gunfits .testitem .ship_gears .gearsbox .owned {
+	padding-left: 5px;
+}

--- a/src/pages/strategy/tabs/gunfits/gunfits.css
+++ b/src/pages/strategy/tabs/gunfits/gunfits.css
@@ -37,12 +37,15 @@
 	width: 100%;
 }
 .tab_gunfits .testitem .ship_gears .gearsbox .gear_icon img {
-	width: 25px;
+	vertical-align: middle;
+	width: 40px;
 	float: left;
 }
 .tab_gunfits .testitem .ship_gears .gearsbox .gear_name {
 	padding-left: 5px;
+	float: left;
 }
 .tab_gunfits .testitem .ship_gears .gearsbox .owned {
 	padding-left: 5px;
+	float: left;
 }

--- a/src/pages/strategy/tabs/gunfits/gunfits.css
+++ b/src/pages/strategy/tabs/gunfits/gunfits.css
@@ -43,9 +43,7 @@
 }
 .tab_gunfits .testitem .ship_gears .gearsbox .gear_name {
 	padding-left: 5px;
-	float: left;
 }
 .tab_gunfits .testitem .ship_gears .gearsbox .owned {
 	padding-left: 5px;
-	float: left;
 }

--- a/src/pages/strategy/tabs/gunfits/gunfits.css
+++ b/src/pages/strategy/tabs/gunfits/gunfits.css
@@ -6,6 +6,23 @@
 .tab_gunfits .factory {
 	display:none;
 }
+
+.tab_gunfits .setting_disabled {
+	background-color: #fdd;
+	color:#c44;
+	padding:10px;
+	margin: 10px;
+	border-radius:10px;
+}
+.tab_gunfits .setting_disabled .settings_link {
+	text-align: center;
+	font-weight: bold;
+	font-size: 14px;
+}
+.tab_gunfits .setting_disabled .settings_link a {
+	color:#f55;
+}
+
 .tab_gunfits .testitem.testingImpossible {
     opacity: 0.4;
 }

--- a/src/pages/strategy/tabs/gunfits/gunfits.html
+++ b/src/pages/strategy/tabs/gunfits/gunfits.html
@@ -41,6 +41,7 @@
       </div>
       <div class="morale_range">?~?</div>
       <!-- <div class="radar_offset"></div> -->
+      <div class="curr_fleet_status"></div>
       <div class="clear"></div>
     </div>
 

--- a/src/pages/strategy/tabs/gunfits/gunfits.html
+++ b/src/pages/strategy/tabs/gunfits/gunfits.html
@@ -7,7 +7,7 @@
 <div class="page_help">
   <div class="help_q">How to help out?</div>
   <div class="help_a">
-    Insert some info here
+    If you have the required ships and equipment specified below, sortie to 1-1 or 1-2 with the ship and equips specified. Do take note of the morale range and thank you for contributing!
   </div>
 </div>
 

--- a/src/pages/strategy/tabs/gunfits/gunfits.html
+++ b/src/pages/strategy/tabs/gunfits/gunfits.html
@@ -1,0 +1,54 @@
+<div class="page_title">
+  Gunfits
+  <div class="page_help_btn hover"><span>?</span> Help Topics</div>
+</div>
+
+<!-- HELP TOPICS -->
+<div class="page_help">
+  <div class="help_q">How to help out?</div>
+  <div class="help_a">
+    Insert some info here
+  </div>
+</div>
+
+<div class="page_padding section_currenttests">
+  <div class="page_section">Current Tests</div>
+  <div class="section_body box_tests">
+
+  </div>
+</div>
+
+<div class="factory">
+  <div class="testitem">
+      <div class="shipinfo">
+        <div class="generalship">
+          <div class="ship_icon hover"><img /></div>
+          <div class="name">???</div>
+        </div>
+        <div class="clear"></div>
+        <div class="lvl">
+          Requested Lv.: <span class="requested">?~?</span><br>
+          Owned Lv.: <span class="lvl_status">/</span>
+          <div class="clear"></div>
+        </div>
+        <div class="ship_status"></div>
+        <div class="clear"></div>
+      </div>
+      <div class="ship_gears">
+        <div class="gearsbox"></div>
+        <div class="gear_status"></div>
+        <div class="clear"></div>
+      </div>
+      <div class="morale_range">?~?</div>
+      <!-- <div class="radar_offset"></div> -->
+      <div class="clear"></div>
+    </div>
+
+    <div class="ship_gear">
+      <div class="gear_icon hover"><img/></div>
+      <div class="gear_name">???</div>
+      <div class="owned">x?</div>
+      <div class="clear"></div>
+    </div>
+  </div>
+</div>

--- a/src/pages/strategy/tabs/gunfits/gunfits.html
+++ b/src/pages/strategy/tabs/gunfits/gunfits.html
@@ -5,14 +5,24 @@
 
 <!-- HELP TOPICS -->
 <div class="page_help">
-  <div class="help_q">How to help out?</div>
+    <div class="help_q">What is this page?</div>
   <div class="help_a">
-    If you have the required ships and equipment specified below, sortie to 1-1 or 1-2 with the ship and equips specified. Do take note of the morale range and thank you for contributing!
-  </div>
+    To collect data regarding gun fits, we require players to run fit tests. This page is meant to orangize the testing effort and allow testers
+    to check which tests are currently avaliable.</div>
+  <div class="help_q">How do I help out?</div>
+  <div class="help_a">
+    If you have the required ships and equipment specified below, sortie to 1-1 or 1-2 with the ship and equips specified, then retreat after the first node. Do take note of 
+    the morale range and thank you for contributing!</div>
+  <div class="help_q">Why is my player ID and username being submitted?</div>
+  <div class="help_a">This is so that we can filter out data tampering.</div>
+  <div class="help_q">What other data is being submitted?</div>
+  <div class="help_a">Current battle conditions.</div>
+  <div class="help_q">What about improved gear?</div>
+  <div class="help_a">If possible, please use base equipment for testing.</div>
 </div>
 
 <div class="setting_disabled">
-  You do not have the setting TsunDBSubmissionExtra enabled! Please enable this in the settings to submit your name, player id (to prevent abuse) and gunfit data.
+  You do not have both TsunDB submission and extra submission enabled! Please enable this in the settings to submit your name, player id (to prevent abuse) and gunfit data.
   <div class="settings_link">
     <a href="/pages/settings/settings.html#tsundbsubmission" target="_blank">Click here to open settings in a new tab</a>
   </div>

--- a/src/pages/strategy/tabs/gunfits/gunfits.html
+++ b/src/pages/strategy/tabs/gunfits/gunfits.html
@@ -11,6 +11,12 @@
   </div>
 </div>
 
+<div class="setting_disabled">
+  You do not have the setting TsunDBSubmissionExtra enabled! Please enable this in the settings to submit your name, player id (to prevent abuse) and gunfit data.
+  <div class="settings_link">
+    <a href="/pages/settings/settings.html#tsundbsubmission" target="_blank">Click here to open settings in a new tab</a>
+  </div>
+</div>
 <div class="page_padding section_currenttests">
   <div class="page_section">Current Tests</div>
   <div class="section_body box_tests">

--- a/src/pages/strategy/tabs/gunfits/gunfits.html
+++ b/src/pages/strategy/tabs/gunfits/gunfits.html
@@ -12,7 +12,7 @@
   <div class="help_q">How do I help out?</div>
   <div class="help_a">
     If you have the required ships and equipment specified below, sortie to 1-1 or 1-2 with the ship and equips specified, then retreat after the first node. Do take note of 
-    the morale range and thank you for contributing!</div>
+    the morale range (this is morale before battle started, so at port screen/map selection) and thank you for contributing!</div>
   <div class="help_q">Why is my player ID and username being submitted?</div>
   <div class="help_a">This is so that we can filter out data tampering.</div>
   <div class="help_q">What other data is being submitted?</div>

--- a/src/pages/strategy/tabs/gunfits/gunfits.html
+++ b/src/pages/strategy/tabs/gunfits/gunfits.html
@@ -27,8 +27,8 @@
         </div>
         <div class="clear"></div>
         <div class="lvl">
-          Requested Lv.: <span class="requested">?~?</span><br>
-          Owned Lv.: <span class="lvl_status">/</span>
+          Req. Lvl: <span class="requested">?~?</span><br>
+          Owned Lvl: <span class="lvl_status">/</span>
           <div class="clear"></div>
         </div>
         <div class="ship_status"></div>

--- a/src/pages/strategy/tabs/gunfits/gunfits.js
+++ b/src/pages/strategy/tabs/gunfits/gunfits.js
@@ -40,6 +40,11 @@
 		execute :function(){
 			let self = this;
 			
+			if(ConfigManager.TsunDBSubmissionExtra_enabled)
+				$(".setting_disabled").hide();
+			else
+				$(".setting_disabled").show();
+
 			let shipClickFunc = function(e){
 				KC3StrategyTabs.gotoTab("mstship", $(this).attr("alt"));
 			};
@@ -85,6 +90,7 @@
 				}
 
 				// Generate equipment info
+				let requiredCount = {};
 				$(".ship_gears .gear_status", testItem).text("Good to go!");
 				$.each(test.equipment, function(i, gearId) {
 					let ship_gear = $(".tab_gunfits .factory .ship_gear").clone();
@@ -99,8 +105,8 @@
 						.click(gearClickFunc);
 					$(".gear_name", ship_gear).text(gearName);
 					$(".owned", ship_gear).text(`Owned: x${ownedGear.length}`);
-					if(ownedGear.length == 0) {
-						// TODO support multiple same equip
+					requiredCount[gearId] = (requiredCount[gearId] || 0) + 1;
+					if(ownedGear.length < requiredCount[gearId]) {
 						$(".ship_gears .gear_status", testItem).text("Missing some equipment");
 						testItem.addClass("testingImpossible");
 					}

--- a/src/pages/strategy/tabs/gunfits/gunfits.js
+++ b/src/pages/strategy/tabs/gunfits/gunfits.js
@@ -119,7 +119,7 @@
 					$(".curr_fleet_status", testItem).text(`First fleet ready!`);
 					testItem.addClass("testingActive");
 				}
-			}
+			};
 
 			$.each( self.tests, function(i,test) {
 				let testItem = $(".tab_gunfits .factory .testitem").clone();

--- a/src/pages/strategy/tabs/gunfits/gunfits.js
+++ b/src/pages/strategy/tabs/gunfits/gunfits.js
@@ -127,7 +127,7 @@
 				}
 			};
 
-			$.each( self.tests, function(i,test) {
+			$.each( self.tests.filter((test) => test.active), function(i,test) {
 				let testItem = $(".tab_gunfits .factory .testitem").clone();
 				generateTestItem(test, testItem);
 				testItem.appendTo(".section_currenttests .box_tests");

--- a/src/pages/strategy/tabs/gunfits/gunfits.js
+++ b/src/pages/strategy/tabs/gunfits/gunfits.js
@@ -1,0 +1,132 @@
+(function(){
+	"use strict";
+
+	KC3StrategyTabs.gunfits = new KC3StrategyTab("gunfits");
+
+	KC3StrategyTabs.gunfits.definition = {
+		tabSelf: KC3StrategyTabs.gunfits,
+		tests: [],
+
+		/* INIT
+		Prepares all data needed
+		---------------------------------*/
+		init :function(){
+			// TODO load/cache from some URL
+			this.tests = [
+				{
+					"shipId": 576,
+					"lvlRange": [90, 99],
+					"moraleRange": [0, 52],
+					"equipment": [289, 300]
+				},
+				{
+					"shipId": 576,
+					"lvlRange": [90, 99],
+					"moraleRange": [0, 52],
+					"equipment": [183]
+				},
+				{
+					"shipId": 571,
+					"lvlRange": [90, 99],
+					"moraleRange": [0, 52],
+					"equipment": [9]
+				}
+			];
+		},
+
+		/* RELOAD
+		Prepares latest ships data
+		---------------------------------*/
+		reload :function(){
+			KC3ShipManager.load();
+			KC3GearManager.load();
+		},
+
+		/* EXECUTE
+		Places data onto the interface
+		---------------------------------*/
+		execute :function(){
+			var self = this;
+			
+			var shipClickFunc = function(e){
+				KC3StrategyTabs.gotoTab("mstship", $(this).attr("alt"));
+			};
+			var gearClickFunc = function(e){
+				KC3StrategyTabs.gotoTab("mstship", $(this).attr("alt"));
+			};
+			var rangeText = function(range){
+				if(range[0] == range[1])
+					return range[0];
+				return range.join(" ~ ");
+			}
+			var generateTestItem = function(test, testItem) {
+				// Generate ship info
+				let shipId = test.shipId;
+				let shipName = KC3Meta.shipName(KC3Master.ship(shipId).api_name);
+				let ownedShips = KC3ShipManager.find((a) => a.masterId == shipId);
+
+				$(".shipinfo .generalship .ship_icon img", testItem)
+					.attr("src", KC3Meta.shipIcon(shipId))
+					.attr("alt", shipId )
+					.click(shipClickFunc)
+					.attr("title", `${shipName} [${shipId}]`);
+				$(".shipinfo .generalship .name", testItem).text(shipName);
+
+				$(".shipinfo .lvl .requested", testItem).text(rangeText(test.lvlRange));
+				if(ownedShips.length > 0) {
+					$(".shipinfo .lvl .lvl_status", testItem).text(ownedShips.map((a) => a.level).join(", "));
+
+					// check if owned are within requested level range
+					if(ownedShips.filter((a) => a.level >= test.lvlRange[0] && a.level <= test.lvlRange[1]).length > 0) {
+						$(".shipinfo .ship_status", testItem).text("Good to go!");
+					} else {
+						$(".shipinfo .ship_status", testItem).text("You own this remodel, but not correct level");
+						testItem.addClass("testingImpossible");
+					}
+				} else {
+					$(".shipinfo .lvl .lvl_status", testItem).text("/");
+					if(KC3ShipManager.find((a) => RemodelDb.originOf(a.masterId) == RemodelDb.originOf(shipId)).length > 0)
+						$(".shipinfo .ship_status", testItem).text("You own this ship, but not this remodel");
+					else
+						$(".shipinfo .ship_status", testItem).text("You don't own this ship");
+					testItem.addClass("testingImpossible");
+				}
+
+				// Generate equipment info
+				$(".ship_gears .gear_status", testItem).text("Good to go!");
+				$.each(test.equipment, function(i, gearId) {
+					let ship_gear = $(".tab_gunfits .factory .ship_gear").clone();
+					let masterGear = KC3Master.slotitem(gearId);
+					let gearName = KC3Meta.gearName(masterGear.api_name);
+					let ownedGear = KC3GearManager.find((a) => a.masterId == gearId)
+
+					$(".gear_icon img", ship_gear)
+						.attr("src", KC3Meta.itemIcon(masterGear.api_type[3]))
+						.attr("title", `${gearName} [${gearId}]`)
+						.attr("alt", gearId)
+						.click(gearClickFunc);
+					$(".gear_name", ship_gear).text(gearName);
+					$(".owned", ship_gear).text(`Owned: x${ownedGear.length}`);
+					if(ownedGear.length == 0) {
+						// TODO support multiple same equip
+						$(".ship_gears .gear_status", testItem).text("Missing some equipment");
+						testItem.addClass("testingImpossible");
+					}
+					ship_gear.appendTo($(".ship_gears .gearsbox", testItem));
+				});
+				
+				// Generate morale info
+				$(".morale_range", testItem).text(`Morale: ${rangeText(test.moraleRange)}`)
+			}
+
+			$.each( self.tests, function(i,test) {
+				let testItem = $(".tab_gunfits .factory .testitem").clone()
+				generateTestItem(test, testItem);
+				testItem.appendTo(".section_currenttests .box_tests");
+			});
+
+		}
+
+	};
+
+})();

--- a/src/pages/strategy/tabs/gunfits/gunfits.js
+++ b/src/pages/strategy/tabs/gunfits/gunfits.js
@@ -40,7 +40,7 @@
 		execute :function(){
 			let self = this;
 			
-			if(ConfigManager.TsunDBSubmissionExtra_enabled)
+			if(ConfigManager.TsunDBSubmissionExtra_enabled && ConfigManager.TsunDBSubmission_enabled)
 				$(".setting_disabled").hide();
 			else
 				$(".setting_disabled").show();

--- a/src/pages/strategy/themes/dark.css
+++ b/src/pages/strategy/themes/dark.css
@@ -2445,3 +2445,9 @@ button, input, select, textarea {
 .tab_gunfits .testitem.testingImpossible {
     background: #621f1f;
 }
+.tab_gunfits .testitem.testingWrongMorale {
+    background: #736200;
+}
+.tab_gunfits .testitem.testingActive {
+    background: #1f9a00;
+}

--- a/src/pages/strategy/themes/dark.css
+++ b/src/pages/strategy/themes/dark.css
@@ -2434,3 +2434,14 @@ button, input, select, textarea {
 	border:1px solid #555;
 	background:#333;
 }
+
+/* GUN_FITS
+--------------------------------*/
+.tab_gunfits .testitem {
+	border-bottom:1px solid #555555;
+	border-radius:0px;
+	padding: 5px 0px 5px 0px !important;
+}
+.tab_gunfits .testitem.testingImpossible {
+    background: #621f1f;
+}

--- a/src/pages/strategy/themes/legacy.css
+++ b/src/pages/strategy/themes/legacy.css
@@ -1908,3 +1908,9 @@ body {
 .tab_gunfits .testitem.testingImpossible {
     background: #fcc;
 }
+.tab_gunfits .testitem.testingWrongMorale {
+    background: #ffc;
+}
+.tab_gunfits .testitem.testingActive {
+    background: #cfc;
+}

--- a/src/pages/strategy/themes/legacy.css
+++ b/src/pages/strategy/themes/legacy.css
@@ -1897,3 +1897,14 @@ body {
 .tab_shipdrop .filters .time_input input {
 	border:1px solid #aaa;
 }
+
+/* GUN_FITS
+--------------------------------*/
+.tab_gunfits .testitem {
+	border:10px solid transparent;
+	background:#def;
+	border-radius:10px;
+}
+.tab_gunfits .testitem.testingImpossible {
+    background: #fcc;
+}


### PR DESCRIPTION
Automated submission of samples for purpose of (gun)fit verification.

Works by having some page in strategy room where testers can see which tests they can do, and choose one to do. This will make anyone able to do help out with these tests since barrier of entry previously was way higher (setting up logbook, calculating yourself etc). Moving the setup & calculation part away might make it more appealing to some. 

Tab:
Shows whenever or not the user has the required ship/level/equipment and disable the ones that are impossible to test currently.
![Normal screen](https://user-images.githubusercontent.com/5676386/48509267-e44bca00-e850-11e8-9b68-359e0479e75d.png)
When the tester has the ship(s) set up, it'll color yellow/green depending on if correct morale has been reached. 
![Incorrect morale](https://user-images.githubusercontent.com/5676386/48509327-178e5900-e851-11e8-8d4d-b99f03a31f4a.png)
![Ready](https://user-images.githubusercontent.com/5676386/48509440-6c31d400-e851-11e8-91e6-bbbb40d6a085.png)

