### PR TITLE
Display special attack proc chance in ship tooltip

### DIFF
--- a/src/library/objects/Fleet.js
+++ b/src/library/objects/Fleet.js
@@ -1318,6 +1318,24 @@ Contains summary information about a fleet and its ships
 		return result.every(v => v === -1) ? false : result;
 	};
 
+	/**
+	 * Get fleet LoS for determining artillery spotting rate
+	 * @see KC3Ship.dayBattleBaseValue
+	 */
+	KC3Fleet.prototype.artillerySpottingLineOfSight = function() {
+		let value = 0;
+		this.shipsUnescaped().forEach(ship => {
+			value += ship.nakedLoS();
+			ship.equipment().forEach((equip, index) => {
+				const master = equip.master();
+				if (master && [10, 11].includes(master.api_type[2])) {
+					value += Math.floor(Math.sqrt(ship.slots[index] || 0)) * (master.api_saku || 0);
+				}
+			});
+		});
+		return value;
+	};
+
 	/*--------------------------------------------------------*/
 	/*----------------------[ DATA EXPORT ]-------------------*/
 	/*--------------------------------------------------------*/

--- a/src/library/objects/Node.js
+++ b/src/library/objects/Node.js
@@ -454,6 +454,7 @@ Used by SortieManager
 		this.econtactId = planePhase.api_touch_plane[1];
 		this.econtact = this.econtactId > 0 ? KC3Meta.term("BattleContactYes") : KC3Meta.term("BattleContactNo");
 		
+		this.seiku = planePhase.api_disp_seiku;
 		this.airbattle = KC3Meta.airbattle( planePhase.api_disp_seiku );
 		
 		if(!!attackPhase && !!attackPhase.api_air_fire){


### PR DESCRIPTION
Night battle rates established on both wikia/wikiwiki https://kancolle.wikia.com/wiki/Combat/Night_Battle#Night_Cut-In_Chance and https://wikiwiki.jp/kancolle/%E5%A4%9C%E6%88%A6#nightcutin1

Day battle rates uses psvita formulae and may be unreliable, with CVCI introduction and combined fleet https://kancolle.wikia.com/wiki/User_blog:Shadow27X/Artillery_Spotting_Rate_Formula

![image](https://user-images.githubusercontent.com/26541502/51082145-631f8f00-173c-11e9-819f-90bb7ee0326b.png)
Need some of these functions for upcoming tsundb submitter to get new type factors