### PR TITLE
Add ship sunk and damage control statistics to eventstats

### DIFF
--- a/src/pages/strategy/tabs/eventstats/eventstats.css
+++ b/src/pages/strategy/tabs/eventstats/eventstats.css
@@ -66,26 +66,10 @@
 }
 
 .tab_eventstats .memorial .memorial_shipicon {
-	opacity:0.6;
-	display: grid;
-}
-.tab_eventstats .memorial .memorial_shipicon .sink_icon {
-	grid-column: 1;
-  	grid-row: 1;
-	width:10px;
-	height:10px;
-	line-height:10px;
-	float:left;
-	margin:4px 0px 0px 17px;
-}
-.tab_eventstats .memorial .memorial_shipicon .sink_icon img {
-	width:10px;
-	height:10px;
-	vertical-align:top;
+	filter:grayscale(100%);
+    -webkit-filter:grayscale(100%);
 }
 .tab_eventstats .memorial .memorial_shipicon .icon {
-	grid-column: 1;
-  	grid-row: 1;
 	width:26px;
 	height:26px;
 	float:left;

--- a/src/pages/strategy/tabs/eventstats/eventstats.css
+++ b/src/pages/strategy/tabs/eventstats/eventstats.css
@@ -47,3 +47,56 @@
 .tab_eventstats .table5 span {
 	margin:0 5px 0 5px;
 }
+
+.tab_eventstats .page_padding {
+	border-radius:0px;
+	border-bottom:1px solid #555555;
+	padding:0px 0px 20px 0px;
+	margin:0px 0px 20px 0px;
+}
+
+.tab_eventstats .memorial .shiplist {
+	display:flex;
+}
+
+.tab_eventstats .memorial .memorial_shipicon {
+	opacity:0.6;
+	display: grid;
+}
+.tab_eventstats .memorial .memorial_shipicon .sink_icon {
+	grid-column: 1;
+  	grid-row: 1;
+	width:10px;
+	height:10px;
+	line-height:10px;
+	float:left;
+	margin:4px 0px 0px 17px;
+}
+.tab_eventstats .memorial .memorial_shipicon .sink_icon img {
+	width:10px;
+	height:10px;
+	vertical-align:top;
+}
+.tab_eventstats .memorial .memorial_shipicon .icon {
+	grid-column: 1;
+  	grid-row: 1;
+	width:26px;
+	height:26px;
+	float:left;
+	margin:0px 2px;
+	border-radius:13px;
+	border:1px solid #000;
+	overflow:hidden;
+	background:#888;
+	position:relative;
+}
+.tab_eventstats .memorial .memorial_shipicon .icon img {
+	width:26px;
+	height:26px;
+	position:relative;
+	top:-1px;
+	left:-1px;
+	object-fit: cover;
+	border-radius: 50%;
+	image-rendering: auto;
+}

--- a/src/pages/strategy/tabs/eventstats/eventstats.css
+++ b/src/pages/strategy/tabs/eventstats/eventstats.css
@@ -55,8 +55,14 @@
 	margin:0px 0px 20px 0px;
 }
 
+.tab_eventstats .memorial {
+	display:none;
+	text-align: center;
+}
+
 .tab_eventstats .memorial .shiplist {
 	display:flex;
+	justify-content:center;
 }
 
 .tab_eventstats .memorial .memorial_shipicon {

--- a/src/pages/strategy/tabs/eventstats/eventstats.html
+++ b/src/pages/strategy/tabs/eventstats/eventstats.html
@@ -26,6 +26,12 @@
 	<br>
 	<div class="lbcons"></div>
 	<div class="totalcons"></div>
+	<div class="damecons"></div>
+</div>
+
+<div class="memorial">
+	<h2>Ship Memorial</h2>
+	<div class="shiplist"></div>
 </div>
 
 <div class="factory">
@@ -41,5 +47,10 @@
 		<div class="total_runs"></div>
 		<div class="total_cost"></div>
 		<br>
+	</div>
+
+	<div class="memorial_shipicon">
+		<div class="icon"></div>
+		<div class="sink_icon"><img src="../../../../assets/img/client/sunk.png"/></img></div>
 	</div>
 </div>

--- a/src/pages/strategy/tabs/eventstats/eventstats.html
+++ b/src/pages/strategy/tabs/eventstats/eventstats.html
@@ -51,6 +51,5 @@
 
 	<div class="memorial_shipicon">
 		<div class="icon"></div>
-		<div class="sink_icon"><img src="../../../../assets/img/client/sunk.png"/></img></div>
 	</div>
 </div>

--- a/src/pages/strategy/tabs/eventstats/eventstats.html
+++ b/src/pages/strategy/tabs/eventstats/eventstats.html
@@ -30,7 +30,7 @@
 </div>
 
 <div class="memorial">
-	<h2>Ship Memorial</h2>
+	<h3>In Memory Of</h3>
 	<div class="shiplist"></div>
 </div>
 

--- a/src/pages/strategy/tabs/eventstats/eventstats.js
+++ b/src/pages/strategy/tabs/eventstats/eventstats.js
@@ -285,23 +285,20 @@
 					for (let shipIdx = 0; shipIdx < ships.length; shipIdx++) {
 						if (!ships[shipIdx]) continue;
 						const taihaHp = maxHps[shipIdx] / 4;
-						if (initialHps[shipIdx] < taihaHp) continue;
 						const resultHp = player[shipIdx].hp;
 
 						// Handle pre-boss taiha
-						if (resultHp < taihaHp) {
-							if (resultHp > 0) {
+						if (resultHp < taihaHp && resultHp > 0 && initialHps[shipIdx] > taihaHp) {
 								this.stats.taihaMagnets[ships[shipIdx].mst_id] = (this.stats.taihaMagnets[ships[shipIdx].mst_id] || 0) + 1;
-							} else {
-								if (ships[shipIdx].equip.includes(42) || ships[shipIdx].equip.includes(43)) {
-									this.stats.dameconCount += 1;
-								} else if (!battle.boss) {
-									if (!this.stats.kuso[sortie.id]) { this.stats.kuso[sortie.id] = []; }
-									this.stats.kuso[sortie.id].push(ships[shipIdx].mst_id);
-								}
+						}
+						if (resultHp <= 0) {
+							if (ships[shipIdx].equip.includes(42) || ships[shipIdx].equip.includes(43)) {
+								this.stats.dameconCount += 1;
+							} else if (!battle.boss) {
+								if (!this.stats.kuso[sortie.id]) { this.stats.kuso[sortie.id] = []; }
+								this.stats.kuso[sortie.id].push(ships[shipIdx].mst_id);
 							}
 						}
-
 					}
 				}));
 

--- a/src/pages/strategy/tabs/eventstats/eventstats.js
+++ b/src/pages/strategy/tabs/eventstats/eventstats.js
@@ -100,6 +100,7 @@
 			$(".table5").hide();
 			$(".lbcons").hide();
 			$(".map_list").html("").hide();
+			$(".memorial").hide();
 			const allPromises = [];
 			const hqId = PlayerManager.hq.id;
 			this.stats = {
@@ -117,7 +118,8 @@
 				bossCount: {},
 				clearCount: {},
 				ldCount: {},
-				kuso: {}
+				kuso: {},
+				dameconCount: 0
 			};
 
 			const buildConsumptionArray = arr => arr.reduce((acc, o) =>
@@ -148,7 +150,7 @@
 
 			const checkFleetAttacks = (fleet, ships, checkForLastHit, mapnum) => {
 				for (let i = 0; i < fleet.length; i++) {
-					checkShipKill(fleet[i].attacks, ships[i], checkForLastHit, mapnum);
+					checkShipKill(fleet[i].attacks, ships[i].mst_id, checkForLastHit, mapnum);
 				}
 			};
 
@@ -157,7 +159,7 @@
 				if (ships.length == maxHps.length || sortieKuso.length == 0) { return ships; }
 				let result = [];
 				ships.forEach(ship => {
-					if (!sortieKuso.includes(ship)) {
+					if (!sortieKuso.includes(ship.mst_id)) {
 						result.push(ship);
 					}
 				});
@@ -233,7 +235,7 @@
 
 					let result = KC3BattlePrediction.analyzeBattle(battleData, [], battleType);
 					const fleetSent = battleData.api_deck_id;
-					let ships = sortie["fleet" + fleetSent].map(ship => ship.mst_id);
+					let ships = sortie["fleet" + fleetSent];
 					let maxHps = battleData.api_f_maxhps, initialHps = battleData.api_f_nowhps;
 					if (!maxHps) return;
 					const sortieKuso = this.stats.kuso[sortie.id] || [];
@@ -243,7 +245,7 @@
 					}
 					ships = checkShipLength(ships, maxHps);
 					if (sortie.combined > 0) {
-						let fleet2 = sortie.fleet2.map(ship => ship.mst_id);
+						let fleet2 = sortie.fleet2;
 						const maxHps2 = battleData.api_f_maxhps_combined;
 						if (!maxHps2) return;
 						fleet2 = checkShipLength(fleet2, maxHps2, sortieKuso);
@@ -263,7 +265,7 @@
 					let player = result.fleets.playerMain.concat(result.fleets.playerEscort);
 					let enemy = result.fleets.enemyMain.concat(result.fleets.enemyEscort);
 					player.forEach((ship, index) => {
-						this.stats.shipDamageDealt[ships[index]] = (this.stats.shipDamageDealt[ships[index]] || 0) + ship.damageDealt;
+						this.stats.shipDamageDealt[ships[index].mst_id] = (this.stats.shipDamageDealt[ships[index].mst_id] || 0) + ship.damageDealt;
 					});
 					checkFleetAttacks(player, ships, checkForLastHit, mapnum);
 					if (Object.keys(battle.yasen).length > 0 && time === "day") {
@@ -274,30 +276,32 @@
 						result = KC3BattlePrediction.analyzeBattle(battle.yasen, [], battleType);
 						player = result.fleets.playerMain.concat(result.fleets.playerEscort);
 						player.forEach((ship, index) => {
-							this.stats.shipDamageDealt[ships[index]] = (this.stats.shipDamageDealt[ships[index]] || 0) + ship.damageDealt;
+							this.stats.shipDamageDealt[ships[index].mst_id] = (this.stats.shipDamageDealt[ships[index].mst_id] || 0) + ship.damageDealt;
 						});
 						checkFleetAttacks(player, ships, checkForLastHit, mapnum);
 					}
 
 					// Assign taiha magnets
-					if (!battle.boss) {
-						for (let shipIdx = 0; shipIdx < ships.length; shipIdx++) {
-							if (!ships[shipIdx]) continue;
-							const taihaHp = maxHps[shipIdx] / 4;
-							if (initialHps[shipIdx] < taihaHp) continue;
-							const resultHp = player[shipIdx].hp;
+					for (let shipIdx = 0; shipIdx < ships.length; shipIdx++) {
+						if (!ships[shipIdx]) continue;
+						const taihaHp = maxHps[shipIdx] / 4;
+						if (initialHps[shipIdx] < taihaHp) continue;
+						const resultHp = player[shipIdx].hp;
 
-							// Handle pre-boss taiha
-							if (resultHp < taihaHp) {
-								if (resultHp > 0) {
-									this.stats.taihaMagnets[ships[shipIdx]] = (this.stats.taihaMagnets[ships[shipIdx]] || 0) + 1;
-								} else {
+						// Handle pre-boss taiha
+						if (resultHp < taihaHp) {
+							if (resultHp > 0) {
+								this.stats.taihaMagnets[ships[shipIdx].mst_id] = (this.stats.taihaMagnets[ships[shipIdx].mst_id] || 0) + 1;
+							} else {
+								if (ships[shipIdx].equip.includes(42) || ships[shipIdx].equip.includes(43)) {
+									this.stats.dameconCount += 1;
+								} else if (!battle.boss) {
 									if (!this.stats.kuso[sortie.id]) { this.stats.kuso[sortie.id] = []; }
-									this.stats.kuso[sortie.id].push(ships[shipIdx]);
+									this.stats.kuso[sortie.id].push(ships[shipIdx].mst_id);
 								}
 							}
-
 						}
+
 					}
 				}));
 
@@ -434,13 +438,23 @@
 				totalCost = adder(totalCost, this.stats.sortieConsumption[i]);
 				curBox.appendTo(".map_list");
 			}
+
+			Object.keys(this.stats.kuso).forEach(sortieid => {
+				this.stats.kuso[sortieid].forEach(shipId => {
+					const icon = $(".tab_eventstats .factory .memorial_shipicon").clone();
+					$(".icon", icon).append("<img src=" + KC3Meta.getIcon(shipId) + "></img>");
+					icon.appendTo(".memorial .shiplist");
+				});
+			});
+
 			$(".lbcons").append("Land Base Cost: " + buildLBMessage(this.stats.lbConsumption));
 			$(".totalcons").append("Total Event Cost: " + buildConsMessage(totalCost));
+			$(".damecons").append("Damage Control Consumed: " + this.stats.dameconCount);
 			$(".loading").hide();
 			$(".table5").show();
 			$(".lbcons").show();
 			$(".map_list").show();
-
+			if (Object.keys(this.stats.kuso).length > 0) { $(".memorial").show(); }
 		},
 	};
 

--- a/src/pages/strategy/tabs/eventstats/eventstats.js
+++ b/src/pages/strategy/tabs/eventstats/eventstats.js
@@ -288,13 +288,14 @@
 						const resultHp = player[shipIdx].hp;
 
 						// Handle pre-boss taiha
-						if (resultHp < taihaHp && resultHp > 0 && initialHps[shipIdx] > taihaHp) {
+						if (resultHp < taihaHp && resultHp > 0 && initialHps[shipIdx] > taihaHp && !battle.boss) {
 								this.stats.taihaMagnets[ships[shipIdx].mst_id] = (this.stats.taihaMagnets[ships[shipIdx].mst_id] || 0) + 1;
 						}
+						// Handle sunk ships
 						if (resultHp <= 0) {
 							if (ships[shipIdx].equip.includes(42) || ships[shipIdx].equip.includes(43)) {
 								this.stats.dameconCount += 1;
-							} else if (!battle.boss) {
+							} else {
 								if (!this.stats.kuso[sortie.id]) { this.stats.kuso[sortie.id] = []; }
 								this.stats.kuso[sortie.id].push(ships[shipIdx].mst_id);
 							}


### PR DESCRIPTION
Display ships from the recorded sunk entries and capture damecon/damegami usage
Damage control usage is not accurate because flagship advance is not recorded
Also assume that player will not sink a ship that has already used damage control

![image](https://user-images.githubusercontent.com/26541502/135702631-1c51a9b2-ab57-4e6e-92a4-eb4f67a4682c.png)
