### PR TITLE
Add expedition only config for pushalert

### DIFF
--- a/src/data/settings.json
+++ b/src/data/settings.json
@@ -1129,6 +1129,12 @@
 				"options" : {}
 			},
 			{
+				"id" : "PushAlerts_expedition_only",
+				"name" : "SettingsPushAlertsExpeditionOnly",
+				"type" : "check",
+				"options" : {}
+			},
+			{
 				"id" : "PushAlerts_key",
 				"name" : "SettingsPushAlertsKey",
 				"type" : "long_text",

--- a/src/library/managers/ConfigManager.js
+++ b/src/library/managers/ConfigManager.js
@@ -49,6 +49,7 @@ Retrieves when needed to apply on components
 				TsunDBSubmission_enabled : false,
 				TsunDBSubmissionExtra_enabled : false,
 				PushAlerts_enabled   : 0,
+				PushAlerts_expedition_only: false,
 				PushAlerts_key       : '',
 
 				info_quest_activity  : true,

--- a/src/library/modules/Service.js
+++ b/src/library/modules/Service.js
@@ -118,6 +118,8 @@ See Manifest File [manifest.json] under "background" > "scripts"
 			});
 			// Sending Mobile Push notification if enabled
 			if(ConfigManager.PushAlerts_enabled) {
+				// Expedition IDs are 0_0, 0_1, 0_2, 0_3
+				if(ConfigManager.PushAlerts_expedition_only && !request.notifId.startsWith("0_")) return;
 				$.ajax({
 					async: true,
 					crossDomain: true,


### PR DESCRIPTION
Hi, I've been using Pushbullet and Parsec for expeditions for a month.
But there was a problem that bothered me.
It also will send other notifications like construction, repair, etc.

I want the expedition notification only.
So I've added an option, as well as translations for EN, JP, and CN.
https://github.com/Sean2525/KC3Kai/commit/5a3b72ed5e6be1b1ac25dc3f290234f28c08f1c5
https://github.com/Sean2525/kc3-translations/commit/897087137869314bcb881d2f5e753c8e8d10ef9e

The notifId can be used to check if it is an expedition.
https://github.com/KC3Kai/KC3Kai/blob/408ca39eb817dcae852a8676069043e061b737ab/src/library/objects/Timer.js#L174-L179

<img src="https://user-images.githubusercontent.com/17308188/185639086-1ed7b0d1-e50b-4dfa-b776-3acb1a291b81.jpg" data-canonical-src="https://user-images.githubusercontent.com/17308188/185639086-1ed7b0d1-e50b-4dfa-b776-3acb1a291b81.jpg" width="200" height="400" />


![](https://i.imgur.com/hFpgOxr.png)
![image](https://user-images.githubusercontent.com/17308188/185619048-48c97112-52e0-4aad-b111-2ad0ce2ad2f6.png)

After I tried it for a day, it works well.

Could you help review it? 
Thanks.