### PR TITLE
Add DE modding submissions for TsunDB

### DIFF
--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -947,7 +947,7 @@
 			const ship = KC3ShipManager.get(data.rosterId);
 			const modFod = data.consumedMasterIds.map((id) => KC3Master.ship(id));
 
-			// Checks in RemodelUtils.calcPowerUpParams
+			// Checks in main.js#RemodelUtils.calcPowerUpParams
 			const deCount = modFod.filter((s) => s.api_stype == 1).length;
 
 			const mizuhoCount = modFod.filter((s) => s.api_ctype == 62).length;

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -206,7 +206,18 @@
 			result: null,
 			success: null
 		},
+		lolimodfod: {
+			shipid: null,
+			shiplvl: null,
+			modids: null,
+			modlvls: null,
+
+			modbefore: null,
+			modafter: null,
+			modleft: null
+		},
 		handlers : {},
+		networkListener: false,
 		mapInfo : [],
 		currentMap : [0, 0],
 		
@@ -253,12 +264,26 @@
 				'api_req_kousyou/createitem': this.processDevelopment,
 
 				// Debuff gimmick check
-				'api_port/port': this.processGimmick
+				'api_port/port': [this.processGimmick, this.addListener],
+
+				'Modernize': this.processModernize
 			};
 			this.manifest = chrome.runtime.getManifest() || {};
 			this.kc3version = this.manifest.version + ("update_url" in this.manifest ? "" : "d");
 		},
 		
+		addListener: function() {
+			if(!this.networkListener) {
+				this.networkListener = true;
+				const handlers = this.handlers;
+
+				KC3Network.addGlobalListener(function(event, data) {
+					if(handlers[event] != undefined)
+						handlers[event](data);
+				});
+			}
+		},
+
 		processMapInfo: function(http) {
 			this.mapInfo = $.extend(true, [], http.response.api_data.api_map_info);
 		},
@@ -917,7 +942,29 @@
 			//console.debug(this.development);
 			this.sendData(this.development, 'development');
 		},
-		
+
+		processModernize: function(data) {
+			const ship = KC3ShipManager.get(data.rosterId);
+			const modFod = data.consumedMasterIds.map((id) => KC3Master.ship(id));
+
+			// DE mod filter
+			if (modFod.filter((s) => s.api_stype == 1).length == 0)
+				return;
+
+			this.lolimodfod = {
+				shipid: ship.masterId,
+				shiplvl: ship.level,
+				modids: data.consumedMasterIds,
+				modlvls: data.consumedMasterLevels,
+	
+				modbefore: data.oldMod,
+				modafter: data.newMod,
+				modleft: data.left
+			};
+			//console.debug(this.lolimodfod);
+			this.sendData(this.lolimodfod, 'lolimodfod');
+		},
+
 		handleFleet: function(fleet) {
 			// Update fleet minimal speed
 			fleet.speed();
@@ -946,7 +993,7 @@
 				if(gf.updateTime + 3 > currentHour) // Cache for ~3h
 					return;
 			}
-			const dataSourceUrl = `https://raw.githubusercontent.com/Tibo442/TsunTools/master/config/gunfits.json?cache=${currentHour}`;
+			const dataSourceUrl = `https://raw.githubusercontent.com/Tibowl/TsunTools/master/config/gunfits.json?cache=${currentHour}`;
 			$.getJSON(dataSourceUrl, newGunfitData => {
 				if(callback) callback(newGunfitData);
 				localStorage.tsundb_gunfits = JSON.stringify({

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -946,9 +946,12 @@
 		processModernize: function(data) {
 			const ship = KC3ShipManager.get(data.rosterId);
 			const modFod = data.consumedMasterIds.map((id) => KC3Master.ship(id));
+			const deCount = modFod.filter((s) => s.api_stype == 1).length;
+			const mizuhoKamoiCount = modFod.filter((s) => [62, 72].indexOf(s.api_ctype)).length;
+			const isMizuhoKamoiHPAble = [72, 62, 41, 37].indexOf(ship.master().api_ctype) >= 0;
 
-			// DE mod filter
-			if (modFod.filter((s) => s.api_stype == 1).length == 0)
+			// DE / Mizuho/Kamoi mod filter
+			if (deCount == 0 && !(isMizuhoKamoiHPAble && mizuhoKamoiCount > 0))
 				return;
 
 			this.lolimodfod = {

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -946,12 +946,18 @@
 		processModernize: function(data) {
 			const ship = KC3ShipManager.get(data.rosterId);
 			const modFod = data.consumedMasterIds.map((id) => KC3Master.ship(id));
+
+			// Checks in RemodelUtils.calcPowerUpParams
 			const deCount = modFod.filter((s) => s.api_stype == 1).length;
-			const mizuhoKamoiCount = modFod.filter((s) => [62, 72].indexOf(s.api_ctype)).length;
-			const isMizuhoKamoiHPAble = [72, 62, 41, 37].indexOf(ship.master().api_ctype) >= 0;
+
+			const mizuhoCount = modFod.filter((s) => s.api_ctype == 62).length;
+			const isMizuhoHPAble = [62, 72].indexOf(ship.master().api_ctype) >= 0;
+
+			const kamoiCount = modFod.filter((s) => s.api_ctype == 72).length;
+			const isKamoiHPAble = [72, 62, 41, 37].indexOf(ship.master().api_ctype) >= 0;
 
 			// DE / Mizuho/Kamoi mod filter
-			if (deCount == 0 && !(isMizuhoKamoiHPAble && mizuhoKamoiCount > 0))
+			if (deCount == 0 && !(isMizuhoHPAble && mizuhoCount >= 2) && !(isKamoiHPAble && kamoiCount >= 2))
 				return;
 
 			this.lolimodfod = {


### PR DESCRIPTION
Uses KC3Network listener because Kcsapi.js will have handled the modernization by the time the (async) DB submittor gets it (can't get lvl/master id of consumed ships / mod difference).