### PR TITLE
Refinements to the TsunDB submitter

### DIFF
--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -1111,21 +1111,21 @@
 			// playerShipsPartial2: Second shelling for MF
 			// playerShipsPartial3: Third shelling for MF (single vs CF only)
 			const playerShipsPartial1 =
-				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyShips.length <= 6) ?
+				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyList.length <= 6) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_single_vs_single1).fleets.playerMain:
-				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyShips.length == 12) ?
+				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyList.length == 12) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_single_vs_CF1).fleets.playerMain:
-				(thisNode.battleNight == undefined && this.data.fleetType == 1 && enemyShips.length <= 6) ?
+				(thisNode.battleNight == undefined && this.data.fleetType == 1 && enemyList.length <= 6) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_CTF_vs_single1).fleets.playerMain:
-				(thisNode.battleNight == undefined && this.data.fleetType == 1 && enemyShips.length == 12) ?
+				(thisNode.battleNight == undefined && this.data.fleetType == 1 && enemyList.length == 12) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_CTF_vs_CF1).fleets.playerMain:
 				(thisNode.battleNight == undefined && this.data.fleetType == 2) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_STF_vs_all1).fleets.playerMain:
 				{};
 			const playerShipsPartial2 =
-				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyShips.length <= 6) ?
+				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyList.length <= 6) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_single_vs_single2).fleets.playerMain:
-				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyShips.length == 12) ?
+				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyList.length == 12) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_single_vs_CF2).fleets.playerMain:
 				(thisNode.battleNight == undefined && this.data.fleetType == 1) ?
 					result.playerMain || []:
@@ -1133,7 +1133,7 @@
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_STF_vs_all2).fleets.playerMain:
 				{};
 			const playerShipsPartial3 =
-				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyShips.length == 12) ?
+				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyList.length == 12) ?
 					result.playerMain || []:
 				{};
 

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -1350,11 +1350,17 @@
 
 					// New field for the HP values of Abyssal attackers after the opening/closing torpedo phase. The Abyssal attacker must be in CF.
 					// Using defenderHPAfter as the key just so that it is consistent with yasen submissions
+					// Adding field opening for good measure
 					if (time == "torp" && enemyShips.length == 12 && idx >= 6) {
-						if (attack.opening)
+						if (attack.opening) {
 							shipInfo.defenderHPAfter = enemyEscortShipsPartial1[idx-6].hp;
-						else
+							shipInfo.opening = true;
+						}
+							
+						else {
 							shipInfo.defenderHPAfter = enemyEscortShipsPartial2[idx-6].hp;
+							shipInfo.opening = false;
+						}
 					}
 						
 

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -1105,7 +1105,7 @@
 			//const phases_CTF_vs_CF2			= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1', 'hougeki2', 'raigeki', 'hougeki3'];
 
 			const phases_STF_vs_all1		= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1'];
-			const phases_STF_vs_all2		= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1', 'hougeki2']
+			const phases_STF_vs_all2		= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1', 'hougeki2'];
 
 			// playerShipsPartial1: First shelling for MF
 			// playerShipsPartial2: Second shelling for MF

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -1082,6 +1082,62 @@
 			const playerShips = (result.playerMain || []).concat(result.playerEscort || []);
 			const fleetSent = this.data.sortiedFleet;
 			const battleConds = KC3Calc.collectBattleConditions();
+
+			// Ship index list
+			const shipIndexListSpecial = {
+				101: [1],
+				102: [1],
+				103: [1, 2],
+			};
+
+			// Partially analyse day battle to obtain HP of friendly ships after first and second round of main fleet shelling
+			const phases_single_vs_single1	= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1'];
+			const phases_single_vs_single2	= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1', 'hougeki2', 'hougeki3'];
+			
+			const phases_single_vs_CF1		= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1'];
+			const phases_single_vs_CF2		= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1', 'raigeki', 'hougeki2'];
+			//const phases_single_vs_CF3		= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1', 'raigeki', 'hougeki2', 'hougeki3'];
+			
+			const phases_CTF_vs_single1		= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1', 'raigeki', 'hougeki2'];
+			//const phases_CTF_vs_single2		= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1', 'raigeki', 'hougeki2', 'hougeki3'];
+			
+			const phases_CTF_vs_CF1			= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1',];
+			//const phases_CTF_vs_CF2			= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1', 'hougeki2', 'raigeki', 'hougeki3'];
+
+			const phases_STF_vs_all1		= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1'];
+			const phases_STF_vs_all2		= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1', 'hougeki2']
+
+			// playerShipsPartial1: First shelling for MF
+			// playerShipsPartial2: Second shelling for MF
+			// playerShipsPartial3: Third shelling for MF (single vs CF only)
+			const playerShipsPartial1 =
+				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyShips.length <= 6) ?
+					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_single_vs_single1).fleets.playerMain:
+				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyShips.length == 12) ?
+					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_single_vs_CF1).fleets.playerMain:
+				(thisNode.battleNight == undefined && this.data.fleetType == 1 && enemyShips.length <= 6) ?
+					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_CTF_vs_single1).fleets.playerMain:
+				(thisNode.battleNight == undefined && this.data.fleetType == 1 && enemyShips.length == 12) ?
+					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_CTF_vs_CF1).fleets.playerMain:
+				(thisNode.battleNight == undefined && this.data.fleetType == 2) ?
+					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_STF_vs_all1).fleets.playerMain:
+				{};
+			const playerShipsPartial2 =
+				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyShips.length <= 6) ?
+					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_single_vs_single2).fleets.playerMain:
+				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyShips.length == 12) ?
+					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_single_vs_CF2).fleets.playerMain:
+				(thisNode.battleNight == undefined && this.data.fleetType == 1) ?
+					result.playerMain || []:
+				(thisNode.battleNight == undefined && this.data.fleetType == 2) ?
+					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_STF_vs_all2).fleets.playerMain:
+				{};
+			const playerShipsPartial3 =
+				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyShips.length == 12) ?
+					result.playerMain || []:
+				{};
+
+
 			const fillShipInfo = ship => ({
 				id: ship.masterId,
 				lvl: ship.level,
@@ -1156,6 +1212,30 @@
 					}
 					if (specialCutinIds.includes(cutinType[1])) {
 						if (attack.hp / ship.hp[1] <= 0.5) { continue; }
+
+						// Additional HP checks for escort ships for NagaMutsu Touch and Colorado Touch (101, 102, 103). This check is only necessary for day battle
+						// Sorties that consume damecon are removed
+						if (thisNode.dameConConsumed.includes(true)) { continue; }
+
+						let taiha_flag = false;
+						if (thisNode.battleNight == undefined && num == 0 && cutinType[1] in shipIndexListSpecial)
+							for (let idxk = 0; idxk < shipIndexListSpecial[cutinType[1]].length; idxk++)
+								if (playerShipsPartial1[idxk].hp / fleet.ship(idxk).hp[1] <= 0.25)
+									taiha_flag = true;
+						
+						if (thisNode.battleNight == undefined && num == 1 && cutinType[1] in shipIndexListSpecial)
+							for (let idxk = 0; idxk < shipIndexListSpecial[cutinType[1]].length; idxk++)
+								if (playerShipsPartial2[idxk].hp / fleet.ship(idxk).hp[1] <= 0.25)
+									taiha_flag = true;
+
+						if (thisNode.battleNight == undefined && num == 2 && cutinType[1] in shipIndexListSpecial)
+							for (let idxk = 0; idxk < shipIndexListSpecial[cutinType[1]].length; idxk++)
+								if (playerShipsPartial3[idxk].hp / fleet.ship(idxk).hp[1] <= 0.25)
+									taiha_flag = true;
+
+						if (taiha_flag == true) { continue; }
+
+
 						misc = buildSortieSpecialInfo(fleet, cutinType[1]);
 					} else if (time === "day"
 						&& !(thisNode.planeFighters.player[0] === 0
@@ -1239,17 +1319,17 @@
 			// enemyEscortShipsPartial2: HP after closing torpedo
 			// Damecons are ignored here as we are only interested in Abyssal ships
 			const enemyEscortShipsPartial1 =
-				(thisNode.battleDay !== undefined && enemyShips.length == 12) ?
+				(thisNode.battleNight == undefined && enemyShips.length == 12) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_opening).fleets.enemyEscort:
 				{};
 			const enemyEscortShipsPartial2 = 
-				(thisNode.battleDay !== undefined && this.data.fleetType == 0 && enemyShips.length == 12) ?
+				(thisNode.battleNight == undefined && this.data.fleetType == 0 && enemyShips.length == 12) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_single_vs_CF).fleets.enemyEscort:
-				(thisNode.battleDay !== undefined && this.data.fleetType == 1 && enemyShips.length == 12) ?
+				(thisNode.battleNight == undefined && this.data.fleetType == 1 && enemyShips.length == 12) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_CTF_vs_CF).fleets.enemyEscort:
-				(thisNode.battleDay !== undefined && this.data.fleetType == 2 && enemyShips.length == 12) ?
+				(thisNode.battleNight == undefined && this.data.fleetType == 2 && enemyShips.length == 12) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_STF_vs_CF).fleets.enemyEscort:
-				(thisNode.battleDay !== undefined && this.data.fleetType == 3 && enemyShips.length == 12) ?
+				(thisNode.battleNight == undefined && this.data.fleetType == 3 && enemyShips.length == 12) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_TCF_vs_CF).fleets.enemyEscort:
 				{};
 

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -1239,17 +1239,17 @@
 			// enemyEscortShipsPartial2: HP after closing torpedo
 			// Damecons are ignored here as we are only interested in Abyssal ships
 			const enemyEscortShipsPartial1 =
-				(enemyShips.length == 12) ?
+				(thisNode.battleDay !== undefined && enemyShips.length == 12) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_opening).fleets.enemyEscort:
 				{};
 			const enemyEscortShipsPartial2 = 
-				(this.data.fleetType == 0 && enemyShips.length == 12) ?
+				(thisNode.battleDay !== undefined && this.data.fleetType == 0 && enemyShips.length == 12) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_single_vs_CF).fleets.enemyEscort:
-				(this.data.fleetType == 1 && enemyShips.length == 12) ?
+				(thisNode.battleDay !== undefined && this.data.fleetType == 1 && enemyShips.length == 12) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_CTF_vs_CF).fleets.enemyEscort:
-				(this.data.fleetType == 2 && enemyShips.length == 12) ?
+				(thisNode.battleDay !== undefined && this.data.fleetType == 2 && enemyShips.length == 12) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_STF_vs_CF).fleets.enemyEscort:
-				(this.data.fleetType == 3 && enemyShips.length == 12) ?
+				(thisNode.battleDay !== undefined && this.data.fleetType == 3 && enemyShips.length == 12) ?
 					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_TCF_vs_CF).fleets.enemyEscort:
 				{};
 

--- a/src/library/modules/TsunDBSubmission.js
+++ b/src/library/modules/TsunDBSubmission.js
@@ -1227,7 +1227,32 @@
 			const fleetSent = this.data.sortiedFleet;
 			const starshellActivated = thisNode.flarePos >= 0;
 			const ncontact = thisNode.fcontactId == 102;
-			
+
+			// Obtain the battle status right after the opening/closing torpdo phase if enemy fleet is CF
+			// This information is required for torpedo accuracy tests due to torpedo resolve order in CF combat
+			const phases_opening		= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack'];
+			const phases_single_vs_CF	= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1', 'raigeki'];
+			const phases_CTF_vs_CF		= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1', 'hougeki2', 'raigeki'];
+			const phases_STF_vs_CF		= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1', 'hougeki2', 'hougeki3', 'raigeki'];
+			const phases_TCF_vs_CF		= ['airBaseInjection', 'injectionKouku', 'airBaseAttack', 'friendlyKouku', 'kouku', 'kouku2', 'support', 'openingTaisen', 'openingAtack', 'hougeki1', 'hougeki2', 'raigeki'];
+			// enemyEscortShipsPartial1: HP after opening torpedo
+			// enemyEscortShipsPartial2: HP after closing torpedo
+			// Damecons are ignored here as we are only interested in Abyssal ships
+			const enemyEscortShipsPartial1 =
+				(enemyShips.length == 12) ?
+					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_opening).fleets.enemyEscort:
+				{};
+			const enemyEscortShipsPartial2 = 
+				(this.data.fleetType == 0 && enemyShips.length == 12) ?
+					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_single_vs_CF).fleets.enemyEscort:
+				(this.data.fleetType == 1 && enemyShips.length == 12) ?
+					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_CTF_vs_CF).fleets.enemyEscort:
+				(this.data.fleetType == 2 && enemyShips.length == 12) ?
+					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_STF_vs_CF).fleets.enemyEscort:
+				(this.data.fleetType == 3 && enemyShips.length == 12) ?
+					KC3BattlePrediction.analyzeBattlePartially(thisNode.battleDay, [], phases_TCF_vs_CF).fleets.enemyEscort:
+				{};
+
 			// Player attacks
 			for (let idx = 0; idx < playerShips.length; idx++) {
 				const attacks = (playerShips[idx] || {}).attacks || [];
@@ -1301,8 +1326,9 @@
 					// Includes NB DA for a larger dataset
 					if ((attack.cutin || attack.ncutin || 0) !== 0 && attack.ncutin !== 1) { continue; }
 					let time = "day";
-					if (attack.phase !== undefined && attack.phase == "raigeki") { 
-						if (attack.opening) { continue; }
+					if (attack.phase !== undefined && attack.phase == "raigeki") {
+						// Only ignore opening torpedo for Abyssal single fleet 
+						if (attack.opening && enemyShips.length <= 6) { continue; }
 						time = "torp";
 					}
 					if (attack.ncutin >= 0) { time = "yasen"; }
@@ -1321,6 +1347,18 @@
 					shipInfo.position = [shipPos, fleet.ships.filter(id => id > 0).length, (idx > 5 ? idx - 6 : idx)];
 					shipInfo.isAttacker = false;
 
+
+					// New field for the HP values of Abyssal attackers after the opening/closing torpedo phase. The Abyssal attacker must be in CF.
+					// Using defenderHPAfter as the key just so that it is consistent with yasen submissions
+					if (time == "torp" && enemyShips.length == 12 && idx >= 6) {
+						if (attack.opening)
+							shipInfo.defenderHPAfter = enemyEscortShipsPartial1[idx-6].hp;
+						else
+							shipInfo.defenderHPAfter = enemyEscortShipsPartial2[idx-6].hp;
+					}
+						
+
+					
 					if (time == "yasen") {
 						shipInfo.starshellActivated = starshellActivated;
 						shipInfo.searchlightPresent = !!fleet.estimateUsableSearchlight();


### PR DESCRIPTION
1. Added HP after opening/closing torpedo for Abyssal attackers. Opening torpedo data from Abyssal attackers are now submitted.
2. Added HP after the combat phase of every 'attack' (e.g. if 'attack' is the first attack of single vs single combat, then the combat phase is 'hougeki1') for the escort ships in NagaMutsu/Colorado Touch. These HPs are used to filter out potentially invalid spattack submissions.