### PR TITLE
moonlight - ad hoc support for more listed quests

### DIFF
--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -192,6 +192,7 @@ Retrieves when needed to apply on components
 				pan_custom_css_moon  : "",
 
 				pan_layout           : 1,
+				pan_moon_quest_extend: false,
 				RotationPage         : 1,
 				Rotation2Page        : 4,
 
@@ -348,6 +349,13 @@ Retrieves when needed to apply on components
 		setLayout :function(layoutType){
 			this.loadIfNecessary();
 			this.pan_layout = layoutType;
+			this.save();
+		},
+
+		// Toggle quest extension in Moonlight
+		isQuestExtended :function(trigger){
+			this.loadIfNecessary();
+			this.pan_moon_quest_extend = trigger;
 			this.save();
 		},
 

--- a/src/pages/devtools/themes/moonlight/moonlight.css
+++ b/src/pages/devtools/themes/moonlight/moonlight.css
@@ -259,6 +259,23 @@ html,body {
 	-webkit-filter:invert(80%);
 	image-rendering: auto;
 }
+.rotarSquish img {
+	width:9px;
+	height:9px;
+	margin:2px;
+	filter:grayscale(100%) brightness(2);
+	-webkit-filter:grayscale(100%) brightness(2);
+}
+.h .rotarSquish img,
+.v .rotarSquish img {
+	transform: scaleX(-1);
+}
+.rotation .rotarSquish,
+.c .rotarSquish,
+.rotarSquish.squish,
+.t .rotation2 .rotarSquish {
+	display:none;
+}
 
 /*------- HQ INFO -------*/
 .module.admiral {
@@ -1542,14 +1559,14 @@ ABYSS FLEET
 	height:16px;
 }
 .module.activity .activity_quest .quest_list .quest.activated {
-	background: #364;
+	background: #354;
 }
 .module.activity .activity_quest .quest_list .quest.percent50 {
 }
 .module.activity .activity_quest .quest_list .quest.percent80 {
 }
 .module.activity .activity_quest .quest_list .quest.completed {
-	background: #557;
+	background: rgba(0,150,150,0.75);
 }
 .module.activity .activity_quest .quest_list .quest .quest_color {
 	width: 14px;
@@ -1568,7 +1585,7 @@ ABYSS FLEET
 	height: 14px;
 	overflow: hidden;
 	font-size: 11px;
-	line-height:15px;
+	line-height:14px;
 	white-space: nowrap;
 	text-overflow: ellipsis;
 }
@@ -3143,13 +3160,19 @@ ABYSS FLEET
 .quest {
 	height:18px;
 	line-height:18px;
+	padding-left:2px;
 }
 .v .quest {
 	height:27px;
 	line-height:13px;
+	padding-left:0px;
 }
 .quest.complete {
 	background: rgba(0,150,150,0.75);
+	padding-left:2px;
+}
+.v .quest.complete {
+	padding-left:0px;
 }
 .quest_color {
 	width:14px;
@@ -3166,10 +3189,10 @@ ABYSS FLEET
 	height:11px;
 }
 .quest.complete .quest_color {
-	width:16px;
-	height:16px;
+	width:14px;
+	height:14px;
+	margin:2px 2px 0px 0px;
 	font-size:11px;
-	margin:1px 1px 0px -1px;
 	background:#555;
 	float:left;
 	line-height:normal;
@@ -3197,7 +3220,6 @@ ABYSS FLEET
 	overflow:hidden;
 	text-overflow: ellipsis;
 	color:#cdd;
-	float:left;
 	position:relative;
 	left:0px;
 }
@@ -3215,20 +3237,22 @@ ABYSS FLEET
 .quest_track {
 	width:36px;
 	height:14px;
-	margin:1px 0px;
 	background:rgba(70,70,90,0.8);
 	line-height:14px;
 	font-size:11px;
-	float:right;
 	text-align:center;
 	color:#eee;
 	overflow:hidden;
-	margin:2px 2px 0px 0px;
+	position:relative;
+	top:2px;
+	left:2px;
 }
 .v .quest_track {
 	width:34px;
 	height:13px;
 	line-height:13px;
+	top:7px;
+	left:100px;
 }
 .untracked .quest_track {
 	display:none;
@@ -3520,6 +3544,11 @@ ABYSS FLEET
 	top:128px;
 	left:360px;
 }
+.t .rotation .rotarSquish {
+	display:block;
+	transform: rotate(90deg);
+}
+
 .module.summary.disabled {
 	filter:brightness(0.5);
 	-webkit-filter:brightness(0.5);
@@ -5599,36 +5628,57 @@ ABYSS FLEET
 .rotation2 .rotated2.page4 {
 	display:none;
 }
+.h .rotation2 .rotarSquish {
+	position:absolute;
+	left:0px;
+	top:0px;
+}
+.v .rotation2 .rotarSquish {
+	position:absolute;
+	left:0px;
+	top:0px;
+}
 .module.status .status_box {
 	width:110px;
 	height:20px;
 	line-height:20px;
 	float:left;
-	margin:0px 3px 0px 0px;
+	margin-left:2px;
+	margin-top:1px;
+	border:1px solid #70707099;
+	background-color:rgba(0,40,30,0.3);
+}
+.h .module.status.squish .status_box {
+	margin-left:20px;
+	margin-top:3px;
+}
+.v .module.status.squish .status_box {
+	margin-left:38px;
+	margin-top:3px;
 }
 .module.status .status_icon {
-	width:20px;
-	height:20px;
+	width:18px;
+	height:18px;
 	float:left;
-	margin:0px 4px 0px 1px;
 }
 .module.status .status_icon.enclose {
 	background:rgba(34,48,49,1);
 	border-radius:10px;
 }
 .module.status .status_icon img {
-	width:20px;
-	height:20px;
+	width:16px;
+	height:16px;
+	margin:1px;
 	vertical-align:top;
 }
 .module.status .status_text {
 	width:85px;
 	height:20px;
 	float:left;
-	/*background:#cfc;*/
 	color:#fff;
 	text-shadow:0px 0px 5px #000;
-	font-size:12px;
+	font-size:11px;
+	line-height:18px;
 	white-space:nowrap;
 	overflow:hidden;
 	text-overflow: ellipsis;
@@ -5650,16 +5700,19 @@ ABYSS FLEET
 .module.status .status_support img {
 	width:14px;
 	height:14px;
-	margin:3px;
+	margin:2px;
+	filter:invert(60%);
+	-webkit-filter:invert(60%);
 }
 .module.status .status-speed img {
-	width:16px;
-	height:16px;
-	margin:2px;
-	vertical-align:top;
 	filter:invert(35%);
 	-webkit-filter:invert(35%);
-	image-rendering: auto;
+}
+.h .module.status.squish .status_akashi,
+.v .module.status.squish .status_akashi,
+.h .module.status.squish .status_docking,
+.v .module.status.squish .status_docking {
+	display:none;
 }
 
 /* AIR BASES
@@ -5943,6 +5996,14 @@ ABYSS FLEET
 	overflow-x:hidden;
 	overflow-y:auto;
 }
+.h .module.quests.squish {
+	width:388px;
+	height:124px;
+	left:162px;
+	display: flex;
+	flex-wrap: wrap;
+	flex-direction: column;
+}
 ::-webkit-scrollbar-corner {
   background: rgba(0,0,0,0);
 }
@@ -5978,8 +6039,13 @@ ABYSS FLEET
 }
 .h .module.status {
 	width:345px;
-	height:70px;
-	left:202px; top:475px;
+	height:85px;
+	left:202px; top:460px;
+}
+.h .module.status.squish {
+	width:150px;
+	height:124px;
+	left:5px; top:421px;
 }
 .h .module.expeditions2,
 .h .module.consumableList {
@@ -6036,6 +6102,10 @@ ABYSS FLEET
 	width:345px;
 	height:70px;
 }
+.v .module.status.squish {
+	width:190px;
+	height:124px;
+}
 .v .module.expeditions2,
 .v .module.consumableList {
 	width:345px;
@@ -6053,6 +6123,9 @@ ABYSS FLEET
 	left:881px; top:2px;
 	overflow-x:hidden;
 	overflow-y:auto;
+}
+.v .module.quests.squish {
+	height:300px;
 }
 .v .module.quests .quest {
 	width:151px;
@@ -6153,6 +6226,9 @@ ABYSS FLEET
 .t .module.admiral {
 	left:195px; top:129px;
 }
+.t .module.admiral.squish {
+	display:none;
+}
 .t .module.summary {
 	left:195px; top:172px;
 	height:119px;
@@ -6172,11 +6248,14 @@ ABYSS FLEET
 	left:3px; top:38px;
 }
 .t .module.quests {
-	width:183px;
+	width:186px;
 	height:125px;
-	left:197px; top:2px;
+	left:194px; top:2px;
 	overflow-x:hidden;
 	overflow-y:auto;
+}
+.t .module.quests.squish {
+	height:165px;
 }
 .t .module.quests .quest {
 	width:179px;

--- a/src/pages/devtools/themes/moonlight/moonlight.html
+++ b/src/pages/devtools/themes/moonlight/moonlight.html
@@ -17,6 +17,7 @@
 			<div class="wrapper_bg"></div>
 			<div class="rotation">
 				<div class="rotarButtons">
+					<div class="rotarZairo rotarSquish border_radius_5 quest_extendable"><img src="../../../../assets/img/ui/arrow.png" /></div>
 					<div class="rotarZairo rotarSumStats border_radius_5"><img src="../../../../assets/img/ui/sumicon.png" /></div>
 					<div class="rotarZairo rotarQuests border_radius_5"><img src="../../../../assets/img/ui/wall_of_text.png" /></div>
 					<div class="rotarZairo rotarExpedition border_radius_5"><img src="../../../../assets/img/ui/timer2.png" /></div>
@@ -25,7 +26,7 @@
 				</div>
 				<div class="rotated page1">
 					<!-- Module: Admiral Info -->
-					<div class="module admiral border_radius_5">
+					<div class="module admiral border_radius_5 quest_extendable">
 						<div class="admiral_level">
 							<div class="admiral_lvtxt"><span class="i18n">HQAdmiralLv</span> <span class="admiral_lvval"></span></div>
 							<div class="admiral_lvbox bar_border_radius4">
@@ -1093,7 +1094,7 @@
 				</div>
 			</div>
 			<!-- Module: Quests -->
-			<div class="module quests">
+			<div class="module quests quest_extendable">
 				
 			</div>
 			
@@ -1142,6 +1143,7 @@
 
 			<div class="rotation2">	
 				<div class="rotarButtons">
+					<div class="rotarZairo rotarSquish border_radius_5 quest_extendable"><img src="../../../../assets/img/ui/arrow.png" /></div>
 					<div class="rotarZairo rotarLayout border_radius_5"><img src="../../../../assets/img/ui/layout.png" /></div>
 					<div class="rotarZairo rotarExpedition border_radius_5"><img src="../../../../assets/img/ui/timer2.png" /></div>
 					<div class="rotarZairo rotarConsumables border_radius_5"><img src="../../../../assets/img/ui/cog.png" /></div>
@@ -1150,51 +1152,51 @@
 				</div>
 				<div class="rotated2 page1">
 					<!-- Module: Status Reminders -->
-					<div class="module status border_radius_5">
+					<div class="module status border_radius_5 quest_extendable">
 						<!-- Resupply Status -->
-						<div class="status_box status_supply hover">
+						<div class="status_box status_supply hover border_radius_5">
 							<div class="status_icon"><img/></div>
 							<div class="status_text"></div>
 							<div class="clear"></div>
 						</div>
 						<!-- Morale Status -->
-						<div class="status_box status_morale hover">
+						<div class="status_box status_morale hover border_radius_5">
 							<div class="status_icon"><img/></div>
 							<div class="status_text"></div>
 							<div class="clear"></div>
 						</div>
 						<!-- Repair Status -->
-						<div class="status_box status_repair hover">
+						<div class="status_box status_repair hover border_radius_5">
 							<div class="status_icon"><img/></div>
 							<div class="status_text"></div>
 							<div class="clear"></div>
 						</div>
 						<!-- Combine Capability -->
-						<div class="status_box status_butai hover">
+						<div class="status_box status_butai hover border_radius_5">
 							<div class="status_icon"><img src="../../../../assets/img/ui/fleet_single2.png" /></div>
 							<div class="status_text"></div>
 							<div class="clear"></div>
 						</div>
 						<!-- Support Power -->
-						<div class="status_box status_support hover">
+						<div class="status_box status_support hover border_radius_5">
 							<div class="status_icon enclose"><img src="../../../../assets/img/stats/dv.png" /></div>
 							<div class="status_text"></div>
 							<div class="clear"></div>
 						</div>
 						<!-- Docking Time -->
-						<div class="status_box status_docking hover">
+						<div class="status_box status_docking hover border_radius_5">
 							<div class="status_icon"><img src="../../../../assets/img/ui/timer.png" /></div>
 							<div class="status_text"></div>
 							<div class="clear"></div>
 						</div>
 						<!-- Akashi Time -->
-						<div class="status_box status_akashi hover">
+						<div class="status_box status_akashi hover border_radius_5">
 							<div class="status_icon enclose"><img src="../../../../assets/img/items/26.png" /></div>
 							<div class="status_text"></div>
 							<div class="clear"></div>
 						</div>
 						<!-- Fleet Speed -->
-						<div class="status_box status-speed">
+						<div class="status_box status-speed border_radius_5">
 							<div class="status_icon enclose"><img src="../../../../assets/img/stats_p2/sp.png" /></div>
 							<div class="status_text">Fast</div>
 							<div class="clear"></div>

--- a/src/pages/devtools/themes/moonlight/moonlight.js
+++ b/src/pages/devtools/themes/moonlight/moonlight.js
@@ -395,9 +395,10 @@
 	//increases space allotted for the quest list by decreasing space allocated to another element
 	function quest_extender(state) {
 		ConfigManager.isQuestExtended(state);
-		ConfigManager.pan_moon_quest_extend ?
-			$(".quest_extendable").addClass("squish") : 
-			$(".quest_extendable").removeClass("squish");
+		if (ConfigManager.pan_moon_quest_extend == true) {
+			return $(".quest_extendable").addClass("squish");
+		}
+		return $(".quest_extendable").removeClass("squish");
 	}
 
 	$(document).on("ready", function(){

--- a/src/pages/devtools/themes/moonlight/moonlight.js
+++ b/src/pages/devtools/themes/moonlight/moonlight.js
@@ -392,6 +392,14 @@
 		}
 	}
 
+	//increases space allotted for the quest list by decreasing space allocated to another element
+	function quest_extender(state) {
+		ConfigManager.isQuestExtended(state);
+		ConfigManager.pan_moon_quest_extend ?
+			$(".quest_extendable").addClass("squish") : 
+			$(".quest_extendable").removeClass("squish");
+	}
+
 	$(document).on("ready", function(){
 		// Check localStorage
 		if(!window.localStorage){
@@ -633,6 +641,7 @@
 		function setRotation(page) {
 			ConfigManager.scrollSpecificPage(page);
 			NatsuiroListeners.Rotation();
+			quest_extender(false);
 		}
 		$(".rotation .rotarBack").on("click",function() {setRotation(1);});
 		$(".rotation .rotarExpedition").on("click",function() {setRotation(2);});
@@ -644,6 +653,7 @@
 		function setRotation2(page) {
 			ConfigManager.scrollSpecific2Page(page);
 			NatsuiroListeners.Rotation2();
+			quest_extender(false);
 		}
 		$(".rotation2 .rotarBack").on("click",function() {setRotation2(1);});
 		$(".rotation2 .rotarExpedition").on("click",function() {setRotation2(2);});
@@ -651,6 +661,17 @@
 		$(".rotation2 .rotarLayout").on("click",function() {setRotation2(4);});
 		$(".rotation2 .rotarConsumables").on("click",function() {setRotation2(5);});
 		$(".layout_header").text( KC3Meta.term("PanelLayoutSelection") );
+
+		// adjust elements so that the quest list can display more quests
+		$(".rotarSquish").on("click",function() {
+			if(ConfigManager.pan_layout <= 2) {
+				setRotation2(1);
+			}
+			else if(ConfigManager.pan_layout == 4) {
+				setRotation(1);
+			}
+			quest_extender(true);
+		});
 
 		//consumable display
 		var consumable_elements = [
@@ -781,22 +802,15 @@
 				)));
 		});
 
-		$(".module.layouts .btn_change_layout").on("click", function(){
-			ConfigManager.setLayout(1);
+		function changeLayout(type) {
+			ConfigManager.setLayout(type);
 			Orientation();
-		});
-		$(".module.layouts .btn_change_layout2").on("click", function(){
-			ConfigManager.setLayout(2);
-			Orientation();
-		});
-		$(".module.layouts .btn_change_layout3").on("click", function(){
-			ConfigManager.setLayout(3);
-			Orientation();
-		});
-		$(".module.layouts .btn_change_layout4").on("click", function(){
-			ConfigManager.setLayout(4);
-			Orientation();
-		});
+			quest_extender(false);
+		}
+		$(".module.layouts .btn_change_layout").on("click", function(){changeLayout(1);});
+		$(".module.layouts .btn_change_layout2").on("click", function(){changeLayout(2);});
+		$(".module.layouts .btn_change_layout3").on("click", function(){changeLayout(3);});
+		$(".module.layouts .btn_change_layout4").on("click", function(){changeLayout(4);});
 
 		const prepareBattleLogsData = function(){
 			// Don't pop up if a battle has not started yet
@@ -1164,6 +1178,7 @@
 		NatsuiroListeners.Rotation();
 		ConfigManager.scrollSpecific2Page(ConfigManager.Rotation2Page);
 		NatsuiroListeners.Rotation2();
+		quest_extender(ConfigManager.pan_moon_quest_extend);
 	}
 
 	function clearSortieData(){


### PR DESCRIPTION
Adjusts the display of a few elements within the moonlight theme so that a larger number of quests can be displayed. Users must press the appropriate button in order to activate the large quest display view mode.

The square, wide and tall layouts are affected. The compact layout does not require changes at this time.

[imgur screenshots](https://imgur.com/a/pRskbki)