### PR TITLE
Add node flavor text in TsunDB

### DIFF
--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -475,7 +475,12 @@
 			this.data.nodeInfo.eventKind = apiData.api_event_kind;
 			this.data.nodeInfo.nodeColor = apiData.api_color_no;
 			this.data.nodeInfo.itemGet = apiData.api_itemget || [];
-			
+
+			if ((apiData.api_cell_flavor || {}).api_message) {
+				this.data.nodeInfo.flavorType = apiData.api_cell_flavor.api_type;
+				this.data.nodeInfo.flavorMessage = apiData.api_cell_flavor.api_message;
+			}
+
 			// Checks whether the fleet has hit a dead end or not
 			this.data.nextRoute = apiData.api_next;
 			


### PR DESCRIPTION
For [`api_cell_flavor`](https://github.com/andanteyk/ElectronicObserver/blob/develop/ElectronicObserver/Other/Information/apilist.txt#L1563) in `api_req_map/next`, should be some event-related text that popup on empty nodes.