### PR TITLE
Display ship bonuses with equipment in ship library

### DIFF
--- a/src/library/modules/Meta.js
+++ b/src/library/modules/Meta.js
@@ -240,6 +240,21 @@ Provides access to data on built-in JSON files
 			const path = "stats" + (["", "", "_p2"][iconSetId || 0] || "");
 			return chrome.extension.getURL(`/assets/img/${path}/${statName}.png`);
 		},
+
+		statIconApi :function (statName, iconSetId = ConfigManager.info_stats_iconset) {
+			const statApiNames = {
+				"tyku": "aa",
+				"souk": "ar",
+				"tais": "as",
+				"houk": "ev",
+				"houg": "fp",
+				"saku": "ls",
+				"raig": "tp",
+				"houm": "ac",
+				"leng": "rn"
+			};
+			return KC3Meta.statIcon(statApiNames[statName], iconSetId);
+		},
 		
 		itemIconsByType2 :function(type2Id){
 			if(!this._type2IconMap){

--- a/src/pages/strategy/tabs/mstship/mstship.css
+++ b/src/pages/strategy/tabs/mstship/mstship.css
@@ -708,6 +708,132 @@
 	background:inherit;
 	text-shadow:inherit;
 }
+/* GEAR BONUS
+-------------------------------*/
+.tab_mstship .shipInfo .bonusList {
+	width: 458px;
+}
+
+.tab_mstship .shipInfo .bonusList .synergyIcon img,
+.tab_mstship .shipInfo .bonusList .gearIcon img,
+.tab_mstship .shipInfo .bonusList .gearType img {
+	width: 30px;
+	height: 30px;
+}
+
+.tab_mstship .shipInfo .bonusList hr {
+	margin: 7px auto;
+	opacity: 0.3;
+	border-color: #000;
+}
+
+.tab_mstship .shipInfo .bonusList .basicBonusInfo,
+.tab_mstship .shipInfo .bonusList .bonusStatsList,
+.tab_mstship .shipInfo .bonusList .gearStatBonus,
+.tab_mstship .shipInfo .bonusList .gearLevelBonus,
+.tab_mstship .shipInfo .bonusList .synergyFlag,
+.tab_mstship .shipInfo .bonusList .synergyBonusRow {
+	display: flex;
+	flex-direction: row;
+	justify-content: flex-start;
+}
+
+.tab_mstship .shipInfo .bonusList .gearBonuses {
+	padding: 5px 0;
+}
+
+.tab_mstship .shipInfo .gearBonuses {
+	background: #ddd;
+	border-radius: 5px;
+	margin: 5px 0;
+}
+
+.tab_mstship .shipInfo .gearBonuses:nth-child(2n+1) {
+	background: #ccc;
+}
+
+.tab_mstship .shipInfo .bonusList .gearId {
+	padding: 0 5px;
+}
+
+.tab_mstship .shipInfo .bonusList .gearId,
+.tab_mstship .shipInfo .bonusList .gearName,
+.tab_mstship .shipInfo .bonusList .synergyType,
+.tab_mstship .shipInfo .bonusList .gearCount,
+.tab_mstship .shipInfo .bonusList .bonusStatsList,
+.tab_mstship .shipInfo .bonusList .gearLevel {
+	line-height: 30px;
+	height: 30px;
+	vertical-align: middle;
+}
+
+.tab_mstship .shipInfo .bonusList .gearName {
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	width: 386px;
+	overflow: hidden;
+}
+
+.tab_mstship .shipInfo .bonusList .gearId,
+.tab_mstship .shipInfo .bonusList .gearIcon,
+.tab_mstship .shipInfo .bonusList .gearLevel,
+.tab_mstship .shipInfo .bonusList .synergyIcon,
+.tab_mstship .shipInfo .bonusList .gearType {
+	width: 45px;
+}
+
+.tab_mstship .shipInfo .bonusList .synergyIcon:before {
+	margin-left: -10px;
+	height: 30px;
+	content: "+";
+	position: absolute;
+	line-height: 30px;
+	font-size: 20px;
+}
+
+.tab_mstship .shipInfo .bonusList .synergy.distinct .synergyFlag:first-child .synergyType{
+	position:relative;
+}
+.tab_mstship .shipInfo .bonusList .synergy.distinct .synergyFlag:first-child .synergyType:after{
+	position:absolute;
+	top:0;
+	right:-10px;
+	content:"*";
+	color: #ff5151;
+	font-weight: 700;
+	font-size: 20px;
+}
+
+.tab_mstship .shipInfo .bonusList .gearLevel {
+	text-align: right;
+}
+
+.tab_mstship .shipInfo .bonusList .leveledBonusStatsList,
+.tab_mstship .shipInfo .bonusList .synergyGears {
+	padding-left: 40px;
+}
+
+.tab_mstship .shipInfo .bonusList .leveledBonusStatsList .bonusStatsList {
+	padding-left: 20px;
+}
+
+.tab_mstship .shipInfo .bonusList .synergyFlag {
+	padding-left: 20px;
+}
+
+.tab_mstship .shipInfo .bonusList .gearCount {
+	width: 20px;
+	text-align: right;
+}
+
+
+.tab_mstship .shipInfo .bonusList .gearStatBonus {
+	margin-right: 5px;
+}
+
+.tab_mstship .shipInfo .bonusList .statValue {
+	margin-right: 2px;
+}
 
 /* SPECIAL (Salt Check)
 -------------------------------*/

--- a/src/pages/strategy/tabs/mstship/mstship.css
+++ b/src/pages/strategy/tabs/mstship/mstship.css
@@ -797,6 +797,10 @@
 	margin-left:4px;
 }
 
+.tab_mstship .shipInfo .bonusList .synergyFlags{
+    padding-left: 9px;
+} 
+
 .tab_mstship .shipInfo .bonusList .gearLevel {
 	text-align: right;
 }

--- a/src/pages/strategy/tabs/mstship/mstship.css
+++ b/src/pages/strategy/tabs/mstship/mstship.css
@@ -782,26 +782,19 @@
 	width: 45px;
 }
 
-.tab_mstship .shipInfo .bonusList .synergyIcon:before {
-	margin-left: -10px;
-	height: 30px;
-	content: "+";
-	position: absolute;
-	line-height: 30px;
+.tab_mstship .shipInfo .bonusList .synergy .synergyFlag span{
 	font-size: 20px;
+	line-height: 30px;
+	vertical-align: middle;	
 }
 
-.tab_mstship .shipInfo .bonusList .synergy.distinct .synergyFlag:first-child .synergyType{
-	position:relative;
-}
-.tab_mstship .shipInfo .bonusList .synergy.distinct .synergyFlag:first-child .synergyType:after{
-	position:absolute;
-	top:0;
-	right:-10px;
+.tab_mstship .shipInfo .bonusList .synergy .synergyFlag .synergyType span{
 	content:"*";
+	vertical-align: top;
 	color: #ff5151;
 	font-weight: 700;
 	font-size: 20px;
+	margin-left:4px;
 }
 
 .tab_mstship .shipInfo .bonusList .gearLevel {
@@ -817,8 +810,8 @@
 	padding-left: 20px;
 }
 
-.tab_mstship .shipInfo .bonusList .synergyFlag {
-	padding-left: 20px;
+.tab_mstship .shipInfo .bonusList .statIcon{
+	margin-right:5px;
 }
 
 .tab_mstship .shipInfo .bonusList .gearCount {

--- a/src/pages/strategy/tabs/mstship/mstship.html
+++ b/src/pages/strategy/tabs/mstship/mstship.html
@@ -283,7 +283,7 @@
 			</div>
 
 			<div class="clear"></div>
-			<div class="head hover">Equipment bonuses & Synergy</div>
+			<div class="head hover">Equipment Visible Bonuses</div>
 			<div class="body">
 				<div class="bonusList"></div>
 			</div>

--- a/src/pages/strategy/tabs/mstship/mstship.html
+++ b/src/pages/strategy/tabs/mstship/mstship.html
@@ -355,8 +355,8 @@
 	</div>
 	
 	<div class="gearStatBonus">
-		<div class="statValue"></div>
 		<div class="statIcon"><img/></div>
+		<div class="statValue"></div>
 	</div>
 	
 	<div class="synergy">
@@ -366,7 +366,7 @@
 	</div>
 	
 	<div class="synergyFlag">
-		<div class="synergyIcon"><img/></div>
+		<div class="synergyIcon"><span>+</span><img/></div>
 		<div class="synergyType"></div>
 	</div>
 

--- a/src/pages/strategy/tabs/mstship/mstship.html
+++ b/src/pages/strategy/tabs/mstship/mstship.html
@@ -30,7 +30,14 @@
 		<li>If you see different text color of stats or equipment, that means our internal data is different with your encounter's. You could help us by reporting the correct value on tool-tip to us.</li>
 		<li>If you see no stats and equipment but a JSON text, that means there is no data yet for her in our internal data. You could help us once you encounter her.</li>
 	</ul></div>
-	
+
+	<div class="help_q">Why do some equipment bonuses not appear in KC3?</div>
+	<div class="help_a">New equipment bonuses may not have been updated yet. Please report to the KC3 Team if you have found any.
+		Some sites that you can check:
+		<a href="https://kancolle.fandom.com/wiki/Equipment_Bonuses" target="_blank">Wiki Page</a>,
+		<a href="https://docs.google.com/spreadsheets/d/1bInH11S_xKdaKP754bB7SYh-di9gGzcXkiQPvGuzCpg" target="_blank">EN Spreadsheet</a>.
+	</div>
+
 	<div class="help_q">Why is Harusame so cute?</div>
 	<div class="help_a">I know right! kyaaa!</div>
 </div>
@@ -274,6 +281,12 @@
 				<div class="gunfit gunfitList">
 				</div>
 			</div>
+
+			<div class="clear"></div>
+			<div class="head hover">Equipment bonuses & Synergy</div>
+			<div class="body">
+				<div class="bonusList"></div>
+			</div>
 		</div>
 		
 		<div class="clear"></div>
@@ -324,4 +337,42 @@
 		<div class="typeName"></div>
 	</div>
 	
+	<div class="gearBonuses">
+		<div class="basicBonusInfo">
+			<div class="gearId"></div>
+			<div class="gearIcon"><img/></div>
+			<div class="gearName"></div>
+		</div>
+		<div>
+			<div class="leveledBonusStatsList"></div>
+			<div class="synergyGears"></div>
+		</div>
+	</div>
+
+	<div class="gearLevelBonus">
+		<div class="gearLevel"></div>
+		<div class="bonusStatsList"></div>
+	</div>
+	
+	<div class="gearStatBonus">
+		<div class="statValue"></div>
+		<div class="statIcon"><img/></div>
+	</div>
+	
+	<div class="synergy">
+		<hr/>
+		<div class="synergyFlags"></div>
+		<div class="synergyBonusRows"></div>
+	</div>
+	
+	<div class="synergyFlag">
+		<div class="synergyIcon"><img/></div>
+		<div class="synergyType"></div>
+	</div>
+
+	<div class="synergyBonusRow">
+		<div class="gearCount"></div>
+		<div class="gearType"></div>
+		<div class="bonusStatsList"></div>
+	</div>
 </div>

--- a/src/pages/strategy/tabs/mstship/mstship.js
+++ b/src/pages/strategy/tabs/mstship/mstship.js
@@ -924,7 +924,7 @@
 					Object.keys(stats).forEach(function (stat) {
 						const statBox = $(".tab_mstship .factory .gearStatBonus").clone();
 						$(".statIcon img", statBox).attr("src", KC3Meta.statIconApi(stat));
-						$(".statValue", statBox).html(stats[stat]);
+						$(".statValue", statBox).html((stats[stat] > 0 ? "+" : "") + stats[stat]);
 						$(".bonusStatsList", box).append(statBox);
 					});
 				}; 				
@@ -1029,7 +1029,7 @@
 										const synergyBonusBox = $(".tab_mstship .factory .synergyBonusRow").clone();
 										addStatsToBox(bonus, synergyBonusBox);
 										if (syn.distinct) {
-											synergyBox.addClass('distinct');
+											$(".synergyType", synergyBox).append($("<span>*</span>"));
 										}
 										$(".synergyBonusRows", synergyBox).append(synergyBonusBox);
 									} else if (syn.byCount) {

--- a/src/pages/strategy/themes/dark.css
+++ b/src/pages/strategy/themes/dark.css
@@ -2039,7 +2039,21 @@ button, input, select, textarea {
 .tab_mstship .shipInfo .equipExSlot .equippableType {
 	background:#444;
 }
-
+.tab_mstship .shipInfo .gearBonuses {
+	background: #444 !important;
+}
+.tab_mstship .shipInfo .gearBonuses:nth-child(2n+1) {
+	background: #333 !important;
+}
+.tab_mstship .shipInfo .bonusList .statIcon img{
+	filter: invert(1);
+}
+.tab_mstship .shipInfo .tokubest .to-quotes {
+	background: #2b2b5a !important;
+}
+.tab_mstship .shipInfo .bonusList hr {
+	border-color: #FFF !important;
+}
 /* GEARS LIBRARY
 --------------------------------*/
 .tab_mstgear .gearRecords {


### PR DESCRIPTION
Filter equipment bonuses that ship is valid for and display it in mstship. For simplicity, only single bonus from gear is displayed.

May need to add new terms

For white theme
![image](https://user-images.githubusercontent.com/26541502/57542029-0a2ad500-7383-11e9-937d-6b791eeb6a75.png)

![image](https://user-images.githubusercontent.com/26541502/57542147-6f7ec600-7383-11e9-8b01-769e5b418ccf.png)


For dark theme
![image](https://user-images.githubusercontent.com/26541502/57542057-20389580-7383-11e9-95c2-c42ebcd21696.png)

Thanks to @DynamicSTOP 