### PR TITLE
Add taiha warning popup on continue/advance

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -739,6 +739,12 @@
 				"name" : "SettingsNoAnimation",
 				"type" : "check",
 				"options" : {}
+			},
+			{
+				"id" : "alert_taiha_continue",
+				"name" : "SettingTaihaContinueWarning",
+				"type" : "check",
+				"options" : {}
 			}
 		]
 	},

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -121,6 +121,7 @@ Retrieves when needed to apply on components
 				alert_taiha_homeport : false,
 				alert_taiha_damecon  : false,
 				alert_taiha_noanim   : false,
+				alert_taiha_continue : true,
 
 				api_translation   : true,
 				api_tracking      : true,

--- a/src/library/modules/Network.js
+++ b/src/library/modules/Network.js
@@ -15,6 +15,7 @@ Listens to network history and triggers callback if game events happen
 			CatBomb: [],
 			APIError: [],
 			Bomb201: [],
+			ContinueOnTaiha: [],
 			ModalBox: [],
 			GameUpdate: [],
 			DebuffNotify: [],

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -1133,6 +1133,18 @@
 			}
 		},
 
+		ContinueOnTaiha: function(data){
+			$("#catBomb").hide();
+			
+			if (!ConfigManager.alert_taiha_continue) return false;
+			
+			$("#catBomb .title").html( data.title );
+			$("#catBomb .description").html( data.message );
+			$("#catBomb .download").hide();
+			$("#catBomb .content").removeClass("withDownload");
+			$("#catBomb").fadeIn(300);
+		},
+
 		HQ: function(data){
 			$(".module.admiral").hideChildrenTooltips();
 			$(".admiral_name").text( PlayerManager.hq.name );
@@ -2486,6 +2498,27 @@
 				$(".module.activity .sortie_nodes .sortie_node").hide();
 			} else {
 				$(".module.activity .sortie_nodes .sortie_node").show();
+			}
+			
+			if (ConfigManager.alert_taiha_continue) {
+				let str = "";
+				const buildShipTaihaMessage = ship => KC3Meta.term("PanelTaihaContinueMessage").format(ship.name(), ship.level);
+				const fleet = PlayerManager.fleets[KC3SortieManager.fleetSent - 1];
+				let hasTaiha = fleet.hasTaiha();
+				let taihaIndexes = fleet.getTaihas();
+				taihaIndexes.forEach(index => str += buildShipTaihaMessage(fleet.ship(index)));
+				if (KC3SortieManager.isCombinedSortie()) {
+					const fleet2 = PlayerManager.fleets[1];
+					hasTaiha = hasTaiha || fleet2.hasTaiha();
+					taihaIndexes = fleet2.getTaihas();
+					taihaIndexes.forEach(index => str += buildShipTaihaMessage(fleet2.ship(index)));
+				}
+				if (hasTaiha) {
+					KC3Network.trigger("ContinueOnTaiha", {
+						title: KC3Meta.term("PanelTaihaContinueTitle"),
+						message: str,
+					});
+				}
 			}
 		},
 


### PR DESCRIPTION
If player advances with taiha ship in fleet(s), will alert him via panel warning on `/next`

Not sure if we need another after having annoying taiha alert and red glow in panel, but maybe direct warning is more visible

![image](https://user-images.githubusercontent.com/26541502/51393756-6cad5a80-1b73-11e9-9593-9fbeab488384.png)