### PR TITLE
Add pre-sortie warning for ships with empty equip slots or shiplock

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -697,6 +697,17 @@
 				"name" : "SettingsPreSortieAlert",
 				"type" : "check",
 				"options" : {}
+			},
+			{
+				"id" : "alert_pre_sortie_fleet",
+				"name" : "SettingsPreSortieAlertFleet",
+				"type" : "small_text",
+				"bound" : {
+					"min" :   1,
+					"max" :   4,
+					"type": "Number"
+				},
+				"options" : {}
 			}
 		]
 	},

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -705,7 +705,7 @@
 				"bound" : {
 					"min" :   1,
 					"max" :   4,
-					"type": "Number"
+					"type": "Integer"
 				},
 				"options" : {}
 			}

--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -691,6 +691,12 @@
 					"type": "Number"
 				},
 				"options" : { "label" : "%" }
+			},
+			{
+				"id" : "alert_pre_sortie",
+				"name" : "SettingsPreSortieAlert",
+				"type" : "check",
+				"options" : {}
 			}
 		]
 	},

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -112,6 +112,7 @@ Retrieves when needed to apply on components
 				alert_idle_counter : 1,
 				alert_idle_start   : 0,
 				alert_rsc_cap      : 95,
+				alert_pre_sortie   : false,
 
 				alert_taiha          : false,
 				alert_taiha_blur     : false,

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -113,6 +113,7 @@ Retrieves when needed to apply on components
 				alert_idle_start   : 0,
 				alert_rsc_cap      : 95,
 				alert_pre_sortie   : false,
+				alert_pre_sortie_fleet : 1,
 
 				alert_taiha          : false,
 				alert_taiha_blur     : false,

--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -2534,18 +2534,18 @@ Previously known as "Reactor"
 				KC3Network.trigger("Lbas");
 			}
 
-			// If pre sortie warning enabled, check for shiplocks and equip slots
+			// If pre sortie warning enabled, check for empty equip slots on heartlocked ships
 			if(ConfigManager.alert_pre_sortie) {
-				const missingLockShips = [];
 				const missingEquipShips = [];
-				// Assume that usual player sorties with fleet 1 (which is not true for all players)
-				const ships = PlayerManager.fleets[0].ship();
+
+				let ships = PlayerManager.fleets[ConfigManager.alert_pre_sortie_fleet - 1].ship();
 				if (PlayerManager.combinedFleet > 0) {
-					ships.push(...[PlayerManager.fleets[1].ship()]);
+					ships = PlayerManager.fleets[0].ship();
+					ships.push(...PlayerManager.fleets[1].ship());
 				}
 
 				for (const ship of ships) {
-					if (ship.sally == 0) { missingLockShips.push(ship); }
+					if (ship.lock === 0) { continue; }
 
 					let flag = false;
 					for (let idx = 0; idx < ship.slotnum; idx++) {
@@ -2562,7 +2562,27 @@ Previously known as "Reactor"
 						message: KC3Meta.term("AlertPreSortieEquip").format(eqstr),
 					});
 				}
-				else if (missingLockShips.length !== ships.length) {
+			}
+		},
+
+		/* Pre-sortie check for win percentage for event maps
+		-------------------------------------------------------*/
+		"api_get_member/sortie_conditions":function(params, response, headers){
+			// If pre sortie warning enabled, check for ship tag/locks on heartlocked ships
+			if(ConfigManager.alert_pre_sortie) {
+				const missingLockShips = [];
+				let ships = PlayerManager.fleets[ConfigManager.alert_pre_sortie_fleet - 1].ship();
+				if (PlayerManager.combinedFleet > 0) {
+					ships = PlayerManager.fleets[0].ship();
+					ships.push(...PlayerManager.fleets[1].ship());
+				}
+
+				for (const ship of ships) {
+					if (ship.lock === 0) { continue; }
+					if (ship.sally === 0) { missingLockShips.push(ship); }
+				}
+
+				if (missingLockShips.length > 0) {
 					const lockstr = missingLockShips.map(ship => ship.name()).join(", ");
 					KC3Network.trigger("ModalBox", {
 						title: KC3Meta.term("AlertPreSortieTitle"),

--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -2549,7 +2549,7 @@ Previously known as "Reactor"
 
 					let flag = false;
 					for (let idx = 0; idx < ship.slotnum; idx++) {
-						const eq = ship.equipment(idx)
+						const eq = ship.equipment(idx);
 						if (eq.itemId == 0) { flag = true; }
 					}
 					if (ship.ex_item === -1) { flag = true; }

--- a/src/library/modules/Kcsapi.js
+++ b/src/library/modules/Kcsapi.js
@@ -2533,6 +2533,43 @@ Previously known as "Reactor"
 			if(PlayerManager.setBasesOnWorldMap(response.api_data)) {
 				KC3Network.trigger("Lbas");
 			}
+
+			// If pre sortie warning enabled, check for shiplocks and equip slots
+			if(ConfigManager.alert_pre_sortie) {
+				const missingLockShips = [];
+				const missingEquipShips = [];
+				// Assume that usual player sorties with fleet 1 (which is not true for all players)
+				const ships = PlayerManager.fleets[0].ship();
+				if (PlayerManager.combinedFleet > 0) {
+					ships.push(...[PlayerManager.fleets[1].ship()]);
+				}
+
+				for (const ship of ships) {
+					if (ship.sally == 0) { missingLockShips.push(ship); }
+
+					let flag = false;
+					for (let idx = 0; idx < ship.slotnum; idx++) {
+						const eq = ship.equipment(idx)
+						if (eq.itemId == 0) { flag = true; }
+					}
+					if (ship.ex_item === -1) { flag = true; }
+					if (flag) { missingEquipShips.push(ship); }
+				}
+				if (missingEquipShips.length > 0) {
+					const eqstr = missingEquipShips.map(ship => ship.name()).join(", ");
+					KC3Network.trigger("ModalBox", {
+						title: KC3Meta.term("AlertPreSortieTitle"),
+						message: KC3Meta.term("AlertPreSortieEquip").format(eqstr),
+					});
+				}
+				else if (missingLockShips.length !== ships.length) {
+					const lockstr = missingLockShips.map(ship => ship.name()).join(", ");
+					KC3Network.trigger("ModalBox", {
+						title: KC3Meta.term("AlertPreSortieTitle"),
+						message: KC3Meta.term("AlertPreSortieLock").format(lockstr),
+					});
+				}
+			}
 		},
 		
 		/* Ship Modernize


### PR DESCRIPTION
When user enters map selection menu, if user-chosen fleet has empty equip slots, user will be given a warning on which ships have empty equip slots.

At event map pre-sortie check, if user has untagged ships, user will be given a warning on which ships do not have tags.

Non-heartlocked ships will be ignored.

This is inspired by poi feature where user is given warning pre-sortie for ships with no lock during event.
![image](https://user-images.githubusercontent.com/26541502/115908935-61a5ab00-a49d-11eb-802f-c4e42c60d731.png)

