### PR TITLE
Add indicator for one-time sortie attacks

### DIFF
--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -662,6 +662,13 @@ Used by SortieManager
 			this.unexpectedList.push(...this.unexpectedDamagePrediction(result.fleets.playerEscort,
 				1, battleData.api_formation[0], battleData.api_formation[2], isRealBattle)
 			);
+
+			// Check for any one-time special cutin
+			const checkSortieSpecialAttack = attacks => attacks.some(attack => (attack.cutin || attack.ncutin) >= 100);
+			const playerMain = result.fleets.playerMain;
+			if (checkSortieSpecialAttack(playerMain[0].attacks)) {
+				this.sortieSpecialAttack = playerMain.map(ship => checkSortieSpecialAttack(ship.attacks));
+			}
 		}
 
 		if(this.gaugeDamage > -1) {
@@ -929,6 +936,12 @@ Used by SortieManager
 			this.unexpectedList.push(...this.unexpectedDamagePrediction(result.fleets.playerEscort,
 				1, nightData.api_formation[0], nightData.api_formation[2], isRealBattle)
 			);
+			// Check for any one-time special cutin
+			const checkSortieSpecialAttack = attacks => attacks.some(attack => (attack.cutin || attack.ncutin) >= 100);
+			const playerMain = result.fleets.playerMain;
+			if (checkSortieSpecialAttack(playerMain[0].attacks)) {
+				this.sortieSpecialAttack = playerMain.map(ship => checkSortieSpecialAttack(ship.attacks));
+			}
 		}
 		
 		if(this.gaugeDamage > -1

--- a/src/pages/devtools/themes/natsuiro/js/Shipbox.js
+++ b/src/pages/devtools/themes/natsuiro/js/Shipbox.js
@@ -244,7 +244,7 @@
 		})(this.shipData.hp[0])).lazyInitTooltip();
 		
 		// Clear box colors
-		this.element.css("background-color", "transparent");
+		// this.element.css("background-color", "transparent");
 		
 		// Import repair time script by @Javran
 		var repairTimes = this.shipData.repairTime();
@@ -262,37 +262,42 @@
 			$(".ship_hp_box", this.element).attr("title", KC3Meta.term("PanelNoRepair"))
 				.lazyInitTooltip({ position: { at: "left+25 bottom+5" } });
 		}
-		
+
+		// Clear all classes
+		var hpClasses = ['hp_repairing', 'hp_fcf', 'hp_taiha', 'hp_chuuha', 'hp_shouha', 'hp_normal', 'akashiMark']
+		this.element.removeClass(hpClasses.join(' '))
+		$(".ship_hp_bar", this.element).removeClass(hpClasses.join(' '))
+
 		// If ship is being repaired
-		if( PlayerManager.repairShips.indexOf( this.shipData.rosterId ) > -1){
-			$(".ship_hp_bar", this.element).css("background", "#aaccee");
-			this.element.css("background-color", "rgba(100,255,100,0.3)");
-		// If not being repaired
-		}else{
-			if(this.shipData.didFlee){
+		if (PlayerManager.repairShips.indexOf(this.shipData.rosterId) > -1) {
+			$(".ship_hp_bar", this.element).addClass("hp_repairing")
+			this.element.addClass("hp_repairing")
+			// If not being repaired
+		} else {
+			if (this.shipData.didFlee) {
 				//console.debug("Ship", this.shipData.name(), "fled, setting backgrounds to white");
 				// if FCF, mark background and hp bar as white
-				$(".ship_hp_bar", this.element).css("background", "#fff");
-				this.element.css("background", "rgba(255,255,255,0.4)");
-			}else{
-				if(hpPercent <= 0.25){
+				$(".ship_hp_bar", this.element).addClass("hp_fcf")
+				this.element.addClass("hp_fcf")
+			} else {
+				if (hpPercent <= 0.25) {
 					// mark hp bar and container box as red if taiha
-					$(".ship_hp_bar", this.element).css("background", "#FF0000");
-					this.element.css("background", "rgba(255,0,0,0.4)");
-				} else if(hpPercent <= 0.50){
-					$(".ship_hp_bar", this.element).css("background", "#FF9900");
-				} else if(hpPercent <= 0.75){
-					$(".ship_hp_bar", this.element).css("background", "#FFFF00");
-				} else{
-					$(".ship_hp_bar", this.element).css("background", "#00FF00");
+					$(".ship_hp_bar", this.element).addClass("hp_taiha")
+					this.element.addClass("hp_taiha")
+				} else if (hpPercent <= 0.50) {
+					$(".ship_hp_bar", this.element).addClass("hp_chuuha")
+				} else if (hpPercent <= 0.75) {
+					$(".ship_hp_bar", this.element).addClass("hp_shouha")
+				} else {
+					$(".ship_hp_bar", this.element).addClass("hp_normal")
 				}
 			}
-			
-			if(this.shipData.akashiMark) {
-				this.element.css("background-color", "rgba(191,255,100,0.15)");
+
+			if (this.shipData.akashiMark) {
+				this.element.addClass("akashiMark")
 			}
 		}
-		
+
 		this.hideAkashi();
 	};
 	

--- a/src/pages/devtools/themes/natsuiro/js/Shipbox.js
+++ b/src/pages/devtools/themes/natsuiro/js/Shipbox.js
@@ -264,37 +264,37 @@
 		}
 
 		// Clear all classes
-		var hpClasses = ['hp_repairing', 'hp_fcf', 'hp_taiha', 'hp_chuuha', 'hp_shouha', 'hp_normal', 'akashiMark']
-		this.element.removeClass(hpClasses.join(' '))
-		$(".ship_hp_bar", this.element).removeClass(hpClasses.join(' '))
+		var hpClasses = ['hp_repairing', 'hp_fcf', 'hp_taiha', 'hp_chuuha', 'hp_shouha', 'hp_normal', 'akashiMark'];
+		this.element.removeClass(hpClasses.join(' '));
+		$(".ship_hp_bar", this.element).removeClass(hpClasses.join(' '));
 
 		// If ship is being repaired
 		if (PlayerManager.repairShips.indexOf(this.shipData.rosterId) > -1) {
-			$(".ship_hp_bar", this.element).addClass("hp_repairing")
-			this.element.addClass("hp_repairing")
+			$(".ship_hp_bar", this.element).addClass("hp_repairing");
+			this.element.addClass("hp_repairing");
 			// If not being repaired
 		} else {
 			if (this.shipData.didFlee) {
 				//console.debug("Ship", this.shipData.name(), "fled, setting backgrounds to white");
 				// if FCF, mark background and hp bar as white
-				$(".ship_hp_bar", this.element).addClass("hp_fcf")
-				this.element.addClass("hp_fcf")
+				$(".ship_hp_bar", this.element).addClass("hp_fcf");
+				this.element.addClass("hp_fcf");
 			} else {
 				if (hpPercent <= 0.25) {
 					// mark hp bar and container box as red if taiha
-					$(".ship_hp_bar", this.element).addClass("hp_taiha")
-					this.element.addClass("hp_taiha")
+					$(".ship_hp_bar", this.element).addClass("hp_taiha");
+					this.element.addClass("hp_taiha");
 				} else if (hpPercent <= 0.50) {
-					$(".ship_hp_bar", this.element).addClass("hp_chuuha")
+					$(".ship_hp_bar", this.element).addClass("hp_chuuha");
 				} else if (hpPercent <= 0.75) {
-					$(".ship_hp_bar", this.element).addClass("hp_shouha")
+					$(".ship_hp_bar", this.element).addClass("hp_shouha");
 				} else {
-					$(".ship_hp_bar", this.element).addClass("hp_normal")
+					$(".ship_hp_bar", this.element).addClass("hp_normal");
 				}
 			}
 
 			if (this.shipData.akashiMark) {
-				this.element.addClass("akashiMark")
+				this.element.addClass("akashiMark");
 			}
 		}
 

--- a/src/pages/devtools/themes/natsuiro/js/Shipbox.js
+++ b/src/pages/devtools/themes/natsuiro/js/Shipbox.js
@@ -264,9 +264,9 @@
 		}
 
 		// Clear all classes
-		var hpClasses = ['hp_repairing', 'hp_fcf', 'hp_taiha', 'hp_chuuha', 'hp_shouha', 'hp_normal', 'akashiMark'];
-		this.element.removeClass(hpClasses.join(' '));
-		$(".ship_hp_bar", this.element).removeClass(hpClasses.join(' '));
+		var hpClasses = ['hp_repairing', 'hp_fcf', 'hp_taiha', 'hp_chuuha', 'hp_shouha', 'hp_normal', 'akashiMark'].join(' ');
+		this.element.removeClass(hpClasses);
+		$(".ship_hp_bar", this.element).removeClass(hpClasses);
 
 		// If ship is being repaired
 		if (PlayerManager.repairShips.indexOf(this.shipData.rosterId) > -1) {

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -3038,6 +3038,9 @@ ABYSS FLEET
 	float:left;
 	margin:0px 5px 0px 0px;
 }
+.module.fleet .attack_cutin {
+	background-color: rebeccapurple !important;
+}
 /* Long Ship */
 .module.fleet .lship {
 	width:340px;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -3041,8 +3041,21 @@ ABYSS FLEET
 	float:left;
 	margin:0px 5px 0px 0px;
 }
+.module.fleet .hp_repairing {
+	background-color: rgba(100, 255, 100, 0.3);
+}
+.module.fleet .hp_fcf {
+	background-color: rgba(255, 255, 255, 0.4);
+}
+.module.fleet .akashiMark {
+	background-color: rgba(191, 255, 100, 0.15);
+}
 .module.fleet .attack_cutin {
-	background-color: rebeccapurple !important;
+	background-color: rebeccapurple;
+}
+.module.fleet .hp_taiha,
+.module.fleet .hp_taiha.attack_cutin {
+	background-color: rgba(255, 0, 0, 0.4);
 }
 /* Long Ship */
 .module.fleet .lship {
@@ -3215,6 +3228,24 @@ ABYSS FLEET
 	border:1px solid #000;
 	background:#555;
 	position:relative;
+}
+.module.fleet .ship_hp_bar.hp_repairing {
+	background-color: #aaccee;
+}
+.module.fleet .ship_hp_bar.hp_fcf {
+	background-color: #fff;
+}
+.module.fleet .ship_hp_bar.hp_normal {
+	background-color: #0f0;
+}
+.module.fleet .ship_hp_bar.hp_shouha {
+	background-color: #ff0;
+}
+.module.fleet .ship_hp_bar.hp_chuuha {
+	background-color: #f90;
+}
+.module.fleet .ship_hp_bar.hp_taiha {
+	background-color: #f00;
 }
 .module.fleet .lship .ship_hp_bar {
 	height:9px;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -635,6 +635,9 @@ html,body {
 	font-size:9px;
 	letter-spacing:-1px;
 }
+.module.activity .sortie_node.attack_cutin {
+	box-shadow: 0px 0px 2px 2px #FF8C00;
+}
 .module.activity .sortie_nodes .boss_node {
 	float:left;
 	position:absolute;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -1004,8 +1004,6 @@
 					localStorage.lastBackupReminder = currentTime;
 				}
 			}
-
-			localStorage.setItem('attackCutin', JSON.stringify({}))
 		},
 
 		CatBomb: function(data){
@@ -1499,33 +1497,7 @@
 			var isSentOut = KC3SortieManager.isOnSortie() || KC3SortieManager.isPvP();
 			var thisNode = isSentOut ? KC3SortieManager.currentNode() : {};
 			var flarePos = thisNode.flarePos || 0;
-
-			var checkAttackCutin = (attackCutin, fleetIndex, shipIndex) => {
-				if (fleetIndex !== attackCutin.fleet) {
-					return false
-				}
-				switch (attackCutin.type) {
-					case 100:
-						return !(shipIndex % 2)
-					case 101:
-						return shipIndex < 2
-				}
-				return false
-			}
-
-			var attackCutin = {}
-			if (isSentOut) {
-				attackCutin = JSON.parse(localStorage.getItem('attackCutin')) || {}
-				var predictedFleets = thisNode.predictedFleetsDay || thisNode.predictedFleetsNight
-				if (predictedFleets) {
-					var cutinData = predictedFleets.playerMain[0].attacks.filter(attack => (attack.cutin || attack.ncutin) >= 100)
-					if (cutinData.length) {
-						attackCutin.fleet = KC3SortieManager.fleetSent
-						attackCutin.type = cutinData[0].cutin || cutinData[0].ncutin
-						localStorage.setItem('attackCutin', JSON.stringify(attackCutin))
-					}
-				}
-			}
+			var sortieSpecialAttack = ConfigManager.info_compass ? (thisNode.sortieSpecialAttack || []) : [];
 
 			// COMBINED
 			if(selectedFleet == 5){
@@ -1548,7 +1520,7 @@
 						(new KC3NatsuiroShipbox(".sship", rosterId, index, showCombinedFleetBars, dameConConsumed, starShellUsed, noAirBombingDamage))
 							.commonElements()
 							.defineShort(MainFleet)
-							.toggleClass("attack_cutin", checkAttackCutin(attackCutin, 1, index))
+							.toggleClass("attack_cutin", !!sortieSpecialAttack[index])
 							.appendTo(".module.fleet .shiplist_main");
 					}
 				});
@@ -1576,7 +1548,6 @@
 						(new KC3NatsuiroShipbox(".sship", rosterId, index, showCombinedFleetBars, dameConConsumed, starShellUsed, noAirBombingDamage))
 							.commonElements(true)
 							.defineShort(EscortFleet)
-							.toggleClass("attack_cutin", checkAttackCutin(attackCutin, 2, index))
 							.appendTo(".module.fleet .shiplist_escort");
 					}
 				});
@@ -1668,7 +1639,7 @@
 							.commonElements()
 							.defineLong(CurrentFleet)
 							.toggleClass("seven", CurrentFleet.countShips() >= 7)
-							.toggleClass("attack_cutin", checkAttackCutin(attackCutin, selectedFleet, index))
+							.toggleClass("attack_cutin", !!sortieSpecialAttack[index])
 							.appendTo(".module.fleet .shiplist_single");
 					}
 				});
@@ -3003,6 +2974,13 @@
 						.delay( 5000 )
 						.fadeOut(1000, function(){ $(this).remove(); } );
 				});
+			}
+
+			// Add background to node letter if one-time special attack was used
+			const numNodes = KC3SortieManager.countNodes();
+			if (thisNode.sortieSpecialAttack && ConfigManager.info_compass) {
+				$(".module.activity .sortie_node_"+numNodes)
+					.toggleClass("attack_cutin", true);
 			}
 		},
 

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -908,6 +908,7 @@
 		$(".module.activity .sortie_node").text("").removeAttr("title")
 			.removeClass("nc_battle nc_resource nc_maelstrom nc_select nc_avoid long_name")
 			.removeClass(KC3Node.knownNodeExtraClasses().join(" "));
+		$(".module.activity .sortie_node").removeClass("attack_cutin");
 		$(".module.activity .sortie_nodes .boss_node").removeAttr("style");
 		$(".module.activity .sortie_nodes .boss_node").hide();
 		$(".module.activity .node_types").hide();


### PR DESCRIPTION
Add a purple background to shipboxes involved in special attacks (Nagato Cutin/Nelson Touch)
Highlight node letters where special attack has activated
Node letter highlight is only added on battle results

EDIT: realized that the purple bg blocks out the red taiha bg and could be potentially dangerous for players in the below case

EDIT2: fixed

Day battle example
![image](https://user-images.githubusercontent.com/26541502/50574177-f80db880-0e1d-11e9-9eda-c6b1ad77d62b.png)
Night battle
![image](https://cdn.discordapp.com/attachments/529146771742523402/529718540257853441/unknown.png)

Resolves https://github.com/KC3Kai/KC3Kai/issues/2733