### PR TITLE
blocker SE mode falls back to Network when muted

### DIFF
--- a/src/library/modules/Network.js
+++ b/src/library/modules/Network.js
@@ -13,6 +13,9 @@ Listens to network history and triggers callback if game events happen
 	// this flag prevents blocking until result data actually recieved
 	let battle_result_recieved = false;
 
+	// Whether the game is muted in-game
+	let is_muted = true; // Assume muted until we know for sure
+
 	window.KC3Network = {
 		hasOverlay: false,
 		lastUrl: "",
@@ -201,7 +204,7 @@ Listens to network history and triggers callback if game events happen
 					// result data wasn't recieved. it must be yasen switch. show translation divs?
 					// }
 				} else {
-					if (ConfigManager.next_blocker === 2) {
+					if (ConfigManager.next_blocker === 2 || KC3Network.is_muted) {
 						// not from SE check and player selected api check
 						// start showing block now
 						show = true;
@@ -224,6 +227,18 @@ Listens to network history and triggers callback if game events happen
 			}
 		},
 
+		/* GAME MUTE CHECK
+		Checks cookies for the game's current in-game SE level
+		to determine whether to switch to Network mode for next-blocker
+		-------------------------------------------------------*/
+		inGameSEMuteCheck: function() {
+			chrome.cookies.get({url: 'http://www.dmm.com', name: 'kcs_options'}, function(cookie) {
+				if (!cookie) return; // Assume not present or invalid
+				let match = decodeURIComponent(cookie.value).match('(^|;)\\s*vol_se\\s*=\\s*([^;]+)');
+				KC3Network.is_muted = !match || match.pop() === "0";
+			});
+		},
+
 		/* RECEIVED
 		Fired when we receive network entry
 		Inside, use "KC3Network" instead of "this"
@@ -232,6 +247,10 @@ Listens to network history and triggers callback if game events happen
 		------------------------------------------*/
 		received : function(har){
 			const requestUrl = har.request.url;
+			
+			// Check whether the game is muted
+			KC3Network.inGameSEMuteCheck();
+
 			// If request is an API Call
 			if(requestUrl.indexOf("/kcsapi/") > -1){
 				KC3Network.lastUrl = requestUrl;


### PR DESCRIPTION
Currently, SE mode will cause the blocker to never trigger if the user reduces the ingame SE level to 0. This PR adds a check to the network handler which verifies the ingame volume level via the dmm cookie kcs_options=>vol_se, and if it is set to 0, allows the blocker to operate as though in Network mode.