### PR TITLE
Fix ledger not working with very large history

### DIFF
--- a/src/pages/strategy/tabs/overlodger/overlodger.js
+++ b/src/pages/strategy/tabs/overlodger/overlodger.js
@@ -1,4 +1,4 @@
-(function(){
+﻿(function(){
 	"use strict";
 	/*jshint: validthis true*/
 	
@@ -1003,7 +1003,9 @@
 										givenAry.push(newItem);
 										newTotalBuffer.push(newItem);
 									}
-									[].unshift.apply(self.totalBuffer,newTotalBuffer);
+									for (var n = newTotalBuffer.length; n > 0; n-=1000) {
+										newTotalBuffer.unshift.apply(self.totalBuffer, newTotalBuffer.slice(Math.max(0, n - 1000), n));
+									}
 								} catch (e) {
 									console.error("Fetching incremental data", e);
 								} finally {


### PR DESCRIPTION
The kc3 ledger suddenly stops working if your resource history is extensive enough. This is because current behavior of using apply with newTotalBuffer calls unshift with as many args as there are items in your resource history. The javascript engine does not like this when that number starts reaching hundreds of thousands.

To fix, we slice newTotalBuffer and prepend it in batches.