### PR TITLE
PvP opponents friend list

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -1182,6 +1182,14 @@
 				"options" : {
 					"tooltip" : "SettingsPanelCustomCSSTip"
 				}
+			},
+			{
+				"id" : "pan_pvp_friends",
+				"name" : "SettingsPanelPvPFriends",
+				"type" : "textarea",
+				"options" : {
+					"tooltip" : "SettingsPanelPvPFriendsTip"
+				}
 			}
 		]
 	},

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -165,6 +165,7 @@ Retrieves when needed to apply on components
 				pan_custom_css  : "",
 				pan_reloadreminder_start  : 120,
 				pan_reloadreminder_repeat : 0,
+				pan_pvp_friends : "",
 
 				dismissed_hints        : {},
 				sr_theme               : "legacy",

--- a/src/pages/devtools/themes/natsuiro/natsuiro.css
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.css
@@ -2248,6 +2248,9 @@ ABYSS FLEET
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
+.module.activity .activity_pvp .pvp_enemy_name.friend {
+	color: #3ec03e;
+}
 .module.activity .activity_pvp .pvp_enemy_level {
 	width: 20px;
 	height: 17px;

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -3226,14 +3226,30 @@
 				KC3Meta.term("PvpListCreateType{0}".format(data.api_create_kind))
 			);
 			$(".activity_pvp .pvp_list").empty();
+			let pvpFriends = ConfigManager.pan_pvp_friends.split("\n");
 			$.each(data.api_list, function(idx, enemy){
 				var enemyBox = $("#factory .pvpEnemyInfo").clone();
 				$(".pvp_enemy_pic img", enemyBox).attr("src", KC3Meta.shipIcon(enemy.api_enemy_flag_ship));
 				$(".pvp_enemy_pic", enemyBox)
 					.attr("title", KC3Meta.shipName(KC3Master.ship(enemy.api_enemy_flag_ship).api_name))
 					.lazyInitTooltip();
-				$(".pvp_enemy_name", enemyBox).text(enemy.api_enemy_name);
-				$(".pvp_enemy_name", enemyBox).attr("title", enemy.api_enemy_name).lazyInitTooltip();
+				$(".pvp_enemy_name", enemyBox)
+					.text(enemy.api_enemy_name)
+					.attr("title", enemy.api_enemy_name).lazyInitTooltip()
+					.toggleClass("friend", pvpFriends.includes(enemy.api_enemy_name))
+					.click(function() {
+						let pvpFriends = ConfigManager.pan_pvp_friends.split("\n");
+						if(pvpFriends.includes(enemy.api_enemy_name)) {
+							pvpFriends.pop(pvpFriends.indexOf(enemy.api_enemy_name));
+						} else {
+							pvpFriends.push(enemy.api_enemy_name);
+						}
+
+						ConfigManager.pan_pvp_friends = pvpFriends.join("\n");
+						ConfigManager.save();
+
+						$(this).toggleClass("friend", pvpFriends.includes(enemy.api_enemy_name));
+					});
 				$(".pvp_enemy_level", enemyBox).text(enemy.api_enemy_level);
 				// api_enemy_rank is not int ID of rank, fml
 				var rankId = jpRankArr.indexOf(enemy.api_enemy_rank);


### PR DESCRIPTION
Show green name for friends in PvP opponents list. Toggle friend/normal by clicking on name, or by adding manual in line separated setting.

Might also add name coloring to PvPFleet or user ID support in case there are multiple people on your server with same name as a friend.