### PR TITLE
Add high-altitude interception power display

### DIFF
--- a/src/data/fud_weekly.json
+++ b/src/data/fud_weekly.json
@@ -4,6 +4,7 @@
 	"antiAirFighterType2Ids": [6, 7, 8, 11, 45, 47, 48, 57],
 	"antiLandDiveBomberIds": [64, 148, 233, 277, 305, 306, 319],
 	"evadeAntiAirFireIds": [79, 80, 81, 93, 94, 99, 100, 143, 144, 154, 170, 199, 200, 237, 322, 323],
+	"highAltitudeInterceptorIds": [350, 351, 352],
 	"airStrikeBomberType2Ids": [7, 8, 11, 41, 47, 57, 58],
 	"aswAircraftType2Ids": [7, 8, 11, 25, 26, 41, 47, 57],
 	"jetAircraftType2Ids": [56, 57, 58, 59],

--- a/src/library/managers/CalculatorManager.js
+++ b/src/library/managers/CalculatorManager.js
@@ -283,6 +283,14 @@
     const isLandBasesSupplied = () => {
         return PlayerManager.bases.every(base => base.isPlanesSupplied());
     };
+    /**
+     * @return {number} the fighter power modifier dependent on how many high-altitude interceptors on defense mode, capped at 3
+     * @see https://cdn.discordapp.com/attachments/208624431818342400/620539904694288395/lbas_tables_swdn.png
+     */
+    const getLandBaseHighAltitudeModifier = (world) => {
+        return [0.5, 0.8, 1.1, 1.2][PlayerManager.bases.filter(base => base.map === world && base.action === 2).reduce((acc, base) => 
+            acc + base.getHighAltitudeInterceptorCount(), 0)] || 1.2;
+    };
 
     /**
      * Get battle opponent's fighter power only based on master data.
@@ -513,6 +521,7 @@
         getLandBasesSortieCost,
         getLandBasesWorstCond,
         isLandBasesSupplied,
+        getLandBaseHighAltitudeModifier,
         
         enemyFighterPower,
         fighterPowerIntervals,

--- a/src/library/managers/GearManager.js
+++ b/src/library/managers/GearManager.js
@@ -22,6 +22,7 @@ Saves and loads list to and from localStorage
 		// WiP modifiers applied to enemy fleet's AA fire formula:
 		// https://twitter.com/muu_1106/status/1124658313428213760
 		evadeAntiAirFireIds: [79,80,81,93,94,99,100,143,144,154,170,199,200,237,322,323],
+		highAltitudeInterceptorIds: [350,351,352],
 		airStrikeBomberType2Ids: [7,8,11,41,47,57,58],
 		aswAircraftType2Ids: [7,8,11,25,26,41,47,57,58],
 		interceptorsType3Ids: [38,44],

--- a/src/library/modules/Meta.js
+++ b/src/library/modules/Meta.js
@@ -667,6 +667,7 @@ Provides access to data on built-in JSON files
 				airStrikeBomberType2Ids: d.airStrikeBomberType2Ids,
 				antiLandDiveBomberIds: d.antiLandDiveBomberIds,
 				evadeAntiAirFireIds: d.evadeAntiAirFireIds,
+				highAltitudeInterceptorIds: d.highAltitudeInterceptorIds,
 				aswAircraftType2Ids: d.aswAircraftType2Ids,
 				nightAircraftType3Ids: d.nightAircraftType3Ids,
 				interceptorsType3Ids: d.interceptorsType3Ids,

--- a/src/library/objects/LandBase.js
+++ b/src/library/objects/LandBase.js
@@ -215,5 +215,9 @@
 		}
 		return returnObj;
 	};
+
+	KC3LandBase.prototype.getHighAltitudeInterceptorCount = function(){
+		return this.planes.reduce((acc, p) => acc + (KC3GearManager.highAltitudeInterceptorIds.includes(p) ? 1 : 0), 0);
+	};
 	
 })();

--- a/src/pages/devtools/themes/moonlight/moonlight.js
+++ b/src/pages/devtools/themes/moonlight/moonlight.js
@@ -2303,7 +2303,12 @@
 						$(".base_ifp .base_stat_value", baseBox).text(
 							!!ifp ? "\u2248" + ifp : KC3Meta.term("None")
 						);
-						
+						const haifp = Math.floor(ifp * KC3Calc.getLandBaseHighAltitudeModifier(baseInfo.map));
+						if (!!ifp) {
+							$(".base_ifp .base_stat_value", baseBox).attr("title",
+								KC3Meta.term("LandBaseTipHighAltitudeAirDefensePower").format(haifp)
+							).lazyInitTooltip();
+						}												
 						//$(".airbase_infos", baseBox).on("click", togglePlaneName);
 
 						let planeNames = "";

--- a/src/pages/devtools/themes/natsuiro/natsuiro.js
+++ b/src/pages/devtools/themes/natsuiro/natsuiro.js
@@ -2159,6 +2159,12 @@
 						$(".base_ifp .base_stat_value", baseBox).text(
 							!!ifp ? "\u2248" + ifp : KC3Meta.term("None")
 						);
+						const haifp = Math.floor(ifp * KC3Calc.getLandBaseHighAltitudeModifier(baseInfo.map));
+						if (!!ifp) {
+							$(".base_ifp .base_stat_value", baseBox).attr("title",
+								KC3Meta.term("LandBaseTipHighAltitudeAirDefensePower").format(haifp)
+							).lazyInitTooltip();
+						}
 						
 						$(".airbase_infos", baseBox).on("click", togglePlaneName);
 


### PR DESCRIPTION
Add interception power for high-altitude enemy raids, displayed by mousing over normal interception power

Modifiers referred from https://cdn.discordapp.com/attachments/208624431818342400/620539904694288395/lbas_tables_swdn.png and https://twitter.com/Miyako_kc_tw

Moonlight
![image](https://user-images.githubusercontent.com/26541502/64557238-b1406d00-d373-11e9-80f1-3a0c595a7654.png)
Natsuiro
![image](https://user-images.githubusercontent.com/26541502/64557287-cb7a4b00-d373-11e9-9b4c-58a112c57d82.png)
